### PR TITLE
When not using AWS default instance the script release-ec2.py will fail

### DIFF
--- a/scripts/ec2-utils.sh
+++ b/scripts/ec2-utils.sh
@@ -26,18 +26,18 @@ ec2_response_value() {
 
 get_volume_conversion_status() {
  local TASKID=$1
- ec2-describe-conversion-tasks $TASKID | tee /dev/tty | ec2_response_value IMPORTVOLUME Status
+ ec2-describe-conversion-tasks $TASKID --region $AWS_DEFAULT_REGION | tee /dev/tty | ec2_response_value IMPORTVOLUME Status
 }
 
 get_created_volume_id() {
  local TASKID=$1
- ec2-describe-conversion-tasks $TASKID | tee /dev/tty | ec2_response_value DISKIMAGE VolumeId
+ ec2-describe-conversion-tasks $TASKID --region $AWS_DEFAULT_REGION | tee /dev/tty | ec2_response_value DISKIMAGE VolumeId
 }
 
 rename_object() {
  local OBJID=$1
  local OBJNAME=$2
- ec2-create-tags $OBJID --tag Name="$OBJNAME"
+ ec2-create-tags $OBJID --tag Name="$OBJNAME" --region $AWS_DEFAULT_REGION
 }
 
 tag_object() {
@@ -46,7 +46,7 @@ tag_object() {
  local TAGVAL=$3
  shift 3
 
- ec2-create-tags $OBJID --tag $TAGNAME=$TAGVAL $*
+ ec2-create-tags $OBJID --tag $TAGNAME=$TAGVAL $* --region $AWS_DEFAULT_REGION
 }
 
 wait_import_completion() {
@@ -194,7 +194,7 @@ start_instances() {
  ec2-start-instances $*
 }
 stop_instance_forcibly() {
- ec2-stop-instances $1 --force
+ ec2-stop-instances $1 --force --region $AWS_DEFAULT_REGION
 }
 
 create_ami_by_instance() {

--- a/scripts/ec2-utils.sh
+++ b/scripts/ec2-utils.sh
@@ -37,7 +37,7 @@ get_created_volume_id() {
 rename_object() {
  local OBJID=$1
  local OBJNAME=$2
- ec2-create-tags $OBJID --tag Name="$OBJNAME" --region $AWS_DEFAULT_REGION
+ ec2-create-tags $OBJID --region $AWS_DEFAULT_REGION --tag Name="$OBJNAME"
 }
 
 tag_object() {
@@ -46,7 +46,7 @@ tag_object() {
  local TAGVAL=$3
  shift 3
 
- ec2-create-tags $OBJID --tag $TAGNAME=$TAGVAL $* --region $AWS_DEFAULT_REGION
+ ec2-create-tags $OBJID --region $AWS_DEFAULT_REGION --tag $TAGNAME=$TAGVAL $*
 }
 
 wait_import_completion() {

--- a/scripts/release-ec2.sh
+++ b/scripts/release-ec2.sh
@@ -193,7 +193,7 @@ launch_template_instance() {
  local TEMPLATE_AMI_ID=$1
  local TEMPLATE_INSTANCE_TYPE=$2
 
- ec2-run-instances $TEMPLATE_AMI_ID --availability-zone `get_availability_zone` \
+ ec2-run-instances $TEMPLATE_AMI_ID --region $AWS_DEFAULT_REGION --availability-zone `get_availability_zone` \
                                                   --instance-type $TEMPLATE_INSTANCE_TYPE \
                                                   $PLACEMENT \
                                                   | tee /dev/tty | ec2_response_value INSTANCE INSTANCE
@@ -202,7 +202,7 @@ launch_template_instance() {
 get_availability_zone() {
 
  if test x"$OSV_AVAILABILITY_ZONE" = x""; then
-     OSV_AVAILABILITY_ZONE=`ec2-describe-availability-zones | ec2_response_value AVAILABILITYZONE AVAILABILITYZONE | head -1`
+     OSV_AVAILABILITY_ZONE=`ec2-describe-availability-zones --region $AWS_DEFAULT_REGION | ec2_response_value AVAILABILITYZONE AVAILABILITYZONE | head -1`
  fi
 
  echo $OSV_AVAILABILITY_ZONE

--- a/scripts/release-ec2.sh
+++ b/scripts/release-ec2.sh
@@ -162,6 +162,7 @@ import_osv_volume() {
  ec2-import-volume $OSV_VOLUME \
                                  -f raw \
                                  -b $OSV_BUCKET \
+                                 --region $AWS_DEFAULT_REGION \
                                  -z `get_availability_zone` \
                                  $EC2_CREDENTIALS | tee /dev/tty | ec2_response_value IMPORTVOLUME TaskId
 }
@@ -266,8 +267,8 @@ while true; do
        fi
     fi
 
-    echo_progress Creating bucket $OSV_BUCKET
-    aws s3api create-bucket --bucket $OSV_BUCKET
+    echo_progress Creating bucket $OSV_BUCKET in $AWS_DEFAULT_REGION
+    aws s3api create-bucket --bucket $OSV_BUCKET --create-bucket-configuration LocationConstraint=$AWS_DEFAULT_REGION
 
     if test x"$?" != x"0"; then
         handle_error Failed to create S3 bucket.


### PR DESCRIPTION
Need to specify in the AWS commands what "--region" to use, otherwise it will use the default one (us-east-1). And if the user had choose a different one ( `./scripts/release-ec2.sh (...) --region eu-west-1` ) the script will fail
