### PR TITLE
kernel: upgrade to C++ 17

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -292,7 +292,7 @@ endif
 #     returns option if file builds with -ffoo, empty otherwise
 compiler-flag = $(shell $(CXX) $(CFLAGS_WERROR) $1 -o /dev/null -c $3  > /dev/null 2>&1 && echo $2)
 
-compiler-specific := $(call compiler-flag, -std=gnu++11, -DHAVE_ATTR_COLD_LABEL, compiler/attr/cold-label.cc)
+compiler-specific := $(call compiler-flag, -std=$(conf_cxx_level), -DHAVE_ATTR_COLD_LABEL, compiler/attr/cold-label.cc)
 
 source-dialects = -D_GNU_SOURCE
 
@@ -356,7 +356,7 @@ gc-flags = $(gc-flags-$(conf_hide_symbols))
 
 gcc-opt-Og := $(call compiler-flag, -Og, -Og, compiler/empty.cc)
 
-CXXFLAGS = -std=gnu++11 $(COMMON) $(cxx-hide-flags)
+CXXFLAGS = -std=$(conf_cxx_level) $(COMMON) $(cxx-hide-flags)
 CFLAGS = -std=gnu99 $(COMMON)
 
 # should be limited to files under libc/ eventually

--- a/bsd/sys/net/if_llatbl.cc
+++ b/bsd/sys/net/if_llatbl.cc
@@ -208,7 +208,7 @@ struct lltable *
 lltable_init(struct ifnet *ifp, int af)
 {
 	struct lltable *llt;
-	register int i;
+	int i;
 
 	llt = (struct lltable *)malloc(sizeof(struct lltable));
 

--- a/bsd/sys/net/radix.cc
+++ b/bsd/sys/net/radix.cc
@@ -142,8 +142,8 @@ static int	rn_satisfies_leaf(char *trial, struct radix_node *leaf,
 static struct radix_node *
 rn_search(void *v_arg, struct radix_node *head)
 {
-	register struct radix_node *x;
-	register caddr_t v;
+	struct radix_node *x;
+	caddr_t v;
 
 	for (x = head, v = (caddr_t)v_arg; x->rn_bit >= 0;) {
 		if (x->rn_bmask & v[x->rn_offset])
@@ -161,8 +161,8 @@ rn_search(void *v_arg, struct radix_node *head)
 static struct radix_node *
 rn_search_m(void *v_arg, struct radix_node *head, void *m_arg)
 {
-	register struct radix_node *x;
-	register caddr_t v = (caddr_t)v_arg, m = (caddr_t)m_arg;
+	struct radix_node *x;
+	caddr_t v = (caddr_t)v_arg, m = (caddr_t)m_arg;
 
 	for (x = head; x->rn_bit >= 0;) {
 		if ((x->rn_bmask & m[x->rn_offset]) &&
@@ -177,8 +177,8 @@ rn_search_m(void *v_arg, struct radix_node *head, void *m_arg)
 int
 rn_refines(void *m_arg, void *n_arg)
 {
-	register caddr_t m = (caddr_t)m_arg, n = (caddr_t)n_arg;
-	register caddr_t lim, lim2 = lim = n + LEN(n);
+	caddr_t m = (caddr_t)m_arg, n = (caddr_t)n_arg;
+	caddr_t lim, lim2 = lim = n + LEN(n);
 	int longer = LEN(n++) - LEN(m++);
 	int masks_are_equal = 1;
 
@@ -203,7 +203,7 @@ rn_refines(void *m_arg, void *n_arg)
 struct radix_node *
 rn_lookup(void *v_arg, void *m_arg, struct radix_node_head *head)
 {
-	register struct radix_node *x;
+	struct radix_node *x;
 	caddr_t netmask = 0;
 
 	if (m_arg) {
@@ -223,7 +223,7 @@ rn_lookup(void *v_arg, void *m_arg, struct radix_node_head *head)
 static int
 rn_satisfies_leaf(char *trial, struct radix_node *leaf, int skip)
 {
-	register char *cp = trial, *cp2 = leaf->rn_key, *cp3 = leaf->rn_mask;
+	char *cp = trial, *cp2 = leaf->rn_key, *cp3 = leaf->rn_mask;
 	char *cplim;
 	int length = bsd_min(LEN(cp), LEN(cp2));
 
@@ -242,12 +242,12 @@ struct radix_node *
 rn_match(void *v_arg, struct radix_node_head *head)
 {
 	caddr_t v = (caddr_t)v_arg;
-	register struct radix_node *t = head->rnh_treetop, *x;
-	register caddr_t cp = v, cp2;
+	struct radix_node *t = head->rnh_treetop, *x;
+	caddr_t cp = v, cp2;
 	caddr_t cplim;
 	struct radix_node *saved_t, *top = t;
 	int off = t->rn_offset, vlen = LEN(cp), matched_off;
-	register int test, b, rn_bit;
+	int test, b, rn_bit;
 
 	/*
 	 * Open code rn_search(v, top) to avoid overhead of extra
@@ -312,7 +312,7 @@ on1:
 	t = saved_t;
 	/* start searching up the tree */
 	do {
-		register struct radix_mask *m;
+		struct radix_mask *m;
 		t = t->rn_parent;
 		m = t->rn_mklist;
 		/*
@@ -360,7 +360,7 @@ int	rn_debug =  1;
 static struct radix_node *
 rn_newpair(void *v, int b, struct radix_node nodes[2])
 {
-	register struct radix_node *tt = nodes, *t = tt + 1;
+	struct radix_node *tt = nodes, *t = tt + 1;
 	t->rn_bit = b;
 	t->rn_bmask = 0x80 >> (b & 7);
 	t->rn_left = tt;
@@ -393,16 +393,16 @@ rn_insert(void *v_arg, struct radix_node_head *head, int *dupentry, struct radix
 	caddr_t v = (caddr_t)v_arg;
 	struct radix_node *top = head->rnh_treetop;
 	int head_off = top->rn_offset, vlen = LEN(v);
-	register struct radix_node *t = rn_search(v_arg, top);
-	register caddr_t cp = v + head_off;
-	register int b;
+	struct radix_node *t = rn_search(v_arg, top);
+	caddr_t cp = v + head_off;
+	int b;
 	struct radix_node *tt;
     	/*
 	 * Find first bit at which v and t->rn_key differ
 	 */
     {
-	register caddr_t cp2 = t->rn_key + head_off;
-	register int cmp_res;
+	caddr_t cp2 = t->rn_key + head_off;
+	int cmp_res;
 	caddr_t cplim = v + vlen;
 
 	while (cp < cplim)
@@ -417,7 +417,7 @@ on1:
 		cmp_res >>= 1;
     }
     {
-	register struct radix_node *p, *x = top;
+	struct radix_node *p, *x = top;
 	cp = v;
 	do {
 		p = x;
@@ -457,9 +457,9 @@ struct radix_node *
 rn_addmask(void *n_arg, int search, int skip)
 {
 	caddr_t netmask = (caddr_t)n_arg;
-	register struct radix_node *x;
-	register caddr_t cp, cplim;
-	register int b = 0, mlen, j;
+	struct radix_node *x;
+	caddr_t cp, cplim;
+	int b = 0, mlen, j;
 	int maskduplicated, m0, isnormal;
 	struct radix_node *saved_x;
 	static int last_zeroed = 0;
@@ -534,7 +534,7 @@ rn_addmask(void *n_arg, int search, int skip)
 static int	/* XXX: arbitrary ordering for non-contiguous masks */
 rn_lexobetter(void *m_arg, void *n_arg)
 {
-	register u_char *mp = (u_char *)m_arg, *np = (u_char *)n_arg, *lim;
+	u_char *mp = (u_char *)m_arg, *np = (u_char *)n_arg, *lim;
 
 	if (LEN(mp) > LEN(np))
 		return 1;  /* not really, but need to check longer one first */
@@ -548,7 +548,7 @@ rn_lexobetter(void *m_arg, void *n_arg)
 static struct radix_mask *
 rn_new_radix_mask(struct radix_node *tt, struct radix_mask *next)
 {
-	register struct radix_mask *m;
+	struct radix_mask *m;
 
 	MKGet(m);
 	if (m == 0) {
@@ -572,7 +572,7 @@ rn_addroute(void *v_arg, void *n_arg, struct radix_node_head *head,
         struct radix_node treenodes[2])
 {
 	caddr_t v = (caddr_t)v_arg, netmask = (caddr_t)n_arg;
-	register struct radix_node *t, *x = 0, *tt;
+	struct radix_node *t, *x = 0, *tt;
 	struct radix_node *saved_tt, *top = head->rnh_treetop;
 	short b = 0, b_leaf = 0;
 	int keyduplicated;
@@ -743,7 +743,7 @@ on2:
 struct radix_node *
 rn_delete(void *v_arg, void *netmask_arg, struct radix_node_head *head)
 {
-	register struct radix_node *t, *p, *x, *tt;
+	struct radix_node *t, *p, *x, *tt;
 	struct radix_mask *m, *saved_m, **mp;
 	struct radix_node *dupedkey, *saved_tt, *top;
 	caddr_t v, netmask;
@@ -934,7 +934,7 @@ rn_walktree_from(struct radix_node_head *h, void *a, void *m, walktree_f_t *f, v
 	struct radix_node *base, *next;
 	u_char *xa = (u_char *)a;
 	u_char *xm = (u_char *)m;
-	register struct radix_node *rn, *last = 0 /* shut up gcc */;
+	struct radix_node *rn, *last = 0 /* shut up gcc */;
 	int stopping = 0;
 	int lastb;
 
@@ -1035,7 +1035,7 @@ rn_walktree(struct radix_node_head *h, walktree_f_t *f, void *w)
 {
 	int error;
 	struct radix_node *base, *next;
-	register struct radix_node *rn = h->rnh_treetop;
+	struct radix_node *rn = h->rnh_treetop;
 	/*
 	 * This gets complicated because we may delete the node
 	 * while applying the function f to it, so we need to calculate
@@ -1080,8 +1080,8 @@ rn_walktree(struct radix_node_head *h, walktree_f_t *f, void *w)
 int
 rn_inithead(void **head, int off)
 {
-	register struct radix_node_head *rnh;
-	register struct radix_node *t, *tt, *ttt;
+	struct radix_node_head *rnh;
+	struct radix_node *t, *tt, *ttt;
 	if (*head)
 		return (1);
 	R_Zalloc(rnh, struct radix_node_head *, sizeof (*rnh));

--- a/bsd/sys/net/route.cc
+++ b/bsd/sys/net/route.cc
@@ -644,7 +644,7 @@ struct bsd_ifaddr *
 ifa_ifwithroute_fib(int flags, struct bsd_sockaddr *dst, struct bsd_sockaddr *gateway,
 				u_int fibnum)
 {
-	register struct bsd_ifaddr *ifa;
+	struct bsd_ifaddr *ifa;
 	int not_found = 0;
 
 	if ((flags & RTF_GATEWAY) == 0) {
@@ -909,7 +909,7 @@ rn_mpath_update(int req, struct rt_addrinfo *info,
 	 * a matching RTAX_GATEWAY.
 	 */
 	struct rtentry *rt, *rto = NULL;
-	register struct radix_node *rn;
+	struct radix_node *rn;
 	int error = 0;
 
 	rn = rnh->rnh_matchaddr(dst, rnh);
@@ -1010,9 +1010,9 @@ rtrequest1_fib(int req, struct rt_addrinfo *info, struct rtentry **ret_nrt,
 				u_int fibnum)
 {
 	int error = 0, needlock = 0;
-	register struct rtentry *rt;
-	register struct radix_node *rn;
-	register struct radix_node_head *rnh;
+	struct rtentry *rt;
+	struct radix_node *rn;
+	struct radix_node_head *rnh;
 	struct bsd_ifaddr *ifa;
 	struct bsd_sockaddr *ndst;
 	struct bsd_sockaddr_storage mdst;
@@ -1262,9 +1262,9 @@ rt_setgate(struct rtentry *rt, struct bsd_sockaddr *dst, struct bsd_sockaddr *ga
 void
 rt_maskedcopy(struct bsd_sockaddr *src, struct bsd_sockaddr *dst, struct bsd_sockaddr *netmask)
 {
-	register u_char *cp1 = (u_char *)src;
-	register u_char *cp2 = (u_char *)dst;
-	register u_char *cp3 = (u_char *)netmask;
+	u_char *cp1 = (u_char *)src;
+	u_char *cp2 = (u_char *)dst;
+	u_char *cp3 = (u_char *)netmask;
 	u_char *cplim = cp2 + *cp3;
 	u_char *cplim2 = cp2 + *cp1;
 

--- a/bsd/sys/netinet/in.cc
+++ b/bsd/sys/netinet/in.cc
@@ -97,8 +97,8 @@ VNET_DECLARE(struct arpstat, arpstat);  /* ARP statistics, see if_arp.h */
 int
 in_localaddr(struct in_addr in)
 {
-	register u_long i = ntohl(in.s_addr);
-	register struct in_ifaddr *ia;
+	u_long i = ntohl(in.s_addr);
+	struct in_ifaddr *ia;
 
 	IN_IFADDR_RLOCK();
 	TAILQ_FOREACH(ia, &V_in_ifaddrhead, ia_link) {
@@ -139,8 +139,8 @@ in_localip(struct in_addr in)
 int
 in_canforward(struct in_addr in)
 {
-	register u_long i = ntohl(in.s_addr);
-	register u_long net;
+	u_long i = ntohl(in.s_addr);
+	u_long net;
 
 	if (IN_EXPERIMENTAL(i) || IN_MULTICAST(i) || IN_LINKLOCAL(i))
 		return (0);
@@ -158,8 +158,8 @@ in_canforward(struct in_addr in)
 static void
 in_socktrim(struct bsd_sockaddr_in *ap)
 {
-    register char *cplim = (char *) &ap->sin_addr;
-    register char *cp = (char *) (&ap->sin_addr + 1);
+    char *cplim = (char *) &ap->sin_addr;
+    char *cp = (char *) (&ap->sin_addr + 1);
 
     ap->sin_len = 0;
     while (--cp >= cplim)
@@ -214,9 +214,9 @@ int
 in_control(struct socket *so, u_long cmd, caddr_t data, struct ifnet *ifp,
     struct thread *td)
 {
-	register struct bsd_ifreq *ifr = (struct bsd_ifreq *)data;
-	register struct in_ifaddr *ia, *iap;
-	register struct bsd_ifaddr *ifa;
+	struct bsd_ifreq *ifr = (struct bsd_ifreq *)data;
+	struct in_ifaddr *ia, *iap;
+	struct bsd_ifaddr *ifa;
 	struct in_addr allhosts_addr;
 	struct in_addr dst;
 	struct in_ifinfo *ii;
@@ -836,7 +836,7 @@ static int
 in_ifinit(struct ifnet *ifp, struct in_ifaddr *ia, struct bsd_sockaddr_in *sin,
     int scrub)
 {
-	register u_long i = ntohl(sin->sin_addr.s_addr);
+	u_long i = ntohl(sin->sin_addr.s_addr);
 	struct bsd_sockaddr_in oldaddr;
 	int s = splimp(), flags = RTF_UP, error = 0;
 
@@ -1224,7 +1224,7 @@ in_scrubprefix(struct in_ifaddr *target, u_int flags)
 int
 in_broadcast(struct in_addr in, struct ifnet *ifp)
 {
-	register struct bsd_ifaddr *ifa;
+	struct bsd_ifaddr *ifa;
 	u_long t;
 
 	if (in.s_addr == INADDR_BROADCAST ||

--- a/bsd/sys/netinet/ip_icmp.cc
+++ b/bsd/sys/netinet/ip_icmp.cc
@@ -203,10 +203,10 @@ kmod_icmpstat_inc(int statnum)
 void
 icmp_error(struct mbuf *n, int type, int code, uint32_t dest, int mtu)
 {
-	register struct ip *oip = mtod(n, struct ip *), *nip;
-	register unsigned oiphlen = oip->ip_hl << 2;
-	register struct icmp *icp;
-	register struct mbuf *m;
+	struct ip *oip = mtod(n, struct ip *), *nip;
+	unsigned oiphlen = oip->ip_hl << 2;
+	struct icmp *icp;
+	struct mbuf *m;
 	unsigned icmplen, icmpelen, nlen;
 
 	KASSERT((u_int)type <= ICMP_MAXTYPE, ("%s: illegal ICMP type", __func__));
@@ -800,7 +800,7 @@ match:
 	ip->ip_ttl = V_ip_defttl;
 
 	if (optlen > 0) {
-		register u_char *cp;
+		u_char *cp;
 		int opt, cnt;
 		u_int len;
 
@@ -887,9 +887,9 @@ done:
 static void
 icmp_send(struct mbuf *m, struct mbuf *opts)
 {
-	register struct ip *ip = mtod(m, struct ip *);
-	register int hlen;
-	register struct icmp *icp;
+	struct ip *ip = mtod(m, struct ip *);
+	int hlen;
+	struct icmp *icp;
 
 	hlen = ip->ip_hl << 2;
 	m->m_hdr.mh_data += hlen;

--- a/bsd/sys/netinet/ip_output.cc
+++ b/bsd/sys/netinet/ip_output.cc
@@ -1255,7 +1255,7 @@ static void
 ip_mloopback(struct ifnet *ifp, struct mbuf *m, struct bsd_sockaddr_in *dst,
     int hlen)
 {
-	register struct ip *ip;
+	struct ip *ip;
 	struct mbuf *copym;
 
 	/*

--- a/conf/base.mk
+++ b/conf/base.mk
@@ -13,6 +13,7 @@ conf-DEBUG_BUILD=0
 conf-debug_elf=0
 conf_hide_symbols=0
 conf_linker_extra_options=
+conf_cxx_level=gnu++11
 
 conf-lazy_stack=0
 conf-lazy_stack_invariant=0

--- a/core/mmu.cc
+++ b/core/mmu.cc
@@ -59,7 +59,7 @@ namespace mmu {
 #endif
 
 struct vma_range_compare {
-    bool operator()(const vma_range& a, const vma_range& b) {
+    bool operator()(const vma_range& a, const vma_range& b) const {
         return a.start() < b.start();
     }
 };
@@ -70,7 +70,7 @@ std::set<vma_range, vma_range_compare> vma_range_set;
 rwlock_t vma_range_set_mutex;
 
 struct linear_vma_compare {
-    bool operator()(const linear_vma* a, const linear_vma* b) {
+    bool operator()(const linear_vma* a, const linear_vma* b) const {
         return a->_virt_addr < b->_virt_addr;
     }
 };

--- a/core/net_trace.cc
+++ b/core/net_trace.cc
@@ -10,7 +10,13 @@
 #include <vector>
 #include <iterator>
 
-class mbuf_iterator : public std::iterator<std::input_iterator_tag, char, size_t> {
+class mbuf_iterator {
+public:
+    using iterator_category = std::input_iterator_tag;
+    using value_type = char;
+    using difference_type = size_t;
+    using pointer = char*;
+    using reference = char&;
 private:
     struct mbuf* _m;
     size_t _pos;
@@ -73,7 +79,7 @@ public:
         return !(*this == other);
     }
 
-    friend size_t std::distance<mbuf_iterator>(mbuf_iterator, mbuf_iterator);
+    friend constexpr size_t std::distance<mbuf_iterator>(mbuf_iterator, mbuf_iterator);
 };
 
 namespace std {

--- a/include/lockfree/unordered_ring_mpsc.hh
+++ b/include/lockfree/unordered_ring_mpsc.hh
@@ -30,7 +30,13 @@ private:
 public:
     using ring_mpsc_t = unordered_ring_mpsc<T,MaxSizePerCpu>;
 
-    class draining_iterator : public std::iterator<std::input_iterator_tag, T> {
+    class draining_iterator {
+    public:
+        using iterator_category = std::input_iterator_tag;
+        using value_type = T;
+        using difference_type = T;
+        using pointer = T*;
+        using reference = T&;
     private:
         unsigned _idx;
         ring_mpsc_t& _ring;

--- a/include/osv/bitset-iter.hh
+++ b/include/osv/bitset-iter.hh
@@ -64,8 +64,14 @@ static inline size_t get_last_set(const std::bitset<N>& bitset)
 }
 
 template<size_t N>
-class set_iterator : public std::iterator<std::input_iterator_tag, int>
+class set_iterator
 {
+public:
+    using iterator_category = std::input_iterator_tag;
+    using value_type = int;
+    using difference_type = int;
+    using pointer = int*;
+    using reference = int&;
 private:
     void advance()
     {

--- a/include/osv/callstack.hh
+++ b/include/osv/callstack.hh
@@ -60,7 +60,7 @@ public:
 private:
     // Compares two traces for the histogram (most hits first)
     struct histogram_compare {
-        bool operator()(trace* a, trace* b);
+        bool operator()(trace* a, trace* b) const;
     };
 private:
     // Callback from tracepoint_base::probe
@@ -87,7 +87,7 @@ private:
     // per-cpu hash table
     dynamic_percpu<std::unique_ptr<table_type>> _table;
     // global pool of free trace objects
-    std::atomic<void*> _free_traces;
+    std::atomic<uintptr_t> _free_traces;
     // attached tracepoints
     std::vector<tracepoint_base*> _attached;
     friend bool operator==(const trace& a, const trace& b);

--- a/modules/golang/Makefile
+++ b/modules/golang/Makefile
@@ -2,7 +2,7 @@ include ../common.gmk
 
 module_out := $(out)/modules/golang
 
-CXXFLAGS  = -g -rdynamic -Wall -std=c++11 -fPIC $(COMMON)
+CXXFLAGS  = -g -rdynamic -Wall -std=$(conf_cxx_level) -fPIC $(COMMON)
 
 # the build target executable:
 TARGET = go

--- a/modules/httpserver-api/Makefile
+++ b/modules/httpserver-api/Makefile
@@ -7,7 +7,7 @@ INCLUDES += -I. -I $(src)/libc/internal
 # compiler flags:
 #  -g    adds debugging information to the executable file
 #  -Wall turns on most, but not all, compiler warnings
-CXXFLAGS  = -g -Wall -std=c++11 -fPIC $(COMMON) -O2
+CXXFLAGS  = -g -Wall -std=$(conf_cxx_level) -fPIC $(COMMON) -O2
 
 boost-libs := -lboost_system -lboost_filesystem
 

--- a/modules/httpserver-monitoring-api/Makefile
+++ b/modules/httpserver-monitoring-api/Makefile
@@ -7,9 +7,9 @@ INCLUDES += -I. -I../httpserver-api -I $(src)/libc/internal
 # compiler flags:
 #  -g    adds debugging information to the executable file
 #  -Wall turns on most, but not all, compiler warnings
-CXXFLAGS  = -g -Wall -std=c++11 -fPIC $(COMMON) -O2 -DMONITORING -fvisibility=hidden
+CXXFLAGS  = -g -Wall -std=$(conf_cxx_level) -fPIC $(COMMON) -O2 -DMONITORING -fvisibility=hidden
 #TODO: Figure out why lto breaks exception handling
-#CXXFLAGS  = -g -Wall -std=c++11 -fPIC $(COMMON) -O2 -DMONITORING -fvisibility=hidden -flto
+#CXXFLAGS  = -g -Wall -std=$(conf_cxx_level) -fPIC $(COMMON) -O2 -DMONITORING -fvisibility=hidden -flto
 #LDFLAGS = -flto
 
 boost-libs := -lboost_system -lboost_filesystem

--- a/modules/sysinfo/Makefile
+++ b/modules/sysinfo/Makefile
@@ -1,6 +1,6 @@
 INCLUDES = -I../../include
 COMMON_FLAGS = -g -Wall -fPIC $(INCLUDES) -O2
-CXXFLAGS = -std=c++11 $(COMMON_FLAGS)
+CXXFLAGS = -std=$(conf_cxx_level) $(COMMON_FLAGS)
 
 .PHONY: module
 module: sysinfo.so

--- a/modules/tests/Makefile
+++ b/modules/tests/Makefile
@@ -15,7 +15,7 @@ COMMON += -g -O2 -fPIC -DBOOST_TEST_DYN_LINK \
 
 LIBS = $(libgcc_s_dir)/libgcc_s.so.1
 
-CXXFLAGS = -std=gnu++11 $(COMMON)
+CXXFLAGS = -std=$(conf_cxx_level) $(COMMON)
 CFLAGS = -std=gnu99 $(COMMON)
 
 # The following are rules for making a .so from .c or .cc. We could have


### PR DESCRIPTION
This patch makes necessary changes to the relevant source files to make it possible to build kernel at C++ 17 level. This will allow us to take advantage of new features available in C++ 17 standard.

The following changes are part of this PR:

- remove obsolete `register` keyword (mostly under `bsd/` part of the tree)

- add `const` specifier to the comparison operator definitions where necessary

- replace deprecated `std::iterator` usage with explicit definitions of traits (for example `iterator_category`, `value_type`, and 3 others) (for some background info read this - https://www.fluentcpp.com/2018/05/08/std-iterator-deprecated/)

- add `constexpr` to the `friend` declaration of std::distance<mbuf_iterator>

- make tests, httpserver-api, and some other modules compilable with non-C++ 11 level 
Please note, that all the unit tests and modules implemented in C++ are not subject to this change. On that note, the unit tests are passing.

An example of how to build with C++ 17:
```
./scripts/build image=httpserver-api fs=rofs.fg -j$(nproc) conf_cxx_level=gnu++17
```

Finally, this PR does not change the default C++ level which remains at 11, until we permanently decide to change in the future. 