### PR TITLE
Add realpath for setup.py on Ubuntu

### DIFF
--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -135,7 +135,8 @@ class Debian(object):
                 'libmaven-shade-plugin-java', 'tcpdump', 'gdb', 'gawk',
                 'gnutls-bin', 'openssl', 'python-requests', 'python-dpkt',
                 'qemu-system-x86', 'qemu-utils', 'lib32stdc++-4.9-dev',
-                'p11-kit', 'libssl-dev', 'libedit-dev', 'libncurses5-dev']
+                'p11-kit', 'libssl-dev', 'libedit-dev', 'libncurses5-dev',
+                'realpath']
     ec2_packages = standard_ec2_packages
     test_packages = ['libssl-dev', 'zip']
     ec2_post_install = None
@@ -157,7 +158,7 @@ class Ubuntu(object):
                 'libmaven-shade-plugin-java', 'python-dpkt', 'tcpdump', 'gdb', 'qemu-system-x86',
                 'gawk', 'gnutls-bin', 'openssl', 'python-requests', 'p11-kit', 'g++-multilib',
                 'libssl-dev', 'libedit-dev', 'curl', 'libvirt-bin',
-                'libncurses5-dev', 'libyaml-cpp-dev'
+                'libncurses5-dev', 'libyaml-cpp-dev', 'realpath'
                 ]
     ec2_packages = standard_ec2_packages
     test_packages = ['libssl-dev', 'zip']


### PR DESCRIPTION
Module httpserver-api will use realpath, if we don't have
the package, this module will generate a wrong manifest,
and we'll finally get error when build:

```
Traceback (most recent call last):
  File "/home/qhuang/osv/scripts/upload_manifest.py", line 140, in <module>
    main()
  File "/home/qhuang/osv/scripts/upload_manifest.py", line 125, in main
    manifest = read_manifest(options.manifest)
  File "/home/qhuang/osv/scripts/manifest_common.py", line 59, in read_manifest
    hostpath = components[1].strip()
IndexError: list index out of range
./scripts/build failed: $SRC/scripts/upload_manifest.py -o usr.img -m usr.manifest -D jdkbase=$jdkbase -D gccbase=$gccbase -D glibcbase=$glibcbase -D miscbase=$miscbase
```

Signed-off-by: Qiang Huang <h.huangqiang@huawei.com>