### PR TITLE
Disable BARs decoding when computing size

### DIFF
--- a/drivers/pci-device.cc
+++ b/drivers/pci-device.cc
@@ -35,7 +35,7 @@ namespace pci {
         u32 pos = PCI_CFG_BAR_1;
         int idx = 1;
 
-        function::set_bars_enable(true, true);
+        function::enable_bars_decode(true, true);
 
         while (pos <= PCI_CFG_BAR_6) {
             u32 bar_v = pci_readl(pos);

--- a/drivers/pci-function.cc
+++ b/drivers/pci-function.cc
@@ -53,6 +53,10 @@ namespace pci {
 
     u64 bar::read_bar_size()
     {
+        // The device must not decode the following BAR values since they aren't
+        // addresses
+        _dev->disable_bars_decode(true, true);
+
         u32 lo_orig = _dev->pci_readl(_pos);
 
         // Size test
@@ -76,6 +80,8 @@ namespace pci {
             // Restore
             _dev->pci_writel(_pos+4, hi_orig);
         }
+
+        _dev->enable_bars_decode(true, true);
 
         u64 bits = (u64)hi << 32 | lo;
         return ~bits + 1;
@@ -404,7 +410,7 @@ namespace pci {
         set_command(command);
     }
 
-    void function::set_bars_enable(bool mem, bool io)
+    void function::enable_bars_decode(bool mem, bool io)
     {
         u16 command = get_command();
         if (mem) {
@@ -412,6 +418,18 @@ namespace pci {
         }
         if (io) {
             command |= PCI_COMMAND_BAR_IO_ENABLE;
+        }
+        set_command(command);
+    }
+
+    void function::disable_bars_decode(bool mem, bool io)
+    {
+        u16 command = get_command();
+        if (mem) {
+            command &= ~(u16)PCI_COMMAND_BAR_MEM_ENABLE;
+        }
+        if (io) {
+            command &= ~(u16)PCI_COMMAND_BAR_IO_ENABLE;
         }
         set_command(command);
     }

--- a/drivers/pci-function.hh
+++ b/drivers/pci-function.hh
@@ -290,7 +290,10 @@ namespace pci {
         bool get_bus_master();
         void set_bus_master(bool m);
 
-        void set_bars_enable(bool mem, bool io);
+        // Enable/disable the device decoding the BAR address when a write is
+        // performed on the BARs
+        void enable_bars_decode(bool mem, bool io);
+        void disable_bars_decode(bool mem, bool io);
 
         // Enable/Disable intx assertions
         bool is_intx_enabled();


### PR DESCRIPTION
When computing the size of a BAR the device should not try to decode the content of the BAR as an address. For example, this can cause a crash in QEMU trying to map memory at a nonexistent address.