### PR TITLE
Add line breaks to CODINGSTYLE

### DIFF
--- a/CODINGSTYLE.md
+++ b/CODINGSTYLE.md
@@ -97,10 +97,12 @@ with a single space - not with a newline.
 
 ## 5. Commenting
 5.1 Use the // C++ comment style for normal comment
+
 5.2 When documenting a namespace, class, method or function using Doxygen, use /** */ comments.
 
 ## 6. Macros, Enums and RTL
 6.1 Avoid Macros when a method would do. Prefer enum and constant to macro.
+
 6.2 Prefer "enum class" to "enum".
 
 6.3 Macro names and enum label should be capitalized. For "enum class",


### PR DESCRIPTION
Before this commit, viewing CODINGSTYLE.md in a Markdown renderer (such as the GitHub website) would result in some paragraphs (like 5.1 and 5.2) being visually on the same line.

This patch adds trivial newlines between them in the hope of improving readability.