### PR TITLE
fix the package name of libyaml on Ubuntu

### DIFF
--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -115,7 +115,7 @@ class Ubuntu(object):
                 'libmaven-shade-plugin-java', 'python-dpkt', 'tcpdump', 'gdb', 'qemu-system-x86',
                 'gawk', 'gnutls-bin', 'openssl', 'python-requests', 'p11-kit', 'g++-multilib',
                 'libssl-dev', 'libedit-dev', 'curl', 'libvirt-bin',
-                'libncurses5-dev', 'libyaml-cpp'
+                'libncurses5-dev', 'libyaml-cpp-dev'
                 ]
     ec2_packages = standard_ec2_packages
     test_packages = ['libssl-dev', 'zip']


### PR DESCRIPTION
Fix on [issue#742](https://github.com/cloudius-systems/osv/issues/742)
There isn't a package names "libyaml-cpp" in Ubuntu official apt-get repo.
The correct name of the required package is "libyaml-cpp-dev".