### PR TITLE
libc: add minimal implementation of clock_nanosleep()

### DIFF
--- a/exported_symbols/osv_ld-musl.so.1.symbols
+++ b/exported_symbols/osv_ld-musl.so.1.symbols
@@ -76,6 +76,7 @@ clock
 clock_getcpuclockid
 clock_getres
 clock_gettime
+clock_nanosleep
 close
 closedir
 closelog

--- a/exported_symbols/osv_libc.so.6.symbols
+++ b/exported_symbols/osv_libc.so.6.symbols
@@ -53,6 +53,7 @@ clock
 clock_getcpuclockid
 clock_getres
 clock_gettime
+clock_nanosleep
 close
 closedir
 closelog

--- a/libc/time.cc
+++ b/libc/time.cc
@@ -41,6 +41,23 @@ int nanosleep(const struct timespec* req, struct timespec* rem)
 }
 
 OSV_LIBC_API
+int clock_nanosleep(clockid_t clock_id, int flags,
+                    const struct timespec *request,
+                    struct timespec *remain)
+{
+    //We ignore the "remain" argument same way we do it above in nanosleep()
+    //This argument is only relevant if the "sleeping" thread is interrupted
+    //by signals. But OSv signal implementation is limited and would not allow
+    //for such a scenario and both nanosleep() and clock_nanosleep() would
+    //never return EINTR
+    if (flags || clock_id != CLOCK_REALTIME) {
+        return ENOTSUP;
+    }
+    sched::thread::sleep(std::chrono::nanoseconds(convert(*request)));
+    return 0;
+}
+
+OSV_LIBC_API
 int usleep(useconds_t usec)
 {
     sched::thread::sleep(std::chrono::microseconds(usec));

--- a/linux.cc
+++ b/linux.cc
@@ -533,6 +533,7 @@ OSV_LIBC_API long syscall(long number, ...)
     SYSCALL3(sys_getdents64, int, void *, size_t);
     SYSCALL4(renameat, int, const char *, int, const char *);
     SYSCALL1(sys_brk, void *);
+    SYSCALL4(clock_nanosleep, clockid_t, int, const struct timespec *, struct timespec *);
     }
 
     debug_always("syscall(): unimplemented system call %d\n", number);


### PR DESCRIPTION
This patch adds minimal implementation of clock_nanosleep() and corresponding syscall that is enough to support glibc implementation of the userland function nanosleep() which delegates to:

__syscall(clock_nanosleep, CLOCK_REALTIME, 0, req, rem)

In other words, the new clock_nanosleep() only implements scenario where clock_id is CLOCK_REALTIME and flags is 0.

Please note that there is a patch sent to the mailing list that implements the non-zero (TIMER_ABSTIME) scenario which is useful in realtime scheduler scenarios.