### PR TITLE
support etags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,5 @@ java/lib/
 libunwind.a
 
 .gradle
-
+tags
 TAGS

--- a/Makefile
+++ b/Makefile
@@ -40,9 +40,11 @@ external:
 	cp external/libunwind/src/.libs/libunwind.a .
 	make -C external/glibc-testsuite
 
+# default output file of ctags
 tags:
 	find . -name "*.cc" -o -name "*.hh" -o -name "*.h" -o -name "*.c" | ctags -L -
 
+# default output file of etags
 TAGS:
 	rm -f TAGS
 	find . -name "*.cc" -o -name "*.hh" -o -name "*.h" -o -name "*.c" -exec etags -a {} \;


### PR DESCRIPTION
add TAGS target to Makefile to support etags.

Signed-off-by: Yang Bai hamo.by@gmail.com
