### PR TITLE
Add support for release.x64 directory in build-capstan-base-image

### DIFF
--- a/scripts/build-capstan-base-image
+++ b/scripts/build-capstan-base-image
@@ -52,18 +52,21 @@ echo "platform: $platform" >> $index
 
 $build
 
-# Generate QEMU image
-scripts/convert vdi
-scripts/convert vmdk
+build_path=`realpath build/last`
+qemuimage=$build_path/osv.qcow2
+vboximage=$build_path/osv.vdi
+vmwimage=$build_path/osv.vmdk
+gceimage=$build_path/osv.tar.gz
+capstan_local_repository=$HOME/.capstan/repository
 
+# Generate QEMU image
+ln -sf $build_path/usr.img $qemuimage
+# Generate VBOX image
+scripts/convert vdi
+# Generate VMW image
+scripts/convert vmdk
 # Generate GCE image
 scripts/gen-gce-tarball.sh
-
-capstan_local_repository=$HOME/.capstan/repository
-qemuimage=build/`readlink build/last`/osv.qcow2
-vboximage=build/`readlink build/last`/osv.vdi
-gceimage=build/`readlink build/last`/osv.tar.gz
-vmwimage=build/`readlink build/last`/osv.vmdk
 
 read -p "Copy base images into capstan local repository [y/N]? :" -n 1 -t 15 -s
 echo

--- a/scripts/build-capstan-base-image
+++ b/scripts/build-capstan-base-image
@@ -36,13 +36,8 @@ fi
 now=$(date +"%Y-%m-%dT%R:%S")
 
 out=build/capstan/$name
-qemuimage=build/release/osv.qcow2
-vboximage=build/release/osv.vdi
-gceimage=build/release/osv.tar.gz
-vmwimage=build/release/osv.vmdk
 index=$out/index.yaml
 build="scripts/build image=$image"
-capstan_local_repository=$HOME/.capstan/repository
 
 mkdir -p $out
 
@@ -63,6 +58,12 @@ scripts/convert vmdk
 
 # Generate GCE image
 scripts/gen-gce-tarball.sh
+
+capstan_local_repository=$HOME/.capstan/repository
+qemuimage=build/`readlink build/last`/osv.qcow2
+vboximage=build/`readlink build/last`/osv.vdi
+gceimage=build/`readlink build/last`/osv.tar.gz
+vmwimage=build/`readlink build/last`/osv.vmdk
 
 read -p "Copy base images into capstan local repository [y/N]? :" -n 1 -t 15 -s
 echo


### PR DESCRIPTION
Whenever I build a base image on an amd64 system with `scripts/build` and I build it with `./scripts/build-capstan-base-image openjdk17 openjdk9_1x-from-host`, it fails with:

```sh
+ cp build/release/osv.qcow2 /root/.capstan/repository/papermc/papermc.qemu
cp: cannot stat 'build/release/osv.qcow2': No such file or director
```

This fix uses the same method as used in `./scripts/convert` to determine where to find the last build.