### PR TITLE
Fix ant dependency on Debian

### DIFF
--- a/README
+++ b/README
@@ -9,7 +9,7 @@ To build OSv
         libvirt libtool zfs-fuse flex bison
 
    On Debian:
-     apt-get install libboost-all-dev genromfs zfs-fuse autoconf
+     apt-get install libboost-all-dev genromfs zfs-fuse autoconf ant
 
 1) make sure the zfs-fuse daemon is running
    ----------------------------------------


### PR DESCRIPTION
the ant package must be explicitly specified, otherwise the following error will raise when building osv. 

raphaelsc@debian:~/Desktop/osv_dir/osv$ make
  ANT tests/bench
Traceback (most recent call last):
  File "scripts/silentant.py", line 14, in <module>
    stderr = subprocess.PIPE)
  File "/usr/lib/python2.6/subprocess.py", line 623, in **init**
    errread, errwrite)
  File "/usr/lib/python2.6/subprocess.py", line 1141, in _execute_child
    raise child_exception
OSError: [Errno 2] No such file or directory
make: **\* [all] Error 1

Signed-off by: Raphael S. Carvalho raphael.scarv@gmail.com
