### PR TITLE
core: support launching statically linked executables

### DIFF
--- a/arch/aarch64/arch-elf.hh
+++ b/arch/aarch64/arch-elf.hh
@@ -23,4 +23,38 @@ enum {
 
 #define ELF_KERNEL_MACHINE_TYPE 183
 
+static constexpr unsigned SAFETY_BUFFER = 256;
+#include <osv/align.hh>
+
+inline void run_entry_point(void* ep, int argc, char** argv, int argv_size)
+{
+    //The layout of the stack and state of all relevant registers is similar
+    //to how it looks for x86_64. The main difference (possibly for now)
+    //is the inlined assembly
+    int argc_plus_argv_stack_size = argv_size + 1;
+
+    //Capture current stack pointer
+    void *stack;
+    asm volatile ("mov %0, sp" : "=r"(stack));
+
+    //The code below puts argv and auxv vector onto the stack but it may
+    //also end up using some of the stack. To make sure there is no collision
+    //let us leave some space - SAFETY_BUFFER - between current stack pointer
+    //and the position on the stack we will be writing to.
+    stack -= (SAFETY_BUFFER + argc_plus_argv_stack_size * sizeof(char*));
+
+    //According to the document above the stack pointer should be 16-bytes aligned
+    stack = align_down(stack, 16);
+
+    *reinterpret_cast<u64*>(stack) = argc;
+    memcpy(stack + sizeof(char*), argv, argv_size * sizeof(char*));
+
+    //Set stack pointer and jump to the ELF entry point
+    asm volatile (
+        "mov sp, %1\n\t" //set stack
+        "blr %0\n\t"
+        :
+        : "r"(ep), "r"(stack));
+}
+
 #endif /* ARCH_ELF_HH */

--- a/arch/x64/arch-elf.hh
+++ b/arch/x64/arch-elf.hh
@@ -42,4 +42,45 @@ enum {
 
 #define ELF_KERNEL_MACHINE_TYPE 62
 
+static constexpr unsigned SAFETY_BUFFER = 256;
+#include <osv/align.hh>
+
+inline void run_entry_point(void* ep, int argc, char** argv, int argv_size)
+{
+    //The layout of the stack and state of all relevant registers is described
+    //in detail in the section 3.4 (Process Initialization) of the System V Application
+    //Binary Interface AMD64 Architecture Processor Supplement Draft Version 0.95
+    //(see https://refspecs.linuxfoundation.org/elf/x86_64-abi-0.95.pdf)
+    int argc_plus_argv_stack_size = argv_size + 1;
+
+    //Capture current stack pointer
+    void *stack;
+    asm volatile ("movq %%rsp, %0" : "=r"(stack));
+
+    //The code below puts argv and auxv vector onto the stack but it may
+    //also end up using some of the stack. To make sure there is no collision
+    //let us leave some space - SAFETY_BUFFER - between current stack pointer
+    //and the position on the stack we will be writing to.
+    stack -= (SAFETY_BUFFER + argc_plus_argv_stack_size * sizeof(char*));
+
+    //According to the document above the stack pointer should be 16-bytes aligned
+    stack = align_down(stack, 16);
+
+    //... and it should start with argc, followed by argv, environment pointers and
+    //auxiliary vector entries. For details look at application::prepare_argv()
+    *reinterpret_cast<u64*>(stack) = argc;
+    memcpy(stack + sizeof(char*), argv, argv_size * sizeof(char*));
+
+    //TODO: Reset SSE2 and floating point registers and RFLAGS as the "Special Registers"
+    //      paragraph of the section of 3.4 (Process Initialization) of the "System V Application
+    //      Binary Interface" document states
+    //Set stack pointer, reset rdx and jump to the ELF entry point
+    asm volatile (
+        "movq %1, %%rsp\n\t" //set stack
+        "movq $0, %%rdx\n\t" //fini should be 0 for now (TODO: Eventually point to atexit())
+        "jmpq *%0\n\t"
+        :
+        : "r"(ep), "r"(stack));
+}
+
 #endif /* ARCH_ELF_HH */

--- a/include/osv/app.hh
+++ b/include/osv/app.hh
@@ -217,6 +217,7 @@ private:
     void start_and_join(waiter* setup_waiter);
     void main();
     void prepare_argv(elf::program *program);
+    void augment_auxv();
     void run_main();
     friend void ::__libc_start_main(int(*)(int, char**), int, char**, void(*)(),
         void(*)(), void(*)(), void*);
@@ -241,8 +242,11 @@ private:
     // retained as member variable so that it later can be passed as argument by either
     // application::main and application::run_main() or application::run_main() called
     // from __libc_start_main()
+    int _argv_size;
     std::unique_ptr<char *[]> _argv;
     std::unique_ptr<char []> _argv_buf; // actual arguments content _argv points to
+    Elf64_auxv_t* _auxv;
+    int _auxv_idx;
 
     // Must be destroyed before _lib, because contained function objects may
     // have destructors which are part of the application's code.

--- a/include/osv/elf.hh
+++ b/include/osv/elf.hh
@@ -212,6 +212,7 @@ enum {
 };
 enum {
     DF_1_NOW = 0x1,
+    DF_1_PIE = 0x08000000,
 };
 
 enum {
@@ -378,13 +379,39 @@ public:
     size_t initial_tls_size() { return _initial_tls_size; }
     void* initial_tls() { return _initial_tls.get(); }
     void* get_tls_segment() { return _tls_segment; }
-    bool is_pic() { return _ehdr.e_type != ET_EXEC; }
     std::vector<ptrdiff_t>& initial_tls_offsets() { return _initial_tls_offsets; }
+    // OSv is only "interested" in ELF objects with e_type equal to ET_EXEC or ET_DYN
+    // and rejects others (see load_elf_header()). All these can be broken down
+    // into five types:
+    // - (1) dynamically linked position dependent executable
+    // - (2) dynamically linked position independent executable (dynamically linked PIE)
+    // - (3) statically linked position dependent executable
+    // - (4) statically linked position independent executable (statically linked PIE)
+    // - (5) shared library
+    // As OSv processes the ELF objects, most of the time it needs to know if given
+    // object belongs to a superset of these types - dynamically linked executables,
+    // statically linked executables, position dependent object, etc. For this reason
+    // the methods below provide a way to make such determination.
+    //
+    // Is it a position independent code (type 2, 4 or 5)?
+    bool is_pic() { return _ehdr.e_type == ET_DYN; }
+    // Is it a position independent executable (type 2 or 4)?
+    bool is_pie() { return dynamic_exists(DT_FLAGS_1) && (dynamic_val(DT_FLAGS_1) & DF_1_PIE); }
+    // Is it a shared library (type 5)?
+    bool is_shared_library() { return _ehdr.e_type == ET_DYN && !is_pie(); }
+    // Is it a dynamically linked executable (type 1 or 2, determined by presence of PT_INTERP)?
     bool is_dynamically_linked_executable() { return _is_dynamically_linked_executable; }
+    // Is it a statically linked executable (type 3 or 4)?
+    // Absence of PT_INTERP is not enough to determine it is a statically linked executable
+    // as shared libraries also as missing PT_INTERP.
+    bool is_statically_linked_executable() { return !_is_dynamically_linked_executable && !is_shared_library(); }
     ulong get_tls_size();
     ulong get_aligned_tls_size();
     void copy_local_tls(void* to_addr);
     void* eh_frame_addr() { return _eh_frame; }
+    Elf64_Half headers_count() { return _ehdr.e_phnum; }
+    Elf64_Half headers_size() { return _ehdr.e_phentsize; }
+    void* headers_start() { return _headers_start; }
 protected:
     virtual void load_segment(const Elf64_Phdr& segment) = 0;
     virtual void unload_segment(const Elf64_Phdr& segment) = 0;
@@ -415,7 +442,6 @@ private:
     void prepare_local_tls(std::vector<ptrdiff_t>& offsets);
     void alloc_static_tls();
     void make_text_writable(bool flag);
-    bool is_statically_linked() { return !_is_dynamically_linked_executable && _ehdr.e_entry; }
 protected:
     program& _prog;
     std::string _pathname;
@@ -440,6 +466,7 @@ protected:
     bool is_core();
     bool _init_called;
     void* _eh_frame;
+    void* _headers_start;
 
     std::unordered_map<std::string,void*> _cached_symbols;
 


### PR DESCRIPTION
This patch enhances the dynamic linker to support launching statically linked executables.

The dynamically linked executables or shared libraries are typically launched by calling a "main" function which is exported and can be resolved using the ELF symbol table. The statically linked executables do not export
such symbols and instead must be launched by jumping to the ELF entry point specified in the header. To that end this patch implements new functions - `run_entry_point()` - specific for each architecture - x86_64 and aarch64 which fundamentally do a similar thing - put `argc`, `argv`, environment variables, and auxiliary vector on the stack and jump to the elf entry point.

In addition, this patch enhances other parts of the dynamic linker logic to do things a little bit differently for statically linked executables:
- do not relocate as the executable comes with its own code that does this
- do not call INIT and FINI function for the same reason as above
- do not try to load dependent libraries as they would be none

This patch also adds augment_auxv() to add the extra auxiliary vector entries needed by statically linked executables to bootstrap themselves

In addition, this 2nd version of the PR renames the method `is_statically_linked()` to `is_statically_linked_executable()` and fixes it by identifying if an ELF is not a shared library. So it should fix the "liblua.so" problem reported by Nadav.

Closes #1140