### PR TITLE
add syscall tracepoints

### DIFF
--- a/fs/vfs/main.cc
+++ b/fs/vfs/main.cc
@@ -1550,7 +1550,7 @@ char *getcwd(char *path, size_t size)
 }
 
 TRACEPOINT(trace_vfs_dup, "%d", int);
-TRACEPOINT(trace_vfs_dup_ret, "\"%s\"", int);
+TRACEPOINT(trace_vfs_dup_ret, "%d", int);
 TRACEPOINT(trace_vfs_dup_err, "%d", int);
 /*
  * Duplicate a file descriptor
@@ -1645,7 +1645,7 @@ int dup2(int oldfd, int newfd)
 #define SETFL (O_APPEND | O_ASYNC | O_DIRECT | O_NOATIME | O_NONBLOCK)
 
 TRACEPOINT(trace_vfs_fcntl, "%d %d 0x%x", int, int, int);
-TRACEPOINT(trace_vfs_fcntl_ret, "\"%s\"", int);
+TRACEPOINT(trace_vfs_fcntl_ret, "%d", int);
 TRACEPOINT(trace_vfs_fcntl_err, "%d", int);
 
 extern "C" OSV_LIBC_API


### PR DESCRIPTION
This patch adds tracepoints for the syscalls implemented in `linux.cc`. The new tracepoints capture both the arguments and return value. The format is somewhat similar to Linux strace where the return value is first like so:

TRACEPOINT(trace_syscall_open, "%d <= \"%s\" 0x%x", int, const char *, int);

Having both input and output captured by one single tracepoint instead of two makes it easier to observe things using the new OSv strace capability.

With strace enabled, one can observe what syscalls application makes like in this example:

```bash
./scripts/run.py -e '--strace --trace=syscall\* /httpserver.so' OSv v0.57.0-76-g76e30467
eth0: 192.168.122.15
Booted up in 134.48 ms
Cmdline: /httpserver.so
/httpserver.so    0  0.099321648 syscall_sys_sched_getaffinity(8 <= 0 8192 0x2000001fef10)
/httpserver.so    0  0.099337794 syscall_openat(-1 <= -100 "/sys/kernel/mm/transparent_hugepage/hpage_pmd_siz" 00 0)
/httpserver.so    0  0.103745244 syscall_rt_sigprocmask(0 <= 2 0 0x100000491e40 8)
/httpserver.so    0  0.104619488 syscall_sigaltstack(0 <= 0 0x200000200e80)
/httpserver.so    0  0.104619950 syscall_sigaltstack(0 <= 0x200000200e40 0)
/httpserver.so    0  0.104622744 syscall_rt_sigprocmask(0 <= 2 0x200000200e90 0 8)
/httpserver.so    0  0.104623578 syscall_gettid(45 <=)
>/httpserver.so   0  0.104778424 syscall_sigaltstack(0 <= 0 0x200027010ea8)
>/httpserver.so   0  0.104778871 syscall_sigaltstack(0 <= 0x200027010e68 0)
>/httpserver.so   0  0.104782909 syscall_rt_sigprocmask(0 <= 2 0x200027010eb8 0 8)
>/httpserver.so   0  0.104783155 syscall_gettid(46 <=)
>/httpserver.so   0  0.105711348 syscall_nanosleep(0 <= 0x200027010e70 0)
>/httpserver.so   0  0.105731443 syscall_getpid(2 <=)
>/httpserver.so   0  0.105732262 syscall_tgkill(-1 <= 2 45 23)
Go version: go1.18.1, listening on port 8000 ...
>/httpserver.so   0  0.105758384 syscall_nanosleep(0 <= 0x200027010e70 0)
>/httpserver.so   0  0.105783045 syscall_nanosleep(0 <= 0x200027010e70 0)
>/httpserver.so   0  0.105806418 syscall_nanosleep(0 <= 0x200027010e70 0)
>/httpserver.so   0  0.105830684 syscall_nanosleep(0 <= 0x200027010e70 0)
...
```

Please note this patch makes the kernel larger by 80K but its usefulness outweighs the former.

Fixes #1261