### PR TITLE
vfs futimens: prepend path with a mount point part

### DIFF
--- a/fs/vfs/vfs_syscalls.cc
+++ b/fs/vfs/vfs_syscalls.cc
@@ -1415,7 +1415,7 @@ sys_futimens(int fd, const struct timespec times[2])
     if (!fp->f_dentry)
         return EBADF;
 
-    std::string pathname = fp->f_dentry->d_path;
+    std::string pathname = std::string(fp->f_dentry->d_mount->m_path) + fp->f_dentry->d_path;
     auto error = sys_utimensat(AT_FDCWD, pathname.c_str(), times, 0, false);
     return error;
 }


### PR DESCRIPTION
When mounting an optional filesystem using the option `--mount-fs`, it is important in the VFS layer to prepend the final path with a mount point path. 

This commit fixes it in `futimens()` implementation.