### PR TITLE
ovs: fix build error. (bsd/porting/networking.cc)

### DIFF
--- a/bsd/porting/networking.cc
+++ b/bsd/porting/networking.cc
@@ -96,7 +96,7 @@ out:
 int ifup(std::string if_name)
 {
     int error;
-    struct bsd_ifreq ifr = {0};
+    struct bsd_ifreq ifr;
 
     if (if_name.empty()) {
         return (EINVAL);


### PR DESCRIPTION
do not need variable initialize.
(or use memset(3) for zero clear.)

```
(snip)
  CC bsd/sys/kern/sys_socket.o
  CC bsd/sys/kern/subr_disk.o
  CC bsd/porting/route.o
  CXX bsd/porting/networking.o
../../bsd/porting/networking.cc: In function ‘int
osv::ifup(std::string)’:
../../bsd/porting/networking.cc:99:30: error: missing braces around
initializer for ‘char [16]’ [-Werror=missing-braces]
cc1plus: all warnings being treated as errors
make[1]: *** [bsd/porting/networking.o] Error 1
make[1]: Leaving directory
`/home/kouki-o/work/kaishuu0123-osv/build/release'
make: *** [all] Error 2
(snip)
```

Signed-off-by: Kouki Ooyatsu kaishuu0123@gmail.com
