### PR TITLE
Support executing dynamically-linked executables via Linux dynamic linker

### DIFF
--- a/core/app.cc
+++ b/core/app.cc
@@ -217,7 +217,7 @@ application::application(const std::string& command,
         throw launch_error("Failed to load object: " + command);
     }
 
-    if (_lib->is_statically_linked_executable()) {
+    if (_lib->is_statically_linked_executable() || _lib->is_linux_dl()) {
         //Augment auxiliary vector with extra entries like AT_PHDR, AT_ENTRY, etc
         //that are necessary by a static executable to bootstrap itself
         augment_auxv();
@@ -326,7 +326,7 @@ void application::main()
     elf::get_program()->init_library(_args.size(), _argv.get());
     sched::thread::current()->set_name(_command);
 
-    if (_lib->is_statically_linked_executable()) {
+    if (_lib->is_statically_linked_executable() || _lib->is_linux_dl()) {
         run_entry_point(_lib->entry_point(), _args.size(), _argv.get(), _argv_size);
     } else {
         if (_main) {

--- a/include/osv/elf.hh
+++ b/include/osv/elf.hh
@@ -303,6 +303,13 @@ struct Elf64_Sym {
     Elf64_Xword st_size; /* Size of object (e.g., common) */
 };
 
+#ifdef __x86_64__
+    constexpr const char *linux_dl_soname = "ld-linux-x86-64.so.2";
+#endif
+#ifdef __aarch64__
+    constexpr const char *linux_dl_soname = "ld-linux-aarch64.so.1";
+#endif
+
 class program;
 struct symbol_module;
 
@@ -405,6 +412,7 @@ public:
     // Absence of PT_INTERP is not enough to determine it is a statically linked executable
     // as shared libraries also as missing PT_INTERP.
     bool is_statically_linked_executable() { return !_is_dynamically_linked_executable && !is_shared_library(); }
+    bool is_linux_dl() { return this->soname() == linux_dl_soname; }
     ulong get_tls_size();
     ulong get_aligned_tls_size();
     void copy_local_tls(void* to_addr);


### PR DESCRIPTION
This PR enhances OSv to be able to launch dynamically linked executables(PIEs or non-PIEs) using the Linux dynamic linker - `ld-linux-x86-64.so.2` on x86_64 or `ld-linux-aarch64.so.1` on aarch64 like so:

```bash
./scripts/run.py -e '/lib64/ld-linux-x86-64.so.2 /hello'
```

The motivation is to allow running dynamically linked executables that depend on the libc symbols not implemented by the OSv kernel. In this case, the executables launched this way would interact only through system calls just like the statically linked ones do. Actually, my experiments so far seem to show that there are no extra changes needed beyond the same code enhancements to support statically linked executables.

When executing a dynamically linked executable, Linux reads the `PT_INTERP` segment to determine the program interpreter to launch with (typically `ld-linux-x86-64.so.2` on x86_64), probably unmaps the executable, loads the program interpreter, and delegates further execution by jumping to its entry point.

On OSv we could implement similar logic but even though not complicated it would involve some not in significant coding. So this patch takes a simpler approach where we assume a user would explicitly run the Linux program interpreter and pass the path of the executable as its parameter which by the way is a valid thing to do on Linux. To that end, we enhance OSv dynamic linker to process `ld-linux-x86-64.so.2` in the same way we process a statically linked executable (in reality `ld-linux-x86-64.so.2` is a statically linked shared library with non-zero entry point):

- do not relocate
- do not call INIT and FINI functions
- launch by jumping to the entry point

We detect if the given ELF is a Linux program interpreter by comparing its soname to the architecture-specific string - `ld-linux-x86-64.so.2` on x86_64 and` ld-linux-aarch64.so.1` on aarch64.

Fixes #1266