### PR TITLE
syscall: use GS register to store syscall stack address

### DIFF
--- a/arch/aarch64/arch-switch.hh
+++ b/arch/aarch64/arch-switch.hh
@@ -164,6 +164,10 @@ void thread::free_tcb()
     free(_tcb);
 }
 
+void thread::free_syscall_stack()
+{
+}
+
 void thread_main_c(thread* t)
 {
     arch::irq_enable();

--- a/arch/x64/arch-thread-state.hh
+++ b/arch/x64/arch-thread-state.hh
@@ -8,11 +8,16 @@
 #ifndef ARCH_THREAD_STATE_HH_
 #define ARCH_THREAD_STATE_HH_
 
+#include "syscall.hh"
+
 struct thread_state {
     char *exception_stack;
     void* rsp;
     void* rbp;
     void* rip;
+    // The descriptor of the syscall stack intended to be used when handling
+    // SYSCALL instruction on this specific thread
+    syscall_stack_descriptor _syscall_stack_descriptor;
 };
 
 #endif /* ARCH_THREAD_STATE_HH_ */

--- a/arch/x64/arch-tls.hh
+++ b/arch/x64/arch-tls.hh
@@ -13,23 +13,6 @@
 struct thread_control_block {
     thread_control_block* self;
     void* tls_base;
-    //
-    // This field, a per-thread stack for SYSCALL instruction, is  used in
-    // arch/x64/entry.S for %fs's offset.  We currently keep this field in the TCB
-    // to make it easier to access in assembly code through a known offset at %fs:16.
-    // But with more effort, we could have used an ordinary thread-local variable
-    // instead and avoided extending the TCB here.
-    //
-    // The 8 bytes at the top of the syscall stack are used to identify if
-    // the stack is tiny (0) or large (1). So the size of the syscall stack is in
-    // reality smaller by 16 bytes from what was originally allocated because we need
-    // to make it 16-bytes aligned.
-    void* syscall_stack_top;
-    //
-    // This field is used to store the syscall caller stack pointer (value of RSP when
-    // SYSCALL was called) so that it can be restored when syscall completed.
-    // Same as above this field could be an ordinary thread-local variable.
-    void* syscall_caller_stack_pointer;
 };
 
 #endif /* ARCH_TLS_HH */

--- a/arch/x64/msr.hh
+++ b/arch/x64/msr.hh
@@ -62,6 +62,7 @@ enum class msr : uint32_t {
     IA32_LSTAR = 0xc0000082,
     IA32_FMASK = 0xc0000084,
     IA32_FS_BASE = 0xc0000100,
+    IA32_GS_BASE = 0xc0000101,
 
     KVM_WALL_CLOCK = 0x11,
     KVM_SYSTEM_TIME = 0x12,

--- a/arch/x64/syscall.S
+++ b/arch/x64/syscall.S
@@ -19,14 +19,13 @@ syscall_entry:
     .cfi_register rflags, r11 # r11 took previous rflags value
     # There is no ring transition and rflags are left unchanged.
     #
-    # Unfortunately the mov instruction cannot be used to dereference an address
-    # on syscall stack pointed by address in TCB (%fs:16) - double memory dereference.
-    # Therefore we are forced to save caller stack address in a field in TCB.
-    movq %rsp, %fs:24 # syscall_caller_stack_pointer
+    # Save the caller stack address in the field "_caller_stack_pointer" of
+    # the per-cpu _current_syscall_stack_descriptor structure referenced by GS.
+    movq %rsp, %gs:8 # syscall_caller_stack_pointer
     #
     # Switch stack to "tiny" syscall stack that should be large
     # enough to setup "large" syscall stack (only when first SYSCALL on this thread)
-    movq %fs:16, %rsp
+    movq %gs:0, %rsp
 
     # Skip large syscall stack setup if it has been already setup
     cmpq $0, (%rsp)  // Check if we are on tiny or large stack
@@ -56,7 +55,7 @@ syscall_entry:
     # This function does not take any arguments nor returns anything.
     # It ends up allocating large stack and storing its address in tcb
     callq setup_large_syscall_stack
-    movq %fs:16, %rsp  // Switch stack to large stack
+    movq %gs:0, %rsp   // Switch stack to large stack
     subq $128, %rsp    // Skip 128 bytes of large stack so that we can restore all registers saved above (16 pushes).
                        // Please note that these 128 bytes have been copied by setup_large_syscall_stack function
                        // so that we do not have to pop and then push same registers again.
@@ -95,7 +94,7 @@ syscall_entry:
     # We do this just so we can refer to it with CFI and help gdb's DWARF
     # stack unwinding. This saving not otherwise needed for correct operation
     # (we anyway restore it below by undoing all our modifications).
-    pushq %fs:24
+    pushq %gs:8
 
     .cfi_adjust_cfa_offset 8
     .cfi_rel_offset %rsp, 0
@@ -172,7 +171,7 @@ syscall_entry:
     popfq
 
     # Restore caller stack pointer
-    movq %fs:24, %rsp
+    movq %gs:8, %rsp
 
     # jump to rcx where the syscall instruction put rip
     # (sysret would leave rxc cloberred so we have nothing to do to restore it)

--- a/arch/x64/syscall.hh
+++ b/arch/x64/syscall.hh
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2023 Waldemar Kozaczuk
+ *
+ * This work is open source software, licensed under the terms of the
+ * BSD license as described in the LICENSE file in the top-level directory.
+ */
+
+#ifndef SYSCALL_HH_
+#define SYSCALL_HH_
+
+//This structure "describes" a per-thread syscall stack used when handling
+//the SYSCALL instruction. There are 2 places it is used:
+// - thread_state - holds information about this thread syscall stack
+// - arch_cpu - holds information about this cpu CURRENT thread syscall stack
+struct syscall_stack_descriptor {
+    // The address of the top of the syscall stack.
+    //
+    // The 8 bytes at the top of the stack are used to identify if the stack
+    // is tiny (0) or large (1). Therefore the size of the syscall stack is
+    // in reality smaller by 16 bytes from what was originally allocated because we need
+    // to make it 16-bytes aligned.
+    void* stack_top;
+    //
+    // This field is used to store the syscall caller stack pointer (value of RSP when
+    // SYSCALL was called) so that it can be restored when syscall completes.
+    void* caller_stack_pointer;
+};
+
+
+#endif

--- a/core/sched.cc
+++ b/core/sched.cc
@@ -1221,6 +1221,7 @@ thread::~thread()
         delete[] _tls[i];
     }
     free_tcb();
+    free_syscall_stack();
     rcu_dispose(_detached_state.release());
 }
 

--- a/include/osv/sched.hh
+++ b/include/osv/sched.hh
@@ -707,6 +707,7 @@ private:
     void init_stack();
     void setup_tcb();
     void free_tcb();
+    void free_syscall_stack();
     void complete() __attribute__((__noreturn__));
     template <class Action>
     inline void do_wake_with(Action action, unsigned allowed_initial_states_mask);


### PR DESCRIPTION
The original syscall implementation utilized the TCB (Thread Control Block) to store the syscall stack address. On each context switch, the FS segment register would be reset to point to the thread-specific TCB where syscall handler would fetch its stack address.

In order to support statically linked executables that allocate and use their own TCB, OSv needs to be able to switch the FS register between the user and kernel address when handling syscalls. The syscall handler can no longer fetch its stack address from kernel TCB because the FS register points to the app TCB. In order to break this dependency, this patch changes all relevant code to move the syscall stack address and syscall caller stack pointer to the per-CPU memory area addressed by the GS segment register.

To that end, we define a new structure - `syscall_stack_descriptor` - that describes a syscall stack: its top and `SYSCALL` caller stack pointer. Then, we add a new field `_syscall_stack_descriptor` to the `thread_state` to store each thread-allocated syscall stack information.

In addition, we add a new field `_current_syscall_stack_descriptor` to the per-cpu structure `arch_cpu` and initialize each cpu GS register to point to it. Finally, the `thread::switch_to()` is changed to update the `stack_top` and `caller_stack_pointer` fields of `_current_syscall_stack_descriptor` on each context switch so that the syscall handler can fetch syscall stack address using GS segment.