### PR TITLE
ht_enabled -> smt

### DIFF
--- a/scripts/firecracker.py
+++ b/scripts/firecracker.py
@@ -136,7 +136,7 @@ class ApiClient(object):
         machine_config = {
             'vcpu_count': vcpu_count,
             'mem_size_mib': mem_size_in_mb,
-            'ht_enabled' : False
+            'smt' : False
         }
         if self.socket_less:
             self.firecracker_config['machine-config'] = machine_config


### PR DESCRIPTION
Update firecracker config param from  ht_enabled to smt.

Fixes the following error:
```
2023-01-23T03:39:34.650227224 [anonymous-instance:main:ERROR:src/firecracker/src/main.rs:496] Configuration for VMM from one single json failed: Invalid JSON: unknown field `ht_enabled`, expected one of `vcpu_count`, `mem_size_mib`, `smt`, `cpu_
template`, `track_dirty_pages` at line 5 column 18
```