### PR TITLE
syscalls: make exit terminate current thread

### DIFF
--- a/linux.cc
+++ b/linux.cc
@@ -355,7 +355,7 @@ int rt_sigprocmask(int how, sigset_t * nset, sigset_t * oset, size_t sigsetsize)
 
 static int sys_exit(int ret)
 {
-    exit(ret);
+    sched::thread::current()->exit();
     return 0;
 }
 


### PR DESCRIPTION
Unlike the libc `exit()` function, the system call exit in Linux is supposed to terminate the current thread. This patch fixes the current incorrect implementation that delegates to `exit()`.