### PR TITLE
vfs: make headers export C API when included in C++ if needed

### DIFF
--- a/include/osv/dentry.h
+++ b/include/osv/dentry.h
@@ -26,7 +26,7 @@ struct dentry {
 	LIST_ENTRY(dentry) d_children_link;
 };
 
-#ifdef __cplusplus
+#if defined(__cplusplus) && !defined(USE_C_INTERFACE)
 
 #include <boost/intrusive_ptr.hpp>
 

--- a/include/osv/file.h
+++ b/include/osv/file.h
@@ -42,7 +42,7 @@
 #include <bsd/sys/sys/queue.h>
 #include <osv/dentry.h>
 
-#ifdef __cplusplus
+#if defined(__cplusplus) && !defined(USE_C_INTERFACE)
 
 #include <memory>
 #include <vector>
@@ -71,7 +71,7 @@ struct pollreq;
 
 #define FDMAX       (0x4000)
 
-#ifdef __cplusplus
+#if defined(__cplusplus) && !defined(USE_C_INTERFACE)
 
 namespace mmu {
 class file_vma;

--- a/include/osv/mount.h
+++ b/include/osv/mount.h
@@ -148,7 +148,7 @@ void	 release_mp_dentries(struct mount *mp);
 
 __END_DECLS
 
-#ifdef __cplusplus
+#if defined(__cplusplus) && !defined(USE_C_INTERFACE)
 
 #include <vector>
 #include <string>

--- a/include/osv/mutex.h
+++ b/include/osv/mutex.h
@@ -19,7 +19,7 @@
 
 #define LOCKFREE_MUTEX_ALIGN void*
 #define LOCKFREE_MUTEX_SIZE 40
-#ifdef __cplusplus
+#if defined(__cplusplus) && !defined(USE_C_INTERFACE)
 /** C++ **/
 #include <lockfree/mutex.hh>
 typedef lockfree::mutex mutex;
@@ -61,7 +61,7 @@ static inline void mutex_unlock(mutex_t *m) { lockfree_mutex_unlock(m); }
 static inline bool mutex_trylock(mutex_t *m) { return lockfree_mutex_try_lock(m); }
 static inline bool mutex_owned(mutex_t *m) { return lockfree_mutex_owned(m); }
 #endif
-#ifndef __cplusplus
+#if !defined(__cplusplus) || defined(USE_C_INTERFACE)
 static inline void mutex_init(mutex_t* m) { memset(m, 0, sizeof(mutex_t)); }
 static inline void mutex_destroy(mutex_t* m) { }
 #else
@@ -80,7 +80,7 @@ static inline void mutex_destroy(mutex_t* m) { }
 #endif
 #define MUTEX_INITIALIZER   {}
 
-#ifdef __cplusplus
+#if defined(__cplusplus) && !defined(USE_C_INTERFACE)
 #include <mutex>
 #include <cstdlib>
 

--- a/include/osv/uio.h
+++ b/include/osv/uio.h
@@ -61,7 +61,7 @@ int	uiomove(void *cp, size_t n, struct uio *uio);
 
 __END_DECLS
 
-#ifdef __cplusplus
+#if defined(__cplusplus) && !defined(USE_C_INTERFACE)
 
 template <typename F>
 static inline void linearize_uio_write(struct uio *uio, int ioflag, F f)

--- a/include/osv/waitqueue.hh
+++ b/include/osv/waitqueue.hh
@@ -11,7 +11,7 @@
 // A waitqueue is similar to a condition variable, but relies on the
 // user supplied mutex for internal locking.
 
-#ifdef __cplusplus
+#if defined(__cplusplus) && !defined(USE_C_INTERFACE)
 
 
 #include <sys/cdefs.h>


### PR DESCRIPTION
The upcoming C++ implementation of the ext4 filesystem as a module and shared library needs some VFS headers which cannot be included as C++ because it would pull all kinds of other C++ headers (boost, etc) that we do not need and want in this ext4 implementation.

The headers included by the C++ compiler are preprocessed with the __cplusplus macro which enables them as C++. In order to make them "include-able" as C in C++ source code, we add an extra macro `USE_C_INTERFACE` which when defined in C++ code would force the relevant headers to expose its C API.

This example illustrates how this can be accomplished:
```
#define USE_C_INTERFACE 1
#include <osv/device.h>
#include <osv/bio.h>
#include <osv/prex.h>
#include <osv/vnode.h>
#include <osv/mount.h>
#include <osv/debug.h>
```