### PR TITLE
Allow specify test names to testrunner

### DIFF
--- a/tests/testrunner.c
+++ b/tests/testrunner.c
@@ -5,7 +5,6 @@
  * BSD license as described in the LICENSE file in the top-level directory.
  */
 
-
 #include <sys/stat.h>
 #include <dirent.h>
 #include <dlfcn.h>
@@ -14,6 +13,8 @@
 #include <string.h>
 #include <unistd.h>
 #include <limits.h>
+
+#define TESTDIR		"/tests"
 
 extern void dlclose_by_path_np(const char* filename);
 
@@ -42,41 +43,60 @@ void load_test(char *path, char *argv0)
 	dlclose_by_path_np(path);
 }
 
+int check_path(char *path)
+{
+	struct stat st;
+	if (stat(path, &st) < 0) {
+		printf("failed to stat %s\n", path);
+		return 0;
+	}
+
+	if (!S_ISREG(st.st_mode)) {
+		printf("ignoring %s, not a regular file\n", path);
+		return 0;
+	}
+	return 1;
+}
+
 int main(int argc, char **argv)
 {
-#define TESTDIR		"/tests"
-	DIR *dir = opendir(TESTDIR);
 	char path[PATH_MAX];
-	struct dirent *d;
-	struct stat st;
 
-	if (!dir) {
-		perror("failed to open testdir");
-		return EXIT_FAILURE;
-	}
+	if (argc == 1) {
+		DIR *dir = opendir(TESTDIR);
+		struct dirent *d;
 
-	while ((d = readdir(dir))) {
-		if (strcmp(d->d_name, ".") == 0 ||
-		    strcmp(d->d_name, "..") == 0)
-		continue;
-
-		snprintf(path, PATH_MAX, "%s/%s", TESTDIR, d->d_name);
-		if (stat(path, &st) < 0) {
-			printf("failed to stat %s\n", path);
-			continue;
+		if (!dir) {
+			perror("failed to open testdir");
+			return EXIT_FAILURE;
 		}
 
-		if (!S_ISREG(st.st_mode)) {
-			printf("ignoring %s, not a regular file\n", path);
-			continue;
+		while ((d = readdir(dir))) {
+			if (strcmp(d->d_name, ".") == 0 ||
+			    strcmp(d->d_name, "..") == 0)
+				continue;
+
+			snprintf(path, PATH_MAX, "%s/%s", TESTDIR, d->d_name);
+			if (!check_path(path))
+				continue;
+
+			load_test(path, d->d_name);
 		}
-		load_test(path, d->d_name);
+
+		if (closedir(dir) < 0) {
+			perror("failed to close testdir");
+			return EXIT_FAILURE;
+		}
+	} else {
+		for (int i = 1; i < argc; i++) {
+			snprintf(path, PATH_MAX, "%s/%s", TESTDIR, argv[i]);
+			if (!check_path(path))
+				continue;
+
+			load_test(path, argv[i]);
+		}
 	}
 
-	if (closedir(dir) < 0) {
-		perror("failed to close testdir");
-		return EXIT_FAILURE;
-	}
 	printf("All tests complete - %d/%d failures\n", nr_failures, nr_tests);
 
 	return 0;


### PR DESCRIPTION
Allow specify test names to testrunner such as
testrunner.so tst-foo1.so tst-foo2.so
to run tst-foo1 and tst-foo2 only in the order
they are specified.
This does not change the default behavior that
cmdline=testrunner.so will run all tests under
/tests dir.
This change can help developer to run the only
test cases they need quickly to verify new feature
or find possible regressions.

Signed-off-by: Yang Bai hamo.by@gmail.com
