### PR TITLE
Correct resolution of liblua53.so

### DIFF
--- a/modules/cli/Makefile
+++ b/modules/cli/Makefile
@@ -1,6 +1,7 @@
 SRC = $(shell readlink -f ../..)
 
 LUA_DIR = $(SRC)/modules/lua/upstream/lua5.3
+LD_LIBRARY_PATH = $(LUA_DIR)
 
 CC=gcc
 CFLAGS=-O2 -g -Wall -std=gnu99 -I $(LUA_DIR)/include


### PR DESCRIPTION
Host `liblua53.so` might not contain all symbols (e.g. `luaL_newstate`). This makes `lddtree` resolve the correct `liblua53.so`