### PR TITLE
fix _IOW, _IOR and _IORW macro

### DIFF
--- a/include/api/aarch64/bits/ioctl.h
+++ b/include/api/aarch64/bits/ioctl.h
@@ -4,9 +4,9 @@
 #define _IOC_READ  2U
 
 #define _IO(a,b) _IOC(_IOC_NONE,(a),(b),0)
-#define _IOW(a,b,c) _IOC(1,(a),(b),sizeof(c))
-#define _IOR(a,b,c) _IOC(2,(a),(b),sizeof(c))
-#define _IOWR(a,b,c) _IOC(3,(a),(b),sizeof(c))
+#define _IOW(a,b,c) _IOC(_IOC_WRITE,(a),(b),sizeof(c))
+#define _IOR(a,b,c) _IOC(_IOC_READ,(a),(b),sizeof(c))
+#define _IOWR(a,b,c) _IOC(_IOC_READ | _IOC_WRITE,(a),(b),sizeof(c))
 
 #define TCGETS		0x5401
 #define TCSETS		0x5402

--- a/include/api/x64/bits/ioctl.h
+++ b/include/api/x64/bits/ioctl.h
@@ -4,9 +4,9 @@
 #define _IOC_READ  2U
 
 #define _IO(a,b) _IOC(_IOC_NONE,(a),(b),0)
-#define _IOW(a,b,c) _IOC(1,(a),(b),sizeof(c))
-#define _IOR(a,b,c) _IOC(2,(a),(b),sizeof(c))
-#define _IOWR(a,b,c) _IOC(3,(a),(b),sizeof(c))
+#define _IOW(a,b,c) _IOC(_IOC_WRITE,(a),(b),sizeof(c))
+#define _IOR(a,b,c) _IOC(_IOC_READ,(a),(b),sizeof(c))
+#define _IOWR(a,b,c) _IOC(_IOC_READ | _IOC_WRITE,(a),(b),sizeof(c))
 
 #define TCGETS		0x5401
 #define TCSETS		0x5402


### PR DESCRIPTION
This fixes the overflow issue as described by the issue #1313.

Fixes #1313