### PR TITLE
add basic ioctl support for block devices

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -858,6 +858,7 @@ libtsm += drivers/libtsm/tsm_vte_charsets.o
 drivers := $(bsd)
 drivers += core/mmu.o
 drivers += arch/$(arch)/early-console.o
+drivers += drivers/blk-common.o
 drivers += drivers/console.o
 drivers += drivers/console-multiplexer.o
 drivers += drivers/console-driver.o

--- a/drivers/ahci.cc
+++ b/drivers/ahci.cc
@@ -6,6 +6,7 @@
  */
 
 #include "drivers/ahci.hh"
+#include "drivers/blk-common.hh"
 #include <string.h>
 #include <osv/debug.h>
 #include <osv/mmu.hh>
@@ -44,7 +45,7 @@ static struct devops hba_devops {
     no_close,
     hba_read,
     hba_write,
-    no_ioctl,
+    blk_ioctl,
     no_devctl,
     multiplex_strategy,
 };

--- a/drivers/blk-common.cc
+++ b/drivers/blk-common.cc
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2023 Jan Braunwarth
+ * Copyright (C) 2024 Waldemar Kozaczuk
+ *
+ * This work is open source software, licensed under the terms of the
+ * BSD license as described in the LICENSE file in the top-level directory.
+ */
+
+#include <osv/types.h>
+#include <osv/device.h>
+#include <osv/bio.h>
+#include <osv/ioctl.h>
+
+#include <osv/trace.hh>
+#include "drivers/blk-common.hh"
+
+#include <sys/mount.h>
+
+TRACEPOINT(trace_blk_ioctl, "dev=%s type=%#x nr=%d size=%d, dir=%d", char*, int, int, int, int);
+
+static void no_bio_done(bio* b)
+{
+   delete b;
+}
+
+int
+blk_ioctl(struct device* dev, u_long io_cmd, void* buf)
+{
+    assert(dev);
+    trace_blk_ioctl(dev->name, _IOC_TYP(io_cmd), _IOC_NR(io_cmd), _IOC_SIZE(io_cmd), _IOC_DIR(io_cmd));
+
+    switch (io_cmd) {
+        case BLKGETSIZE64:
+            //device capacity in bytes
+            if (!buf) {
+                return EINVAL;
+            }
+            *(off_t*) buf = dev->size;
+            break;
+        case BLKFLSBUF:
+            {
+                auto* bio = alloc_bio();
+                bio->bio_dev = dev;
+                bio->bio_done = no_bio_done;
+                bio->bio_cmd = BIO_FLUSH;
+
+                dev->driver->devops->strategy(bio);
+            }
+            break;
+        default:
+            printf("ioctl not defined; type:%#x nr:%d size:%d, dir:%d\n",_IOC_TYP(io_cmd),_IOC_NR(io_cmd),_IOC_SIZE(io_cmd),_IOC_DIR(io_cmd));
+            return EINVAL;
+    }
+    return 0;
+}

--- a/drivers/blk-common.hh
+++ b/drivers/blk-common.hh
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) 2023 Jan Braunwarth
+ * Copyright (C) 2024 Waldemar Kozaczuk
+ *
+ * This work is open source software, licensed under the terms of the
+ * BSD license as described in the LICENSE file in the top-level directory.
+ */
+
+#ifndef BLK_COMMON_HH
+#define BLK_COMMON_HH
+
+#include <osv/device.h>
+
+int blk_ioctl(struct device* dev, u_long io_cmd, void* buf);
+
+#endif

--- a/drivers/ide.cc
+++ b/drivers/ide.cc
@@ -10,6 +10,7 @@
 
 #include "drivers/ide.hh"
 #include "drivers/pci-device.hh"
+#include "drivers/blk-common.hh"
 #include <osv/interrupt.hh>
 
 #include <osv/mempool.hh>
@@ -64,7 +65,7 @@ static struct devops ide_devops {
     no_close,
     ide_read,
     ide_write,
-    no_ioctl,
+    blk_ioctl,
     no_devctl,
     ide_strategy,
 };

--- a/drivers/virtio-blk.cc
+++ b/drivers/virtio-blk.cc
@@ -9,6 +9,7 @@
 #include <osv/drivers_config.h>
 #include <sys/cdefs.h>
 
+#include "drivers/blk-common.hh"
 #include "drivers/virtio.hh"
 #include "drivers/virtio-blk.hh"
 #include <osv/interrupt.hh>
@@ -88,7 +89,7 @@ static struct devops blk_devops {
     no_close,
     blk_read,
     blk_write,
-    no_ioctl,
+    blk_ioctl,
     no_devctl,
     multiplex_strategy,
 };

--- a/drivers/virtio-fs.cc
+++ b/drivers/virtio-fs.cc
@@ -19,6 +19,7 @@
 #include "drivers/virtio.hh"
 #include "drivers/virtio-fs.hh"
 #include "drivers/virtio-vring.hh"
+#include "drivers/blk-common.hh"
 #include "fs/virtiofs/fuse_kernel.h"
 
 using fuse_request = virtio::fs::fuse_request;
@@ -54,7 +55,7 @@ static struct devops fs_devops {
     no_close,
     no_read,
     no_write,
-    no_ioctl,
+    blk_ioctl,
     no_devctl,
     no_strategy,
 };

--- a/drivers/virtio-scsi.cc
+++ b/drivers/virtio-scsi.cc
@@ -15,6 +15,7 @@
 #include "drivers/virtio.hh"
 #include "drivers/virtio-scsi.hh"
 #include "drivers/scsi-common.hh"
+#include "drivers/blk-common.hh"
 
 #include <string>
 #include <vector>
@@ -61,7 +62,7 @@ static struct devops scsi_devops {
     no_close,
     scsi_read,
     scsi_write,
-    no_ioctl,
+    blk_ioctl,
     no_devctl,
     multiplex_strategy,
 };

--- a/drivers/vmw-pvscsi.cc
+++ b/drivers/vmw-pvscsi.cc
@@ -16,6 +16,7 @@
 #include "drivers/pci-device.hh"
 #include "drivers/scsi-common.hh"
 #include "drivers/vmw-pvscsi.hh"
+#include "drivers/blk-common.hh"
 
 #include <string>
 #include <vector>
@@ -57,7 +58,7 @@ static struct devops pvscsi_devops {
     no_close,
     pvscsi_read,
     pvscsi_write,
-    no_ioctl,
+    blk_ioctl,
     no_devctl,
     multiplex_strategy,
 };

--- a/drivers/xenfront-blk.cc
+++ b/drivers/xenfront-blk.cc
@@ -7,6 +7,7 @@
 
 #include <sstream>
 #include <drivers/xenfront.hh>
+#include "drivers/blk-common.hh"
 #include <osv/device.h>
 #include <bsd/sys/geom/geom_disk.h>
 #include <osv/bio.h>
@@ -36,7 +37,7 @@ static struct devops xenfront_blk_devops {
     no_close,
     xenfront_blk_read,
     xenfront_blk_write,
-    no_ioctl,
+    blk_ioctl,
     no_devctl,
     multiplex_strategy,
 };

--- a/include/osv/ioctl.h
+++ b/include/osv/ioctl.h
@@ -12,6 +12,33 @@
 
 #define _IOC_TYPE(x) (((x) >> 24) & 0xff)
 
+#define _IOC_NRBITS     8
+#define _IOC_TYPEBITS   8
+
+#ifndef _IOC_SIZEBITS
+#define _IOC_SIZEBITS   14
+#endif
+
+#ifndef _IOC_DIRBITS
+#define _IOC_DIRBITS    2
+#endif
+
+#define _IOC_NRMASK     ((1 << _IOC_NRBITS)-1)
+#define _IOC_TYPEMASK   ((1 << _IOC_TYPEBITS)-1)
+#define _IOC_SIZEMASK   ((1 << _IOC_SIZEBITS)-1)
+#define _IOC_DIRMASK    ((1 << _IOC_DIRBITS)-1)
+
+#define _IOC_NRSHIFT    0
+#define _IOC_TYPESHIFT  (_IOC_NRSHIFT+_IOC_NRBITS)
+#define _IOC_SIZESHIFT  (_IOC_TYPESHIFT+_IOC_TYPEBITS)
+#define _IOC_DIRSHIFT   (_IOC_SIZESHIFT+_IOC_SIZEBITS)
+
+/* used to decode ioctl numbers.. */
+#define _IOC_DIR(nr)    (((nr) >> _IOC_DIRSHIFT) & _IOC_DIRMASK)
+#define _IOC_TYP(nr)    (((nr) >> _IOC_TYPESHIFT) & _IOC_TYPEMASK)
+#define _IOC_NR(nr)     (((nr) >> _IOC_NRSHIFT) & _IOC_NRMASK)
+#define _IOC_SIZE(nr)   (((nr) >> _IOC_SIZESHIFT) & _IOC_SIZEMASK)
+
 #define SIOCBEGIN   0x8900
 #define SIOCEND     0x89ff
 


### PR DESCRIPTION
This patch adds very basic `ioctl` support for block devices as described by #1315.

Fixes #1315