### PR TITLE
Add libc pthread_mutexattr_setpshared API stub

### DIFF
--- a/libc/pthread.cc
+++ b/libc/pthread.cc
@@ -791,6 +791,12 @@ int pthread_mutexattr_settype(pthread_mutexattr_t *attr, int type)
     return 0;
 }
 
+int pthread_mutexattr_setpshared(pthread_mutexattr_t *attr, int pshared)
+{
+    WARN_STUBBED();
+    return 0;
+}
+
 int pthread_condattr_init(pthread_condattr_t *attr)
 {
     // We assume there's room for at least one byte in pthread_condattr_t


### PR DESCRIPTION
Because Groonga <http://groonga.org> uses this API.
And I want to port Groonga on OSv.

Signed-off-by: Hiroshi Hatake <cosmo0920.oucc@gmail.com>