### PR TITLE
syscalls: expose statx

### DIFF
--- a/fs/vfs/main.cc
+++ b/fs/vfs/main.cc
@@ -37,6 +37,7 @@
 #include <sys/param.h>
 #include <sys/statvfs.h>
 #include <sys/stat.h>
+#include <sys/statx.h>
 #include <sys/time.h>
 #include <sys/sendfile.h>
 
@@ -1321,42 +1322,6 @@ int stat(const char *pathname, struct stat *st)
 {
     return __xstat(1, pathname, st);
 }
-
-// Our <sys/stat.h> (from Musl) doesn't yet declare statx(), struct statx,
-// or the various STATX_* constants. So we need to do it here for now.
-// Eventually, when we update Musl or modify it manually to include these
-// definitions, they should be removed from here:
-struct statx_timestamp
-{
-    int64_t tv_sec;
-    uint32_t tv_nsec;
-    int32_t statx_timestamp_pad1[1];
-};
-struct statx {
-    uint32_t stx_mask;
-    uint32_t stx_blksize;
-    uint64_t stx_attributes;
-    uint32_t stx_nlink;
-    uint32_t stx_uid;
-    uint32_t stx_gid;
-    uint16_t stx_mode;
-    uint16_t __statx_pad1[1];
-    uint64_t stx_ino;
-    uint64_t stx_size;
-    uint64_t stx_blocks;
-    uint64_t stx_attributes_mask;
-    struct statx_timestamp stx_atime;
-    struct statx_timestamp stx_btime;
-    struct statx_timestamp stx_ctime;
-    struct statx_timestamp stx_mtime;
-    uint32_t stx_rdev_major;
-    uint32_t stx_rdev_minor;
-    uint32_t stx_dev_major;
-    uint32_t stx_dev_minor;
-    uint64_t __statx_pad2[14];
-};
-extern "C" int statx(int dirfd, const char* pathname, int flags, unsigned int mask, struct statx *buf);
-#define STATX_BASIC_STATS 0x000007ffU
 
 OSV_LIBC_API
 int statx(int dirfd, const char* pathname, int flags, unsigned int mask,

--- a/include/api/sys/statx.h
+++ b/include/api/sys/statx.h
@@ -1,0 +1,45 @@
+#ifndef	_SYS_STATX_H
+#define	_SYS_STATX_H
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define STATX_BASIC_STATS 0x000007ffU
+
+struct statx_timestamp
+{
+    int64_t tv_sec;
+    uint32_t tv_nsec;
+    int32_t statx_timestamp_pad1[1];
+};
+
+struct statx {
+    uint32_t stx_mask;
+    uint32_t stx_blksize;
+    uint64_t stx_attributes;
+    uint32_t stx_nlink;
+    uint32_t stx_uid;
+    uint32_t stx_gid;
+    uint16_t stx_mode;
+    uint16_t __statx_pad1[1];
+    uint64_t stx_ino;
+    uint64_t stx_size;
+    uint64_t stx_blocks;
+    uint64_t stx_attributes_mask;
+    struct statx_timestamp stx_atime;
+    struct statx_timestamp stx_btime;
+    struct statx_timestamp stx_ctime;
+    struct statx_timestamp stx_mtime;
+    uint32_t stx_rdev_major;
+    uint32_t stx_rdev_minor;
+    uint32_t stx_dev_major;
+    uint32_t stx_dev_minor;
+    uint64_t __statx_pad2[14];
+};
+
+extern "C" int statx(int dirfd, const char* pathname, int flags, unsigned int mask, struct statx *buf);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/include/api/x64/bits/syscall.h
+++ b/include/api/x64/bits/syscall.h
@@ -313,6 +313,7 @@
 #define __NR_kcmp				312
 #define __NR_finit_module			313
 #define __NR_getrandom				318
+#define __NR_statx				332
 
 #undef __NR_fstatat
 #undef __NR_pread
@@ -642,6 +643,7 @@
 #define SYS_process_vm_writev			311
 #define SYS_kcmp				312
 #define SYS_finit_module			313
+#define SYS_statx				332
 
 #undef SYS_fstatat
 #undef SYS_pread

--- a/linux.cc
+++ b/linux.cc
@@ -33,6 +33,7 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
+#include <sys/statx.h>
 #include <fcntl.h>
 #include <sys/ioctl.h>
 #include <sys/file.h>
@@ -565,6 +566,7 @@ OSV_LIBC_API long syscall(long number, ...)
     SYSCALL4(renameat, int, const char *, int, const char *);
     SYSCALL1(sys_brk, void *);
     SYSCALL4(clock_nanosleep, clockid_t, int, const struct timespec *, struct timespec *);
+    SYSCALL5(statx, int, const char *, int, unsigned int, struct statx *);
     }
 
     debug_always("syscall(): unimplemented system call %d\n", number);


### PR DESCRIPTION
Nadav Har'EL added a basic implementation of `statx` at VFS layer. 
This patch exposes it as a syscall.