### PR TITLE
Dynamic linker: support loading and processing statically linked executables

### DIFF
--- a/arch/aarch64/arch-elf.cc
+++ b/arch/aarch64/arch-elf.cc
@@ -66,7 +66,7 @@ bool object::arch_relocate_rela(u32 type, u32 sym, void *addr,
         if (sym) {
             auto sm = symbol(sym);
             ulong tls_offset;
-            if (sm.obj->is_executable()) {
+            if (sm.obj->is_dynamically_linked_executable()) {
                 // If this is an executable (pie or position-dependant one)
                 // then the variable is located in the reserved slot of the TLS
                 // right where the kernel TLS lives
@@ -119,7 +119,7 @@ void object::arch_relocate_tls_desc(u32 sym, void *addr, Elf64_Sxword addend)
     ulong tls_offset;
     if (sym) {
         auto sm = symbol(sym);
-        if (sm.obj->is_executable() || sm.obj->is_core()) {
+        if (sm.obj->is_dynamically_linked_executable() || sm.obj->is_core()) {
             // If this is an executable (pie or position-dependant one)
             // then the variable is located in the reserved slot of the TLS
             // right where the kernel TLS lives
@@ -163,7 +163,7 @@ void object::prepare_initial_tls(void* buffer, size_t size,
 
 void object::prepare_local_tls(std::vector<ptrdiff_t>& offsets)
 {
-    if (!_static_tls && !is_executable()) {
+    if (!_static_tls && !is_dynamically_linked_executable()) {
         return;
     }
 

--- a/arch/aarch64/arch-switch.hh
+++ b/arch/aarch64/arch-switch.hh
@@ -120,7 +120,7 @@ void thread::setup_tcb()
         assert(obj);
         user_tls_size = obj->initial_tls_size();
         user_tls_data = obj->initial_tls();
-        if (obj->is_executable()) {
+        if (obj->is_dynamically_linked_executable()) {
            executable_tls_size = obj->get_tls_size();
         }
     }

--- a/arch/x64/arch-elf.cc
+++ b/arch/x64/arch-elf.cc
@@ -138,7 +138,7 @@ bool object::arch_relocate_rela(u32 type, u32 sym, void *addr,
         if (sym) {
             auto sm = symbol(sym);
             ulong tls_offset;
-            if (sm.obj->is_executable()) {
+            if (sm.obj->is_dynamically_linked_executable()) {
                 // If this is an executable (pie or position-dependant one)
                 // then the variable is located in the reserved slot of the TLS
                 // right where the kernel TLS lives
@@ -202,7 +202,7 @@ void object::prepare_initial_tls(void* buffer, size_t size,
 
 void object::prepare_local_tls(std::vector<ptrdiff_t>& offsets)
 {
-    if (!_static_tls && !is_executable()) {
+    if (!_static_tls && !is_dynamically_linked_executable()) {
         return;
     }
 

--- a/arch/x64/arch-switch.hh
+++ b/arch/x64/arch-switch.hh
@@ -210,7 +210,7 @@ void thread::setup_tcb()
         assert(obj);
         user_tls_size = obj->initial_tls_size();
         user_tls_data = obj->initial_tls();
-        if (obj->is_executable()) {
+        if (obj->is_dynamically_linked_executable()) {
            executable_tls_size = obj->get_tls_size();
            aligned_executable_tls_size = obj->get_aligned_tls_size();
         }

--- a/include/osv/elf.hh
+++ b/include/osv/elf.hh
@@ -378,7 +378,7 @@ public:
     size_t initial_tls_size() { return _initial_tls_size; }
     void* initial_tls() { return _initial_tls.get(); }
     void* get_tls_segment() { return _tls_segment; }
-    bool is_non_pie_executable() { return _ehdr.e_type == ET_EXEC; }
+    bool is_pic() { return _ehdr.e_type != ET_EXEC; }
     std::vector<ptrdiff_t>& initial_tls_offsets() { return _initial_tls_offsets; }
     bool is_dynamically_linked_executable() { return _is_dynamically_linked_executable; }
     ulong get_tls_size();
@@ -415,6 +415,7 @@ private:
     void prepare_local_tls(std::vector<ptrdiff_t>& offsets);
     void alloc_static_tls();
     void make_text_writable(bool flag);
+    bool is_statically_linked() { return !_is_dynamically_linked_executable && _ehdr.e_entry; }
 protected:
     program& _prog;
     std::string _pathname;

--- a/include/osv/elf.hh
+++ b/include/osv/elf.hh
@@ -380,7 +380,7 @@ public:
     void* get_tls_segment() { return _tls_segment; }
     bool is_non_pie_executable() { return _ehdr.e_type == ET_EXEC; }
     std::vector<ptrdiff_t>& initial_tls_offsets() { return _initial_tls_offsets; }
-    bool is_executable() { return _is_executable; }
+    bool is_dynamically_linked_executable() { return _is_dynamically_linked_executable; }
     ulong get_tls_size();
     ulong get_aligned_tls_size();
     void copy_local_tls(void* to_addr);
@@ -435,7 +435,7 @@ protected:
     Elf64_Dyn* _dynamic_table;
     ulong _module_index;
     std::unique_ptr<char[]> _section_names_cache;
-    bool _is_executable;
+    bool _is_dynamically_linked_executable;
     bool is_core();
     bool _init_called;
     void* _eh_frame;
@@ -462,7 +462,7 @@ protected:
     bool arch_relocate_jump_slot(symbol_module& sym, void *addr, Elf64_Sxword addend);
     void arch_relocate_tls_desc(u32 sym, void *addr, Elf64_Sxword addend);
     size_t static_tls_end() {
-        if (is_core() || is_executable()) {
+        if (is_core() || _is_dynamically_linked_executable) {
             return 0;
         }
         return _static_tls_offset + get_tls_size();


### PR DESCRIPTION
The two commits provide necessary modifications to the OSv dynamic linker to support loading and processing statically linked executables.

Please note these changes are NOT enough to make OSv run statically linked executables.