### PR TITLE
Add strace functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1045,6 +1045,7 @@ objects += core/mmio.o
 objects += core/kprintf.o
 objects += core/trace.o
 objects += core/trace-count.o
+objects += core/strace.o
 objects += core/callstack.o
 objects += core/poll.o
 objects += core/select.o

--- a/core/strace.cc
+++ b/core/strace.cc
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2023 Waldemar Kozaczuk
+ *
+ * This work is open source software, licensed under the terms of the
+ * BSD license as described in the LICENSE file in the top-level directory.
+ */
+
+#include <osv/strace.hh>
+#include <osv/sched.hh>
+#include "drivers/console.hh"
+
+trace_log* _trace_log = nullptr;
+
+static void print_trace(trace_record* tr) {
+    char msg[512];
+    auto tp = tr->tp;
+    float time = tr->time;
+    std::string thread_name = tr->thread_name.data();
+
+    auto len = snprintf(msg, 512, "%-15s %3d %12.9f %s(", thread_name.c_str(), tr->cpu, time / 1000000000, tp->name);
+    auto left = 512 - len;
+    auto m = msg + len;
+
+    auto fmt = tp->format;
+    //Copy all up to 1st '%'
+    while (*fmt && *fmt != '%' && left > 0) {
+       *m++ = *fmt++;
+       left--;
+       len++;
+    }
+
+    auto buf = tr->buffer;
+    auto sig = tr->tp->sig;
+    int written = 0;
+
+    if (tr->backtrace) {
+        buf += tracepoint_base::backtrace_len * sizeof(void*);
+    }
+
+    while (*sig != 0 && left > 2) {
+        //Copy fragment of tp->format up to next '%'
+        char _fmt[128];
+        int i = 0;
+        do {
+           _fmt[i++] = *fmt++;
+        } while (*fmt && *fmt != '%');
+        _fmt[i] = 0;
+
+        //Detect type of data, deserialize and print to the msg
+        switch (*sig++) {
+        case 'c':
+            buf = align_up(buf, object_serializer<char>().alignment());
+            written = snprintf(m, left, _fmt,  *reinterpret_cast<char*>(buf++));
+            break;
+        case 'b':
+        case 'B':
+            buf = align_up(buf, object_serializer<u8>().alignment());
+            written = snprintf(m, left, _fmt,  *buf++);
+            break;
+        case 'h':
+        case 'H':
+            buf = align_up(buf, object_serializer<u16>().alignment());
+            written = snprintf(m, left, _fmt,  *reinterpret_cast<u16*>(buf));
+            buf += sizeof(u16);
+            break;
+        case 'i':
+        case 'I':
+        case 'f':
+            buf = align_up(buf, object_serializer<u32>().alignment());
+            written = snprintf(m, left, _fmt,  *reinterpret_cast<u32*>(buf));
+            buf += sizeof(u32);
+            break;
+        case 'q':
+        case 'Q':
+        case 'd':
+        case 'P':
+            buf = align_up(buf, object_serializer<u64>().alignment());
+            written = snprintf(m, left, _fmt,  *reinterpret_cast<u64*>(buf));
+            buf += sizeof(u64);
+            break;
+        case '?':
+            written = snprintf(m, left, _fmt,  *reinterpret_cast<bool*>(buf++));
+            break;
+        case 'p': {
+            //string
+            char str[128];
+            auto slen = *buf++;
+            int i = 0;
+            while (slen-- && i < 127) {
+                str[i++] = *reinterpret_cast<char*>(buf++);
+            }
+            str[i] = 0;
+            written = snprintf(m, left, _fmt, str);
+            buf += (object_serializer<const char*>::max_len - i - 1);
+            break;
+        }
+        case '*': {
+            //binary data
+            buf = align_up(buf, sizeof(u16));
+            char str[256];
+            auto slen = *reinterpret_cast<u16*>(buf);
+            int i = 0;
+            buf += 2;
+            str[i++] = '{';
+            while (slen-- && (i + 4) < 255) {
+                auto byte = *reinterpret_cast<u8*>(buf++);
+                auto high = byte / 16;
+                str[i++] = high < 10 ? '0' + high : 'a' + (high - 10);
+                auto low = byte % 16;
+                str[i++] = low < 10 ? '0' + low : 'a' + (low - 10);
+                str[i++] = ' ';
+            }
+            str[i++] = '}';
+            str[i] = 0;
+            written = snprintf(m, left, _fmt, str);
+            break;
+        }
+        default:
+            assert(0 && "should not reach");
+        }
+
+        left -= written;
+        len += written;
+        m += written;
+    }
+    *m++ = ')';
+    *m++ = '\n';
+    console::write(msg, len + 2);
+}
+
+static sched::thread *strace = nullptr;
+
+void start_strace() {
+    _trace_log = new trace_log();
+    strace = sched::thread::make([] {
+        while (true) {
+            while (auto tr = _trace_log->read()) {
+                print_trace(tr);
+            }
+            sched::thread::sleep(std::chrono::microseconds(100));
+        }
+    }, sched::thread::attr().name("strace"));
+
+    strace->start();
+}

--- a/core/trace.cc
+++ b/core/trace.cc
@@ -27,6 +27,7 @@
 #include <osv/semaphore.hh>
 #include <osv/elf.hh>
 #include <cxxabi.h>
+#include "drivers/console.hh"
 
 using namespace std;
 
@@ -183,6 +184,14 @@ void enable_backtraces(bool backtrace) {
     global_backtrace_enabled = backtrace;
     for (auto& tp : tracepoint_base::tp_list) {
         tp.backtrace(backtrace);
+    }
+}
+
+void list_all_tracepoints() {
+    char buf[128];
+    for (auto& tp : tracepoint_base::tp_list) {
+        auto len = snprintf(buf, 128, "Tracepoint %s @ %p\n", tp.name, &tp);
+        console::write(buf, len);
     }
 }
 

--- a/include/osv/strace.hh
+++ b/include/osv/strace.hh
@@ -1,0 +1,15 @@
+/*
+ * Copyright (C) 2023 Waldemar Kozaczuk
+ *
+ * This work is open source software, licensed under the terms of the
+ * BSD license as described in the LICENSE file in the top-level directory.
+ */
+
+#ifndef STRACE_HH_
+#define STRACE_HH_
+
+#include <osv/trace.hh>
+
+void start_strace();
+
+#endif


### PR DESCRIPTION
This PR implements a simple strace-like mechanism described by https://github.com/cloudius-systems/osv/issues/1263.

In essence, it adds a new structure trace_log that holds a fixed size (64K)
an array of pointers to trace_records and acts as a ring buffer between threads
capturing active tracepoints (producers) and new thread strace (single consumer)
that prints them to the console. The write pointer - write_offset - is atomic that
rolls over every 64K and the strace thread follows it and tries to print
each trace (see print_trace).

The strace can be activated by adding "--strace" kernel command line argument.

```bash
./scripts/firecracker.py -e '--trace=vfs* --strace /hello'
OSv v0.57.0-75-gb7150705
init              0  0.001666500 vfs_mkdir("/dev" 0755)
init              0  0.001685758 vfs_mkdir_ret()
init              0  0.001698722 vfs_dup(0)
init              0  0.001699344 vfs_dup_ret(1)
init              0  0.001699520 vfs_dup(0)
init              0  0.001699644 vfs_dup_ret(2)
>init             0  0.006818073 vfs_mkdir("/rofs" 0755)
>init             0  0.006821609 vfs_mkdir_ret()
Booted up in 13.77 ms
Cmdline: /hello
>init             0  0.008424749 vfs_open("/usr/lib/fs" 0x0 00)
Hello from C code
>init             0  0.008429978 vfs_open_err(2)
>init             0  0.008435063 vfs_open("/etc/fstab" 0x0 00)
>init             0  0.008438018 vfs_open_ret(3)
>init             0  0.008531832 vfs_open("/dev" 0x0 00)
>init             0  0.008534193 vfs_open_ret(4)
>init             0  0.008534456 vfs_close(4)
>init             0  0.008537971 vfs_close_ret()
>init             0  0.008554489 vfs_open("/proc" 0x0 00)
>init             0  0.008556158 vfs_open_ret(4)
>init             0  0.008556252 vfs_close(4)
>init             0  0.008556763 vfs_close_ret()
>init             0  0.008583356 vfs_open("/sys" 0x0 00)
>init             0  0.008585037 vfs_open_ret(4)
>init             0  0.008585171 vfs_close(4)
>init             0  0.008585676 vfs_close_ret()
>init             0  0.008605026 vfs_open("/tmp" 0x0 00)
>init             0  0.008606443 vfs_open_ret(4)
>init             0  0.008606579 vfs_close(4)
>init             0  0.008607093 vfs_close_ret()
>init             0  0.008619345 vfs_close(3)
>init             0  0.008620198 vfs_close_ret()
>init             0  0.008634389 vfs_ioctl(1 0x5401)
>init             0  0.008634974 vfs_ioctl_ret()
>init             0  0.008635317 vfs_pwritev(1 0x200000501690 0x2 0xffffffff)
>init             0  0.008953023 vfs_pwritev_ret(0x16)
>init             0  0.008954858 vfs_pwritev(1 0x200000501660 0x2 0xffffffff)
>init             0  0.009209918 vfs_pwritev_ret(0x11)
>init             0  0.009235297 vfs_open("/init" 0x0 00)
>init             0  0.009237413 vfs_open_err(2)
>init             0  0.009259309 vfs_lstat(pathname=/hello, stat=0x2000004fe5e0)
>init             0  0.009265126 vfs_lstat_ret()
>init             0  0.009265804 vfs_open("/hello" 0x0 00)
>init             0  0.009267528 vfs_open_ret(3)
>init             0  0.009267772 vfs_close(3)
>init             0  0.009268057 vfs_close_ret()
/hello            0  0.009949201 vfs_pwritev(1 0x200000601e90 0x2 0xffffffff)
/hello            0  0.011528630 vfs_pwritev_ret(0x12)
```
This PR also adds another kernel command line parameter to list all available tracepoints.

Fixes https://github.com/cloudius-systems/osv/issues/1263