### PR TITLE
Add missing 'unzip' package to 'scripts/setup.py' for Ubuntu

### DIFF
--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -164,7 +164,7 @@ class Ubuntu(object):
                 'libmaven-shade-plugin-java', 'python-dpkt', 'tcpdump', 'gdb', 'qemu-system-x86',
                 'gawk', 'gnutls-bin', 'openssl', 'python-requests', 'p11-kit', 'g++-multilib',
                 'libssl-dev', 'libedit-dev', 'curl', 'libvirt-bin',
-                'libncurses5-dev', 'libyaml-cpp-dev'
+                'libncurses5-dev', 'libyaml-cpp-dev', 'unzip'
                 ]
     ec2_packages = standard_ec2_packages
     test_packages = ['libssl-dev', 'zip']


### PR DESCRIPTION
Fixes #899.