### PR TITLE
scripts: fix setup.py for Ubuntu versions

### DIFF
--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -238,7 +238,6 @@ class Ubuntu(object):
                 'maven',
                 'openssl',
                 'p11-kit',
-                'python3-dpkt',
                 'python3-requests',
                 'qemu-system-x86',
                 'qemu-utils',
@@ -256,49 +255,49 @@ class Ubuntu(object):
     ec2_post_install = None
 
     class Ubuntu_20_04(object):
-        packages = ['bridge-utils', 'libvirt-daemon-system', 'libvirt-clients']
+        packages = ['bridge-utils', 'libvirt-daemon-system', 'libvirt-clients', 'python3-dpkt']
         ec2_packages = ['ec2-api-tools', 'awscli']
         test_packages = []
         ec2_post_install = None
         version = '20.04'
 
     class Ubuntu_19_10(object):
-        packages = ['bridge-utils', 'libvirt-daemon-system', 'libvirt-clients']
+        packages = ['bridge-utils', 'libvirt-daemon-system', 'libvirt-clients', 'python3-dpkt']
         ec2_packages = ['ec2-api-tools', 'awscli']
         test_packages = []
         ec2_post_install = None
         version = '19.10'
 
     class Ubuntu_19_04(object):
-        packages = ['bridge-utils', 'libvirt-daemon-system', 'libvirt-clients']
+        packages = ['bridge-utils', 'libvirt-daemon-system', 'libvirt-clients', 'python-dpkt']
         ec2_packages = ['ec2-api-tools', 'awscli']
         test_packages = []
         ec2_post_install = None
         version = '19.04'
 
     class Ubuntu_18_10(object):
-        packages = ['bridge-utils', 'libvirt-daemon-system', 'libvirt-clients']
+        packages = ['bridge-utils', 'libvirt-daemon-system', 'libvirt-clients', 'python-dpkt']
         ec2_packages = ['ec2-api-tools', 'awscli']
         test_packages = []
         ec2_post_install = None
         version = '18.10'
 
     class Ubuntu_18_04(object):
-        packages = ['bridge-utils', 'libvirt-bin']
+        packages = ['bridge-utils', 'libvirt-bin', 'python-dpkt']
         ec2_packages = ['ec2-api-tools', 'awscli']
         test_packages = []
         ec2_post_install = None
         version = '18.04'
 
     class Ubuntu_17_04(object):
-        packages = ['libvirt-bin']
+        packages = ['libvirt-bin', 'python-dpkt']
         ec2_packages = ['ec2-api-tools', 'awscli']
         test_packages = []
         ec2_post_install = None
         version = '17.04'
 
     class Ubuntu_16_04(object):
-        packages = ['libvirt-bin']
+        packages = ['libvirt-bin', 'python-dpkt']
         ec2_packages = ['ec2-api-tools', 'awscli']
         test_packages = []
         ec2_post_install = None


### PR DESCRIPTION
As explained in issue #1085 the setup script is broken for some
Ubuntu versions. This commit installs the packages `python-dpkt`
and `python3-dpkt` for the respective Ubuntu version.

Signed-off-by: Robin Gögge <r.goegge@outlook.com>