### PR TITLE
scripts: Update script to download RPM packages

### DIFF
--- a/scripts/download_rpm_package.sh
+++ b/scripts/download_rpm_package.sh
@@ -8,8 +8,8 @@ arch=aarch64
 
 letter=${package:0:1}
 
-main_repo_url="http://mirrors.kernel.org/fedora/releases/$release/Everything/$arch/os/Packages/$letter/"
-version=$(wget -t 1 -qO- $main_repo_url | grep "${package}-[0-9].*$arch" | grep -Po ">.*<" | sed -e "s/>${package}-\(.*\)\.$arch\.rpm</\1/g" | tail -l)
+main_repo_url="https://download-ib01.fedoraproject.org/pub/fedora/linux/releases/$release/Everything/$arch/os/Packages/$letter/"
+version=$(wget -t 1 -qO- $main_repo_url | grep "${package}-[0-9].*$arch" | grep -Po "href=\".*\"" | sed -e "s/href=\"${package}-\(.*\)\.$arch\.rpm\"/\1/g" | tail -l)
 
 archive_repo_url="http://archives.fedoraproject.org/pub/archive/fedora/linux/releases/$release/Everything/$arch/os/Packages/$letter/"
 if [[ "${version}" != "" ]]; then


### PR DESCRIPTION
Since the script was originally written, a few things such as

  * location of the Fedora repositories
  * format of HTML page

has changed. This leads to errors when setting up cross build
environment for arm64.

Fix these issues by updating the repo url and the regular expression
used to parse the package version.

Note: The mechanism to download the packages is a little fragile and
may break again in the future. Hopefully, all this can go away once
the build system has been migrated to use the native distro packages.

Signed-off-by: Punit Agrawal <pagrawal@lynx.com>
Closes: #1103 