### PR TITLE
Implement arch_prctl syscall to support statically linked executables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1012,6 +1012,7 @@ objects += arch/x64/ioapic.o
 objects += arch/x64/apic.o
 objects += arch/x64/apic-clock.o
 objects += arch/x64/entry-xen.o
+objects += arch/x64/prctl.o
 objects += arch/x64/vmlinux.o
 objects += arch/x64/vmlinux-boot64.o
 objects += arch/x64/pvh-boot.o
@@ -1849,6 +1850,11 @@ musl += time/timegm.o
 musl += time/wcsftime.o
 musl += time/ftime.o
 $(out)/libc/time/ftime.o: CFLAGS += -Ilibc/include
+
+ifeq ($(arch),x64)
+libc += vdso/vdso_kernel.o
+libc_to_hide += vdso/vdso_kernel.o
+endif
 
 musl += termios/tcflow.o
 

--- a/arch/aarch64/arch-switch.hh
+++ b/arch/aarch64/arch-switch.hh
@@ -164,6 +164,10 @@ void thread::free_tcb()
     free(_tcb);
 }
 
+void thread::free_syscall_stack()
+{
+}
+
 void thread_main_c(thread* t)
 {
     arch::irq_enable();

--- a/arch/x64/arch-cpu.hh
+++ b/arch/x64/arch-cpu.hh
@@ -13,6 +13,8 @@
 #include "cpuid.hh"
 #include "osv/pagealloc.hh"
 #include <xmmintrin.h>
+#include "syscall.hh"
+#include "msr.hh"
 
 struct init_stack {
     char stack[4096] __attribute__((aligned(16)));
@@ -46,6 +48,7 @@ struct arch_cpu {
     u32 apic_id;
     u32 acpi_id;
     u64 gdt[nr_gdt];
+    syscall_stack _current_syscall_stack;
     void init_on_cpu();
     void set_ist_entry(unsigned ist, char* base, size_t size);
     char* get_ist_entry(unsigned ist);
@@ -181,6 +184,8 @@ inline void arch_cpu::init_on_cpu()
     processor::init_fpu();
 
     processor::init_syscall();
+
+    processor::wrmsr(msr::IA32_GS_BASE, reinterpret_cast<u64>(&_current_syscall_stack.stack_top));
 }
 
 struct exception_guard {

--- a/arch/x64/arch-cpu.hh
+++ b/arch/x64/arch-cpu.hh
@@ -49,6 +49,7 @@ struct arch_cpu {
     u32 acpi_id;
     u64 gdt[nr_gdt];
     syscall_stack _current_syscall_stack;
+    u64 kernel_tcb;
     void init_on_cpu();
     void set_ist_entry(unsigned ist, char* base, size_t size);
     char* get_ist_entry(unsigned ist);

--- a/arch/x64/arch-switch.hh
+++ b/arch/x64/arch-switch.hh
@@ -37,10 +37,10 @@
 #define LARGE_SYSCALL_STACK_DEPTH (LARGE_SYSCALL_STACK_SIZE - SYSCALL_STACK_RESERVED_SPACE_SIZE)
 
 #define SET_SYSCALL_STACK_TYPE_INDICATOR(value) \
-*reinterpret_cast<long*>(_tcb->syscall_stack_top) = value;
+*reinterpret_cast<long*>(_state._syscall_stack.stack_top) = value;
 
 #define GET_SYSCALL_STACK_TYPE_INDICATOR() \
-*reinterpret_cast<long*>(_tcb->syscall_stack_top)
+*reinterpret_cast<long*>(_state._syscall_stack.stack_top)
 
 #define TINY_SYSCALL_STACK_INDICATOR 0l
 #define LARGE_SYSCALL_STACK_INDICATOR 1l
@@ -88,8 +88,11 @@ void thread::switch_to()
     barrier();
     auto c = _detached_state->_cpu;
     old->_state.exception_stack = c->arch.get_exception_stack();
+    old->_state._syscall_stack.caller_stack_pointer = c->arch._current_syscall_stack.caller_stack_pointer;
     c->arch.set_interrupt_stack(&_arch);
     c->arch.set_exception_stack(_state.exception_stack);
+    c->arch._current_syscall_stack.caller_stack_pointer = _state._syscall_stack.caller_stack_pointer;
+    c->arch._current_syscall_stack.stack_top = _state._syscall_stack.stack_top;
     auto fpucw = processor::fnstcw();
     auto mxcsr = processor::stmxcsr();
     asm volatile
@@ -161,6 +164,25 @@ void thread::init_stack()
     _state.rip = reinterpret_cast<void*>(thread_main);
     _state.rsp = stacktop;
     _state.exception_stack = _arch.exception_stack + sizeof(_arch.exception_stack);
+
+    if (is_app()) {
+        //
+        // Allocate TINY syscall call stack
+        void* tiny_syscall_stack_begin = malloc(TINY_SYSCALL_STACK_SIZE);
+        assert(tiny_syscall_stack_begin);
+        //
+        // The top of the stack needs to be 16 bytes lower to make space for
+        // OSv syscall stack type indicator and extra 8 bytes to make it 16-bytes aligned
+        _state._syscall_stack.stack_top = tiny_syscall_stack_begin + TINY_SYSCALL_STACK_DEPTH;
+        SET_SYSCALL_STACK_TYPE_INDICATOR(TINY_SYSCALL_STACK_INDICATOR);
+        //
+        // Set a canary value at the bottom of the tiny stack to catch potential overflow
+        // caused by setup_large_syscall_stack()
+        *reinterpret_cast<u64*>(tiny_syscall_stack_begin) = STACK_CANARY;
+    }
+    else {
+        _state._syscall_stack.stack_top = 0;
+    }
 }
 
 void thread::setup_tcb()
@@ -247,25 +269,6 @@ void thread::setup_tcb()
     _tcb = static_cast<thread_control_block*>(p + total_tls_size);
     _tcb->self = _tcb;
     _tcb->tls_base = p + user_tls_size;
-
-    if (is_app()) {
-        //
-        // Allocate TINY syscall call stack
-        void* tiny_syscall_stack_begin = malloc(TINY_SYSCALL_STACK_SIZE);
-        assert(tiny_syscall_stack_begin);
-        //
-        // The top of the stack needs to be 16 bytes lower to make space for
-        // OSv syscall stack type indicator and extra 8 bytes to make it 16-bytes aligned
-        _tcb->syscall_stack_top = tiny_syscall_stack_begin + TINY_SYSCALL_STACK_DEPTH;
-        SET_SYSCALL_STACK_TYPE_INDICATOR(TINY_SYSCALL_STACK_INDICATOR);
-        //
-        // Set a canary value at the bottom of the tiny stack to catch potential overflow
-        // caused by setup_large_syscall_stack()
-        *reinterpret_cast<u64*>(tiny_syscall_stack_begin) = STACK_CANARY;
-    }
-    else {
-        _tcb->syscall_stack_top = 0;
-    }
 }
 
 void thread::setup_large_syscall_stack()
@@ -287,20 +290,23 @@ void thread::setup_large_syscall_stack()
     // We could have copied only last 128 (registers) + 16 bytes (2 fields) instead
     // of all of the stack but copying 1024 is simpler and happens
     // only once per thread.
-    void* tiny_syscall_stack_top = _tcb->syscall_stack_top;
+    void* tiny_syscall_stack_top = _state._syscall_stack.stack_top;
     memcpy(large_syscall_stack_top - TINY_SYSCALL_STACK_DEPTH,
            tiny_syscall_stack_top - TINY_SYSCALL_STACK_DEPTH, TINY_SYSCALL_STACK_SIZE);
     //
     // Check if the tiny stack has not been overflowed
-    assert(*reinterpret_cast<u64*>(_tcb->syscall_stack_top - TINY_SYSCALL_STACK_DEPTH) == STACK_CANARY);
+    assert(*reinterpret_cast<u64*>(_state._syscall_stack.stack_top - TINY_SYSCALL_STACK_DEPTH) == STACK_CANARY);
     //
     // Save beginning of tiny stack at the bottom of LARGE stack so
     // that we can deallocate it in free_tiny_syscall_stack
     *((void**)large_syscall_stack_begin) = tiny_syscall_stack_top - TINY_SYSCALL_STACK_DEPTH;
     //
     // Switch syscall stack address value in TCB to the top of the LARGE one
-    _tcb->syscall_stack_top = large_syscall_stack_top;
+    _state._syscall_stack.stack_top = large_syscall_stack_top;
     SET_SYSCALL_STACK_TYPE_INDICATOR(LARGE_SYSCALL_STACK_INDICATOR);
+    //
+    // Switch what GS points to
+     _detached_state->_cpu->arch._current_syscall_stack.stack_top = large_syscall_stack_top;
 }
 
 void thread::free_tiny_syscall_stack()
@@ -312,7 +318,7 @@ void thread::free_tiny_syscall_stack()
     assert(is_app());
     assert(GET_SYSCALL_STACK_TYPE_INDICATOR() == LARGE_SYSCALL_STACK_INDICATOR);
 
-    void* large_syscall_stack_top = _tcb->syscall_stack_top;
+    void* large_syscall_stack_top = _state._syscall_stack.stack_top;
     void* large_syscall_stack_begin = large_syscall_stack_top - LARGE_SYSCALL_STACK_DEPTH;
     //
     // Lookup address of tiny stack saved by setup_large_syscall_stack()
@@ -329,11 +335,14 @@ void thread::free_tcb()
     } else {
         free(_tcb->tls_base);
     }
+}
 
-    if (_tcb->syscall_stack_top) {
+void thread::free_syscall_stack()
+{
+    if (_state._syscall_stack.stack_top) {
         void* syscall_stack_begin = GET_SYSCALL_STACK_TYPE_INDICATOR() == TINY_SYSCALL_STACK_INDICATOR ?
-            _tcb->syscall_stack_top - TINY_SYSCALL_STACK_DEPTH :
-            _tcb->syscall_stack_top - LARGE_SYSCALL_STACK_DEPTH;
+            _state._syscall_stack.stack_top - TINY_SYSCALL_STACK_DEPTH :
+            _state._syscall_stack.stack_top - LARGE_SYSCALL_STACK_DEPTH;
         free(syscall_stack_begin);
     }
 }

--- a/arch/x64/arch-thread-state.hh
+++ b/arch/x64/arch-thread-state.hh
@@ -8,11 +8,14 @@
 #ifndef ARCH_THREAD_STATE_HH_
 #define ARCH_THREAD_STATE_HH_
 
+#include "syscall.hh"
+
 struct thread_state {
     char *exception_stack;
     void* rsp;
     void* rbp;
     void* rip;
+    syscall_stack _syscall_stack;
 };
 
 #endif /* ARCH_THREAD_STATE_HH_ */

--- a/arch/x64/arch-tls.hh
+++ b/arch/x64/arch-tls.hh
@@ -13,23 +13,6 @@
 struct thread_control_block {
     thread_control_block* self;
     void* tls_base;
-    //
-    // This field, a per-thread stack for SYSCALL instruction, is  used in
-    // arch/x64/entry.S for %fs's offset.  We currently keep this field in the TCB
-    // to make it easier to access in assembly code through a known offset at %fs:16.
-    // But with more effort, we could have used an ordinary thread-local variable
-    // instead and avoided extending the TCB here.
-    //
-    // The 8 bytes at the top of the syscall stack are used to identify if
-    // the stack is tiny (0) or large (1). So the size of the syscall stack is in
-    // reality smaller by 16 bytes from what was originally allocated because we need
-    // to make it 16-bytes aligned.
-    void* syscall_stack_top;
-    //
-    // This field is used to store the syscall caller stack pointer (value of RSP when
-    // SYSCALL was called) so that it can be restored when syscall completed.
-    // Same as above this field could be an ordinary thread-local variable.
-    void* syscall_caller_stack_pointer;
 };
 
 #endif /* ARCH_TLS_HH */

--- a/arch/x64/arch-tls.hh
+++ b/arch/x64/arch-tls.hh
@@ -13,6 +13,8 @@
 struct thread_control_block {
     thread_control_block* self;
     void* tls_base;
+    unsigned long app_tcb;
+    long kernel_tcb_counter; //If >=1 indicates that FS points to kernel TCB
 };
 
 #endif /* ARCH_TLS_HH */

--- a/arch/x64/arch.hh
+++ b/arch/x64/arch.hh
@@ -20,7 +20,6 @@ namespace arch {
 #define INSTR_SIZE_MIN 1
 #define ELF_IMAGE_START OSV_KERNEL_BASE
 
-#if CONF_lazy_stack
 inline void ensure_next_stack_page() {
     char i;
     asm volatile("movb -4096(%%rsp), %0" : "=r"(i));
@@ -31,7 +30,6 @@ inline void ensure_next_two_stack_pages() {
     asm volatile("movb -4096(%%rsp), %0" : "=r"(i));
     asm volatile("movb -8192(%%rsp), %0" : "=r"(i));
 }
-#endif
 
 inline void irq_disable()
 {

--- a/arch/x64/mmu.cc
+++ b/arch/x64/mmu.cc
@@ -15,9 +15,11 @@
 #include <osv/prio.hh>
 #include <osv/elf.hh>
 #include "exceptions.hh"
+#include "tls-switch.hh"
 
 void page_fault(exception_frame *ef)
 {
+    arch::tls_switch_on_exception_stack tls_switch;
     sched::fpu_lock fpu;
     SCOPE_LOCK(fpu);
     sched::exception_guard g;

--- a/arch/x64/msr.hh
+++ b/arch/x64/msr.hh
@@ -62,6 +62,7 @@ enum class msr : uint32_t {
     IA32_LSTAR = 0xc0000082,
     IA32_FMASK = 0xc0000084,
     IA32_FS_BASE = 0xc0000100,
+    IA32_GS_BASE = 0xc0000101,
 
     KVM_WALL_CLOCK = 0x11,
     KVM_SYSTEM_TIME = 0x12,

--- a/arch/x64/prctl.cc
+++ b/arch/x64/prctl.cc
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2014 Cloudius Systems, Ltd.
+ * Copyright (C) 2023 Waldemar Kozaczuk
+ *
+ * This work is open source software, licensed under the terms of the
+ * BSD license as described in the LICENSE file in the top-level directory.
+ */
+
+#include "arch.hh"
+#include "libc/libc.hh"
+
+#include <assert.h>
+#include <stdio.h>
+
+#include <osv/sched.hh>
+
+enum {
+    ARCH_SET_GS = 0x1001,
+    ARCH_SET_FS = 0x1002,
+    ARCH_GET_FS = 0x1003,
+    ARCH_GET_GS = 0x1004,
+};
+
+long arch_prctl(int code, unsigned long addr)
+{
+    switch (code) {
+    case ARCH_SET_FS:
+        sched::thread::current()->set_app_tcb(addr);
+        return 0;
+    case ARCH_GET_FS:
+        return sched::thread::current()->get_app_tcb();
+    }
+    return libc_error(EINVAL);
+}

--- a/arch/x64/syscall.S
+++ b/arch/x64/syscall.S
@@ -20,13 +20,14 @@ syscall_entry:
     # There is no ring transition and rflags are left unchanged.
     #
     # Unfortunately the mov instruction cannot be used to dereference an address
-    # on syscall stack pointed by address in TCB (%fs:16) - double memory dereference.
-    # Therefore we are forced to save caller stack address in a field in TCB.
-    movq %rsp, %fs:24 # syscall_caller_stack_pointer
+    # on syscall stack pointed by address in TCB (%gs:0) - double memory dereference.
+    # Therefore we are forced to save caller stack address in a field in a per-cpu
+    # structure referenced by GS.
+    movq %rsp, %gs:8 # syscall_caller_stack_pointer
     #
     # Switch stack to "tiny" syscall stack that should be large
     # enough to setup "large" syscall stack (only when first SYSCALL on this thread)
-    movq %fs:16, %rsp
+    movq %gs:0, %rsp
 
     # Skip large syscall stack setup if it has been already setup
     cmpq $0, (%rsp)  // Check if we are on tiny or large stack
@@ -56,7 +57,7 @@ syscall_entry:
     # This function does not take any arguments nor returns anything.
     # It ends up allocating large stack and storing its address in tcb
     callq setup_large_syscall_stack
-    movq %fs:16, %rsp  // Switch stack to large stack
+    movq %gs:0, %rsp  // Switch stack to large stack
     subq $128, %rsp    // Skip 128 bytes of large stack so that we can restore all registers saved above (16 pushes).
                        // Please note that these 128 bytes have been copied by setup_large_syscall_stack function
                        // so that we do not have to pop and then push same registers again.
@@ -95,7 +96,7 @@ syscall_entry:
     # We do this just so we can refer to it with CFI and help gdb's DWARF
     # stack unwinding. This saving not otherwise needed for correct operation
     # (we anyway restore it below by undoing all our modifications).
-    pushq %fs:24
+    pushq %gs:8
 
     .cfi_adjust_cfa_offset 8
     .cfi_rel_offset %rsp, 0
@@ -172,7 +173,7 @@ syscall_entry:
     popfq
 
     # Restore caller stack pointer
-    movq %fs:24, %rsp
+    movq %gs:8, %rsp
 
     # jump to rcx where the syscall instruction put rip
     # (sysret would leave rxc cloberred so we have nothing to do to restore it)

--- a/arch/x64/syscall.hh
+++ b/arch/x64/syscall.hh
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2023 Waldemar Kozaczuk
+ *
+ * This work is open source software, licensed under the terms of the
+ * BSD license as described in the LICENSE file in the top-level directory.
+ */
+
+#ifndef SYSCALL_HH_
+#define SYSCALL_HH_
+
+struct syscall_stack {
+    //
+    // This field, a per-thread stack for SYSCALL instruction, is  used in
+    // arch/x64/entry.S for %gs's offset.  We currently keep this field in
+    // the per-cpu structure to make it easier to access in assembly
+    // code through a known offset at %gs:0.
+    //
+    // The 8 bytes at the top of the syscall stack are used to identify if
+    // the stack is tiny (0) or large (1). So the size of the syscall stack is in
+    // reality smaller by 16 bytes from what was originally allocated because we need
+    // to make it 16-bytes aligned.
+    void* stack_top;
+    //
+    // This field is used to store the syscall caller stack pointer (value of RSP when
+    // SYSCALL was called) so that it can be restored when syscall completed.
+    // Same as above this field could be an ordinary thread-local variable.
+    void* caller_stack_pointer;
+};
+
+
+#endif

--- a/arch/x64/tls-switch.hh
+++ b/arch/x64/tls-switch.hh
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2023 Waldemar Kozaczuk
+ *
+ * This work is open source software, licensed under the terms of the
+ * BSD license as described in the LICENSE file in the top-level directory.
+ */
+
+#ifndef TLS_SWITCH_HH
+#define TLS_SWITCH_HH
+
+#include "arch.hh"
+#include "arch-tls.hh"
+#include <osv/barrier.hh>
+
+namespace sched {
+    extern bool fsgsbase_avail;
+}
+
+//Simple RAII utility classes that implement the logic to switch
+//fsbase to the kernel address and back to the app one
+namespace arch {
+
+inline void set_fsbase(u64 v)
+{
+    barrier();
+    if (sched::fsgsbase_avail) {
+        processor::wrfsbase(v);
+    } else {
+        processor::wrmsr(msr::IA32_FS_BASE, v);
+    }
+    barrier();
+}
+
+//Intended to be used in the interrupt, page fault and other
+//exceptions handlers where we know interrupts are disabled
+class tls_switch_on_exception_stack {
+    thread_control_block *_kernel_tcb;
+public:
+    tls_switch_on_exception_stack() {
+        asm volatile ( "movq %%gs:16, %0\n\t" : "=r"(_kernel_tcb));
+
+        if (_kernel_tcb->app_tcb) {
+            //Switch to kernel tcb if app tcb present and on app tcb
+            if (!_kernel_tcb->kernel_tcb_counter) {
+                set_fsbase(reinterpret_cast<u64>(_kernel_tcb->self));
+            }
+            _kernel_tcb->kernel_tcb_counter++;
+        }
+    }
+
+    ~tls_switch_on_exception_stack() {
+        if (_kernel_tcb->app_tcb) {
+            _kernel_tcb->kernel_tcb_counter--;
+            if (!_kernel_tcb->kernel_tcb_counter) {
+                //Restore app tcb
+                set_fsbase(reinterpret_cast<u64>(_kernel_tcb->app_tcb));
+            }
+        }
+    }
+};
+
+//Intended to be used in the syscall handler
+class tls_switch_on_syscall_stack {
+    thread_control_block *_kernel_tcb;
+public:
+    tls_switch_on_syscall_stack() {
+        asm volatile ( "movq %%gs:16, %0\n\t" : "=r"(_kernel_tcb));
+
+        if (_kernel_tcb->app_tcb) {
+            //Switch to kernel tcb if app tcb present and on app tcb
+            //We need to disable interrupts to make sure the switch of
+            //the fs register and update of the kernel_tcb_counter
+            //is atomic
+            arch::irq_disable();
+            if (!_kernel_tcb->kernel_tcb_counter) {
+                set_fsbase(reinterpret_cast<u64>(_kernel_tcb->self));
+            }
+            _kernel_tcb->kernel_tcb_counter++;
+            arch::irq_enable();
+        }
+    }
+
+    ~tls_switch_on_syscall_stack() {
+        if (_kernel_tcb->app_tcb) {
+            //We need to disable interrupts to make sure the switch of
+            //the fs register and update of the kernel_tcb_counter
+            //is atomic
+            arch::irq_disable();
+            _kernel_tcb->kernel_tcb_counter--;
+            if (!_kernel_tcb->kernel_tcb_counter) {
+                //Restore app tcb
+                set_fsbase(reinterpret_cast<u64>(_kernel_tcb->app_tcb));
+            }
+            arch::irq_enable();
+        }
+    }
+};
+
+//Intended to be used when on application thread that uses it own
+//TCB and makes calls to VDSO optimized functions
+class tls_switch_on_app_stack {
+    thread_control_block *_kernel_tcb;
+public:
+    tls_switch_on_app_stack() {
+        asm volatile ( "movq %%gs:16, %0\n\t" : "=r"(_kernel_tcb));
+
+        //Switch to kernel tcb if app tcb present and on app tcb
+        if (_kernel_tcb->app_tcb && !_kernel_tcb->kernel_tcb_counter) {
+            //To avoid page faults on user stack when interrupts are disabled
+            arch::ensure_next_stack_page();
+            arch::irq_disable();
+            set_fsbase(reinterpret_cast<u64>(_kernel_tcb->self));
+        }
+    }
+
+    ~tls_switch_on_app_stack() {
+        //Restore app tcb
+        if (_kernel_tcb->app_tcb && !_kernel_tcb->kernel_tcb_counter) {
+            set_fsbase(reinterpret_cast<u64>(_kernel_tcb->app_tcb));
+            arch::irq_enable();
+        }
+    }
+};
+
+}
+
+#endif

--- a/core/elf.cc
+++ b/core/elf.cc
@@ -536,7 +536,7 @@ void object::process_headers()
         }
     }
     if (!is_core() && is_statically_linked_executable()) {
-        abort("Statically linked executables are not supported yet!\n");
+        std::cout << "WARNING: Statically linked executables are only supported to limited extent!\n";
     }
     if (_is_dynamically_linked_executable && _tls_segment) {
         auto app_tls_size = get_aligned_tls_size();

--- a/core/sched.cc
+++ b/core/sched.cc
@@ -1221,6 +1221,7 @@ thread::~thread()
         delete[] _tls[i];
     }
     free_tcb();
+    free_syscall_stack();
     rcu_dispose(_detached_state.release());
 }
 

--- a/include/osv/sched.hh
+++ b/include/osv/sched.hh
@@ -805,6 +805,8 @@ private:
     std::shared_ptr<osv::application_runtime> _app_runtime;
 public:
     void destroy();
+    unsigned long get_app_tcb() { return _tcb->app_tcb; }
+    void set_app_tcb(unsigned long tcb) { _tcb->app_tcb = tcb; }
 private:
 #ifdef __aarch64__
     friend void ::destroy_current_cpu_terminating_thread();

--- a/include/osv/sched.hh
+++ b/include/osv/sched.hh
@@ -707,6 +707,7 @@ private:
     void init_stack();
     void setup_tcb();
     void free_tcb();
+    void free_syscall_stack();
     void complete() __attribute__((__noreturn__));
     template <class Action>
     inline void do_wake_with(Action action, unsigned allowed_initial_states_mask);

--- a/libc/vdso/vdso.c
+++ b/libc/vdso/vdso.c
@@ -3,22 +3,25 @@
 #include <sys/time.h>
 
 #ifdef __x86_64__
+time_t __vdso_kernel_time(time_t *tloc);
 __attribute__((__visibility__("default")))
 time_t __vdso_time(time_t *tloc)
 {
-    return time(tloc);
+    return __vdso_kernel_time(tloc);
 }
 
+int __vdso_kernel_gettimeofday(struct timeval *tv, struct timezone *tz);
 __attribute__((__visibility__("default")))
 int __vdso_gettimeofday(struct timeval *tv, struct timezone *tz)
 {
-    return gettimeofday(tv, tz);
+    return __vdso_kernel_gettimeofday(tv, tz);
 }
 
+int __vdso_kernel_clock_gettime(clockid_t clk_id, struct timespec *tp);
 __attribute__((__visibility__("default")))
 int __vdso_clock_gettime(clockid_t clk_id, struct timespec *tp)
 {
-    return clock_gettime(clk_id, tp);
+    return __vdso_kernel_clock_gettime(clk_id, tp);
 }
 #endif
 

--- a/libc/vdso/vdso_kernel.cc
+++ b/libc/vdso/vdso_kernel.cc
@@ -1,0 +1,24 @@
+#include <time.h>
+#include <sys/time.h>
+#include "tls-switch.hh"
+
+extern "C" __attribute__((__visibility__("default")))
+time_t __vdso_kernel_time(time_t *tloc)
+{
+    arch::tls_switch_on_app_stack _tls_switch;
+    return time(tloc);
+}
+
+extern "C" __attribute__((__visibility__("default")))
+int __vdso_kernel_gettimeofday(struct timeval *tv, struct timezone *tz)
+{
+    arch::tls_switch_on_app_stack _tls_switch;
+    return gettimeofday(tv, tz);
+}
+
+extern "C" __attribute__((__visibility__("default")))
+int __vdso_kernel_clock_gettime(clockid_t clk_id, struct timespec *tp)
+{
+    arch::tls_switch_on_app_stack _tls_switch;
+    return clock_gettime(clk_id, tp);
+}

--- a/linux.cc
+++ b/linux.cc
@@ -41,6 +41,7 @@
 #include <sys/random.h>
 #include <sys/vfs.h>
 #include <termios.h>
+#include "tls-switch.hh"
 
 #include <unordered_map>
 
@@ -482,6 +483,8 @@ static int tgkill(int tgid, int tid, int sig)
 #define __NR_sys_getdents64 __NR_getdents64
 extern "C" ssize_t sys_getdents64(int fd, void *dirp, size_t count);
 
+extern long arch_prctl(int code, unsigned long addr);
+
 #define __NR_sys_brk __NR_brk
 void *get_program_break();
 static long sys_brk(void *addr)
@@ -499,6 +502,11 @@ static long sys_brk(void *addr)
 
 OSV_LIBC_API long syscall(long number, ...)
 {
+#ifdef __x86_64__
+    // Switch TLS register if necessary
+    arch::tls_switch_on_syscall_stack tls_switch;
+#endif
+
     // Save FPU state and restore it at the end of this function
     sched::fpu_lock fpu;
     SCOPE_LOCK(fpu);
@@ -591,6 +599,9 @@ OSV_LIBC_API long syscall(long number, ...)
     SYSCALL4(clock_nanosleep, clockid_t, int, const struct timespec *, struct timespec *);
     SYSCALL4(mknodat, int, const char *, mode_t, dev_t);
     SYSCALL5(statx, int, const char *, int, unsigned int, struct statx *);
+#ifdef __x86_64__
+    SYSCALL2(arch_prctl, int, unsigned long);
+#endif
     }
 
     debug_always("syscall(): unimplemented system call %d\n", number);


### PR DESCRIPTION
This PR implements the `arch_prctl` syscall and makes other changes to support switching the FS register between the application and kernel TCB when running statically linked executables.

In essence, it makes it possible to launch simple statically linked executables like "Hello World" on OSv:
```
gcc -static -o hello-static-non-pie hello.c

./scripts/run.py -e /hello-static-non-pie
OSv v0.57.0-69-g053fc914
eth0: 192.168.122.15
Booted up in 193.02 ms
Cmdline: /hello-static-pie
WARNING: Statically linked executables are only supported to limited extent!
syscall(): unimplemented system call 218
syscall(): unimplemented system call 273
syscall(): unimplemented system call 334
syscall(): unimplemented system call 302
syscall(): unimplemented system call 89
syscall(): unimplemented system call 10
Hello from C code
```

Please note, that the code changes touch some critical places of the kernel functionality - context switching, syscall handling, exception handling, and VDSO implementation. 

As far as context switching goes, this patch adds only a handful of memory read/write operations that do not seem to affect it in any measurable way based on what the `misc-ctxsw.cc` indicates.

On the other hand, one could see the syscall handling cost go up by 6 - 10 ns (6-10% of the total cost based on what `misc-syscall-perf.cc` measures) when executing statically linked executables due to the fact we need to switch the `fsbase` and turn interrupts off and on twice. The good news is that the syscall handling does not seem to be affected in any significant way when running dynamically linked executables.

Finally, I did not measure the impact of changes to the exception handling (interrupts, page faults, etc) but I think it should be lower than syscall handling given we do not need to turn interrupts on and off. Also, we should not see any impact when running dynamically linked executables.

Depends on https://github.com/cloudius-systems/osv/pull/1254
Closes #1137