### PR TITLE
pci: avoid execution of msix_enable() function if already enabled

### DIFF
--- a/drivers/pci-function.cc
+++ b/drivers/pci-function.cc
@@ -680,7 +680,7 @@ namespace pci {
 
     void function::msix_enable()
     {
-        if (!is_msix()) {
+        if (!is_msix() || _msix_enabled) {
             return;
         }
 
@@ -717,7 +717,7 @@ namespace pci {
 
     void function::msi_enable()
     {
-        if (!is_msi()) {
+        if (!is_msi() || _msi_enabled) {
             return;
         }
 


### PR DESCRIPTION
When using the `interrupt_manager::easy_register()` function multiple times on a device (e.g., to register interrupts for multiple queue pairs in a virtio-net device), `msi(x)_enable()` is called multiple times, causing interrupts that have previously been registered to be masked and never unmasked. Avoid this problem by preventing  the execution of `msi[x]_enable()` if msi[x] is already enabled.