### PR TITLE
rofs: use contiguous buffer when reading i-node table

### DIFF
--- a/fs/rofs/rofs_vfsops.cc
+++ b/fs/rofs/rofs_vfsops.cc
@@ -26,6 +26,7 @@
 #include <sys/types.h>
 #include <osv/device.h>
 #include <osv/debug.h>
+#include <osv/contiguous_alloc.hh>
 #include <fs/vfs/vfs_id.h>
 #include <iomanip>
 #include <iostream>
@@ -70,21 +71,22 @@ rofs_mount(struct mount *mp, const char *dev, int flags, const void *data)
         return error;
     }
 
-    void *buf = malloc(BSIZE); //Just enough for single block of 512 bytes
-    error = rofs_read_blocks(device, ROFS_SUPERBLOCK_BLOCK, 1, buf);
+    using namespace memory;
+    std::unique_ptr<void, void(*)(void*)> buf(alloc_phys_contiguous_aligned(BSIZE, PAGE_SIZE), [] (void *ptr) {
+       free_phys_contiguous_aligned(ptr);
+    }); //Just enough for single block of 512 bytes
+    error = rofs_read_blocks(device, ROFS_SUPERBLOCK_BLOCK, 1, buf.get());
     if (error) {
         kprintf("[rofs] Error reading rofs superblock\n");
         device_close(device);
-        free(buf);
         return error;
     }
 
     // We see if the file system is ROFS, if not, return error and close everything
-    sb = (struct rofs_super_block *) buf;
+    sb = (struct rofs_super_block *) buf.get();
     if (sb->magic != ROFS_MAGIC) {
         print("[rofs] Error magics do not match!\n");
         print("[rofs] Expecting %016llX but got %016llX\n", ROFS_MAGIC, sb->magic);
-        free(buf);
         device_close(device);
         return -1; // TODO: Proper error code
     }
@@ -92,7 +94,6 @@ rofs_mount(struct mount *mp, const char *dev, int flags, const void *data)
     if (sb->version != ROFS_VERSION) {
         kprintf("[rofs] Found rofs volume but incompatible version!\n");
         kprintf("[rofs] Expecting %llu but found %llu\n", ROFS_VERSION, sb->version);
-        free(buf);
         device_close(device);
         return -1;
     }
@@ -108,16 +109,14 @@ rofs_mount(struct mount *mp, const char *dev, int flags, const void *data)
     //
     // Since we have found ROFS, we can copy the superblock now
     sb = new rofs_super_block;
-    memcpy(sb, buf, ROFS_SUPERBLOCK_SIZE);
-    free(buf);
+    memcpy(sb, buf.get(), ROFS_SUPERBLOCK_SIZE);
     //
     // Read structure_info_blocks_count to construct array of directory enries, symlinks and i-nodes
-    buf = malloc(BSIZE * sb->structure_info_blocks_count);
-    error = rofs_read_blocks(device, sb->structure_info_first_block, sb->structure_info_blocks_count, buf);
+    buf.reset(alloc_phys_contiguous_aligned(BSIZE * sb->structure_info_blocks_count, PAGE_SIZE));
+    error = rofs_read_blocks(device, sb->structure_info_first_block, sb->structure_info_blocks_count, buf.get());
     if (error) {
         kprintf("[rofs] Error reading rofs structure info blocks\n");
         device_close(device);
-        free(buf);
         return error;
     }
 
@@ -125,7 +124,7 @@ rofs_mount(struct mount *mp, const char *dev, int flags, const void *data)
     rofs->sb = sb;
     rofs->dir_entries = (struct rofs_dir_entry *) malloc(sizeof(struct rofs_dir_entry) * sb->directory_entries_count);
 
-    void *data_ptr = buf;
+    void *data_ptr = buf.get();
     //
     // Read directory entries
     for (unsigned int idx = 0; idx < sb->directory_entries_count; idx++) {
@@ -164,8 +163,6 @@ rofs_mount(struct mount *mp, const char *dev, int flags, const void *data)
     for (unsigned int idx = 0; idx < sb->inodes_count; idx++) {
         print("[rofs] inode: %d, size: %d\n", rofs->inodes[idx].inode_no, rofs->inodes[idx].file_size);
     }
-
-    free(buf);
 
     // Save a reference to our superblock
     mp->m_data = rofs;


### PR DESCRIPTION
The filesystem read and write operations call block device drivers `strategy()` function. The buffer argument of these functions needs to point to a contiguous area of physical memory because eventually the virtual address pointer will be converted to a physical one before being passed to the host layer.

Unfortunately, the logic in the ROFS mount that reads the master block and the i-node table uses regular `malloc()` to allocate buffers to read to. Everything works fine if the i-node table occupies less than 1 page (4K) on disk. But if it occupies more than 1 page of memory and underlying physical memory is fragmented one can experience errors like the one in the description of issue #1033.

This patch fixes this issue, by changing two `malloc()` calls with `alloc_phys_contiguous_aligned()`. In addition, we improve the code by using `std::unique_ptr()` to let the compiler emit code to automatically call `free_phys_contiguous_aligned()` in all cases when the `rofs_mount()` returns.

Fixes #1033