### PR TITLE
poll: drop POLLINIGNEOF and fix POLLRDHUP

### DIFF
--- a/bsd/sys/kern/uipc_socket.cc
+++ b/bsd/sys/kern/uipc_socket.cc
@@ -3190,17 +3190,17 @@ sopoll_generic_locked(struct socket *so, int events)
 		}
 	}
 
-    if (revents == 0 || events & EPOLLET) {
-        if (events & (POLLIN | POLLPRI | POLLRDNORM | POLLRDBAND)) {
-            so->so_rcv.sb_flags |= SB_SEL;
-        }
+	if (revents == 0 || events & EPOLLET) {
+		if (events & (POLLIN | POLLPRI | POLLRDNORM | POLLRDBAND)) {
+			so->so_rcv.sb_flags |= SB_SEL;
+		}
 
-        if (events & (POLLOUT | POLLWRNORM)) {
-            so->so_snd.sb_flags |= SB_SEL;
-        }
-    }
+		if (events & (POLLOUT | POLLWRNORM)) {
+			so->so_snd.sb_flags |= SB_SEL;
+		}
+	}
 
-    return revents;
+	return revents;
 }
 
 /*

--- a/bsd/sys/kern/uipc_socket.cc
+++ b/bsd/sys/kern/uipc_socket.cc
@@ -3182,12 +3182,10 @@ sopoll_generic_locked(struct socket *so, int events)
 		if (so->so_oobmark || (so->so_rcv.sb_state & SBS_RCVATMARK))
 			revents |= events & (POLLPRI | POLLRDBAND);
 
-	if ((events & POLLINIGNEOF) == 0) {
-		if (so->so_rcv.sb_state & SBS_CANTRCVMORE) {
-			revents |= events & (POLLIN | POLLRDNORM);
-			if (so->so_snd.sb_state & SBS_CANTSENDMORE)
-				revents |= POLLHUP;
-		}
+	if (so->so_rcv.sb_state & SBS_CANTRCVMORE) {
+		revents |= events & (POLLIN | POLLRDNORM | POLLRDHUP);
+		if (so->so_snd.sb_state & SBS_CANTSENDMORE)
+			revents |= POLLHUP;
 	}
 
 	if (revents == 0 || events & EPOLLET) {

--- a/include/osv/poll.h
+++ b/include/osv/poll.h
@@ -80,9 +80,6 @@ struct pollfd {
 #define POLLRDBAND  0x0080      /* OOB/Urgent readable data */
 #define POLLWRBAND  0x0100      /* OOB/Urgent data can be written */
 
-/* General FreeBSD extension (currently only supported for sockets): */
-#define POLLINIGNEOF    0x2000      /* like POLLIN, except ignore EOF */
-
 /*
  * These events are set if they occur regardless of whether they were
  * requested.
@@ -105,8 +102,6 @@ struct pollfd {
 #include <sys/poll.h>
 #define POLLSTANDARD    (POLLIN|POLLPRI|POLLOUT|POLLRDNORM|POLLRDBAND|\
              POLLWRBAND|POLLERR|POLLHUP|POLLNVAL)
-/* General FreeBSD extension (currently only supported for sockets): */
-#define POLLINIGNEOF    0x2000      /* like POLLIN, except ignore EOF */
 
 #endif
 

--- a/libc/af_local.cc
+++ b/libc/af_local.cc
@@ -65,6 +65,7 @@ int af_local::ioctl(u_long cmd, void *data)
 void af_local::init()
 {
     send->attach_sender(this);
+    send->set_no_receiver_event(POLLRDHUP);
     receive->attach_receiver(this);
 }
 

--- a/libc/pipe_buffer.cc
+++ b/libc/pipe_buffer.cc
@@ -29,7 +29,7 @@ void pipe_buffer::detach_receiver()
     if (receiver) {
         receiver = nullptr;
         if (sender)
-            poll_wake(sender, POLLERR|POLLOUT);
+            poll_wake(sender, no_receiver_event);
         may_write.wake_all();
     }
 }
@@ -57,7 +57,7 @@ int pipe_buffer::read_events_unlocked()
 int pipe_buffer::write_events_unlocked()
 {
     if (!receiver) {
-        return POLLERR|POLLOUT;
+        return no_receiver_event;
     }
     int ret = 0;
     ret |= q.size() < max_buf ? POLLOUT : 0;

--- a/libc/pipe_buffer.hh
+++ b/libc/pipe_buffer.hh
@@ -30,6 +30,9 @@ public:
     void detach_receiver();
     void attach_sender(struct file *f);
     void attach_receiver(struct file *f);
+    void set_no_receiver_event(int event) {
+        this->no_receiver_event = event;
+    }
 private:
     int read_events_unlocked();
     int write_events_unlocked();
@@ -41,6 +44,7 @@ private:
     std::atomic<unsigned> refs = {};
     condvar may_read;
     condvar may_write;
+    int no_receiver_event = POLLERR|POLLOUT;
     friend void intrusive_ptr_add_ref(pipe_buffer* p) {
         p->refs.fetch_add(1, std::memory_order_relaxed);
     }

--- a/tests/tst-epoll.cc
+++ b/tests/tst-epoll.cc
@@ -116,6 +116,74 @@ static void test_epoll_file()
     close(fd);
 }
 
+#include <arpa/inet.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+static void test_socket_epollrdhup()
+{
+    constexpr int MAXEVENTS = 1024;
+    struct epoll_event events[MAXEVENTS];
+
+    int ep = epoll_create(1);
+    report(ep >= 0, "epoll_create");
+
+    // Create a TCP server socket
+    int serverfd = socket(AF_INET, SOCK_STREAM, 0);
+    report(serverfd >= 0, "server socket");
+    struct sockaddr_in server = {
+        .sin_family = AF_INET,
+        .sin_port   = htons(65432),
+        .sin_addr   = {
+            .s_addr = htonl(INADDR_LOOPBACK),
+        },
+    };
+    int r = bind(serverfd,
+                 reinterpret_cast<const struct sockaddr *>(&server),
+                 sizeof(server));
+    report(r == 0, "bind serverfd");
+
+    r = listen(serverfd, 1);
+    report(r == 0, "listen on serverfd");
+
+    // Create a thread to connect and disconnect
+    std::thread client([&] {
+        int clientfd = socket(AF_INET, SOCK_STREAM, 0);
+        report (clientfd >= 0, "client socket");
+        struct sockaddr_in server = {
+            .sin_family = AF_INET,
+            .sin_port   = htons(65432),
+            .sin_addr   = {
+                .s_addr = htonl(INADDR_LOOPBACK),
+            }
+        };
+        int r = connect(clientfd,
+                        reinterpret_cast<const struct sockaddr *>(&server),
+                        sizeof(server));
+        report(r == 0, "connect to server");
+        close(clientfd);
+    });
+
+    // Accept the client
+    int c = accept(serverfd, NULL, NULL);
+    report(c >= 0, "accepted client");
+
+    // and wait for socket to close
+    struct epoll_event event = {
+        .events  = EPOLLRDHUP,
+        .data    = {
+            .u32 = 789,
+        }
+    };
+    r = epoll_ctl(ep, EPOLL_CTL_ADD, c, &event);
+    report(r == 0, "epoll_ctl ADD");
+
+    r = epoll_wait(ep, events, MAXEVENTS, 10);
+    report(r == 1 && (event.events & EPOLLRDHUP) &&
+           (event.data.u32 == 789), "epoll_wait for EPOLLRDHUP");
+    close(serverfd);
+    client.join();
+}
+
 int main(int ac, char** av)
 {
     int ep = epoll_create(1);
@@ -269,6 +337,7 @@ int main(int ac, char** av)
 
     test_epolloneshot();
     test_epoll_file();
+    test_socket_epollrdhup();
 
     std::cout << "SUMMARY: " << tests << ", " << fails << " failures\n";
     return !!fails;


### PR DESCRIPTION
[poll: drop POLLINIGNEOF and fix POLLRDHUP](https://github.com/cloudius-systems/osv/commit/67eab5e0b1924c59275a34a9a7af626e7f0a2f89) 

Both POLLIGNEOF and POLLRDHUP use the same value. POLLRDHUP must
be congruent to EPOLLRDHUP, so it can't change. However, POLLIGNEOF is
unused so extirpate POLLINIGNEOF from the code base.

Also, update sopoll_generic_locked so that POLLRDHUP can actually
be set when requested by clients.

Finally, add support of EPOLLRDHUP in AF_LOCAL sockets