### PR TITLE
tests: add auto-load safe-path init command to gdb

### DIFF
--- a/scripts/trace.py
+++ b/scripts/trace.py
@@ -257,6 +257,9 @@ def extract(args):
             os.remove(args.tracefile)
             assert(not os.path.exists(args.tracefile))
         cmdline = ['gdb', elf_path, '-batch']
+        # enable adding OSv's python modules to gdb, see
+        # http://sourceware.org/gdb/onlinedocs/gdb/Auto_002dloading-safe-path.html
+        cmdline.extend(['-iex', 'set auto-load safe-path .'])
         if args.remote:
             cmdline.extend(['-ex', 'target remote ' + args.remote])
         else:


### PR DESCRIPTION
Running make check from a fresh Ubuntu gave the following error message

```
TEST tracing_smoke_test
warning: File "/home/elazar/dev/osv/scripts/loader.py" auto-loading has been declined by your `auto-load safe-path' set to "$debugdir:$datadir/auto-load".
```

Signed-off-by: Elazar Leibovich elazarl@gmail.com
