### PR TITLE
block cache: use correct data type for block number

### DIFF
--- a/include/osv/buf.h
+++ b/include/osv/buf.h
@@ -43,7 +43,7 @@
 struct buf: boost::intrusive::list_base_hook<> {
 	int		b_flags;	/* see defines below */
 	struct device	*b_dev;		/* device */
-	int		b_blkno;	/* block # on device */
+	off_t		b_blkno;	/* block # on device */
 	mutex_t		b_lock;		/* lock for access */
 	void		*b_data;	/* pointer to data buffer */
 };


### PR DESCRIPTION
This issue was discovered by Jan Braunwarth when implementing the NVMe driver and full credit goes to him.

The `b_blkno` field of the `buf` struct uses 4-bytes `int` type and may cause overflow when block cache is used by `bdev_read()` and `bdev_write()` in devfs. To correct this, we changed the type to `off_t`.