### PR TITLE
fixed NameError: name 'file' is not defined

### DIFF
--- a/scripts/run.py
+++ b/scripts/run.py
@@ -499,7 +499,7 @@ def choose_hypervisor(external_networking, arch):
     if os.path.exists('/dev/kvm') and arch == host_arch:
         return 'kvm'
     if (os.path.exists('/proc/xen/capabilities')
-        and 'control_d' in file('/proc/xen/capabilities').read()
+        and 'control_d' in open('/proc/xen/capabilities', 'r').read()
         and external_networking):
         return 'xen'
     return 'qemu'


### PR DESCRIPTION
The problem happens when XEN is the provider configured on the server.

I was running `./scripts/build image=openjdk8-zulu-full,spring-boot-example` and I got this error:

```
Saving command line to /home/inacio/osv/build/release.x64/cmdline
Building into build/release.x64
  GEN gen/include/osv/version.h
Traceback (most recent call last):
  File "scripts/run.py", line 637, in <module>
    cmdargs.hypervisor = choose_hypervisor(cmdargs.networking,cmdargs.arch)
  File "scripts/run.py", line 502, in choose_hypervisor
    and 'control_d' in file('/proc/xen/capabilities').read()
NameError: name 'file' is not defined
Traceback (most recent call last):
  File "/home/inacio/osv/scripts/upload_manifest.py", line 170, in <module>
    main()
  File "/home/inacio/osv/scripts/upload_manifest.py", line 160, in main
    upload(osv, manifest, depends, upload_port)
  File "/home/inacio/osv/scripts/upload_manifest.py", line 29, in upload
    s.connect(("127.0.0.1", port))
ConnectionRefusedError: [Errno 111] Connection refused
./scripts/build failed: "$SRC"/scripts/upload_manifest.py -o $qcow2_disk.img -m usr.manifest -D libgcc_s_dir="$libgcc_s_dir" $upload_kernel_mode
```

This fix solves the problem.