### PR TITLE
printf.hh/debug.hh: eliminate osv::sprintf() that uses boost::format

### DIFF
--- a/arch/aarch64/smp.cc
+++ b/arch/aarch64/smp.cc
@@ -47,7 +47,7 @@ void smp_init()
     if (nr_cpus < 1) {
         abort("smp_init: could not get cpus from device tree.\n");
     }
-    debug(fmt("%d CPUs detected\n") % nr_cpus);
+    debug("%d CPUs detected\n", nr_cpus);
     u64 *mpids = (u64 *)alloca(sizeof(u64) * nr_cpus);
     if (!dtb_get_cpus_mpid(mpids, nr_cpus)) {
         abort("smp_init: failed to get cpus mpids from device tree.\n");

--- a/arch/x64/exceptions.cc
+++ b/arch/x64/exceptions.cc
@@ -10,7 +10,6 @@
 #include <osv/mmu.hh>
 #include "processor.hh"
 #include <osv/interrupt.hh>
-#include <boost/format.hpp>
 #include <osv/sched.hh>
 #include <osv/debug.hh>
 #include <libc/signal.hh>
@@ -21,8 +20,6 @@
 #include <osv/intr_random.hh>
 
 #include "fault-fixup.hh"
-
-typedef boost::format fmt;
 
 __thread exception_frame* current_interrupt_frame;
 interrupt_descriptor_table idt __attribute__((init_priority((int)init_prio::idt)));

--- a/arch/x64/smp.cc
+++ b/arch/x64/smp.cc
@@ -92,7 +92,7 @@ void parse_madt()
     if (!nr_cpus) { // No MP table was found or no cpu was found in there -> assume uni-processor
         register_cpu(nr_cpus++, 0);
     }
-    debug(fmt("%d CPUs detected\n") % nr_cpus);
+    debug("%u CPUs detected\n", nr_cpus);
 }
 #endif
 
@@ -197,7 +197,7 @@ void parse_mp_table()
         register_cpu(nr_cpus++, 0);
     }
 
-    debug(fmt("%d CPUs detected\n") % nr_cpus);
+    debug("%u CPUs detected\n", nr_cpus);
 }
 
 void smp_init()

--- a/core/debug.cc
+++ b/core/debug.cc
@@ -9,7 +9,6 @@
 #include <cstdarg>
 #include <iostream>
 #include <iomanip>
-#include "boost/format.hpp"
 #include "drivers/console.hh"
 #include <osv/sched.hh>
 #include <osv/debug.hh>
@@ -110,20 +109,6 @@ const char* logger::loggable_severity(logger_severity severity)
     return (ret);
 }
 
-void logger::wrt(const char* tag, logger_severity severity, const boost::format& _fmt)
-{
-    if (this->is_filtered(tag, severity)) {
-        return;
-    }
-
-    unsigned long tid = sched::thread::current()->id();
-    _lock.lock();
-    debug(fmt("[%s/%d %s]: ") % loggable_severity(severity) % tid % tag);
-    debug(_fmt);
-    debug("\n");
-    _lock.unlock();
-}
-
 void logger::wrt(const char* tag, logger_severity severity, const char* _fmt, ...)
 {
     va_list ap;
@@ -184,11 +169,6 @@ void debug(std::string str)
     if (verbose) {
         console::write(str.c_str(), str.length());
     }
-}
-
-void debug(const boost::format& fmt)
-{
-    debug(fmt.str());
 }
 
 void enable_verbose()

--- a/core/elf.cc
+++ b/core/elf.cc
@@ -8,7 +8,6 @@
 #include <osv/elf.hh>
 #include <osv/app.hh>
 #include <osv/mmu.hh>
-#include <boost/format.hpp>
 #include <exception>
 #include <memory>
 #include <string.h>
@@ -51,10 +50,6 @@ extern size_t elf_size;
 extern char libvdso_start[];
 
 using namespace boost::range;
-
-namespace {
-    typedef boost::format fmt;
-}
 
 namespace elf {
 

--- a/core/mmu.cc
+++ b/core/mmu.cc
@@ -10,7 +10,6 @@
 #include "processor.hh"
 #include <osv/debug.hh>
 #include "exceptions.hh"
-#include <boost/format.hpp>
 #include <string.h>
 #include <iterator>
 #include "libc/signal.hh"
@@ -36,12 +35,6 @@
 
 extern void* elf_start;
 extern size_t elf_size;
-
-namespace {
-
-typedef boost::format fmt;
-
-}
 
 extern const char text_start[], text_end[];
 

--- a/include/osv/debug.hh
+++ b/include/osv/debug.hh
@@ -15,7 +15,6 @@
 #include <osv/debug.h>
 #include <osv/mutex.h>
 #include <osv/printf.hh>
-#include "boost/format.hpp"
 
 #define DEBUG_BUFFER_SIZE 1024*50 // 50kb buffer
 
@@ -45,8 +44,6 @@ do {                                                         \
 #define DEBUG_ASSERT(cond, msg, ...) (void)0
 #endif /* NDEBUG */
 
-typedef boost::format fmt;
-
 class isa_serial_console;
 
 class logger {
@@ -66,7 +63,6 @@ public:
     // Interface for logging, these functions checks the filters and
     // calls the underlying debug functions.
     //
-    void wrt(const char* tag, logger_severity severity, const boost::format& _fmt);
     void wrt(const char* tag, logger_severity severity, const char* _fmt, ...);
     void wrt(const char* tag, logger_severity severity, const char* _fmt, va_list ap);
 
@@ -95,9 +91,6 @@ extern "C" {
 }
 void flush_debug_buffer();
 void enable_verbose();
-void debug(const boost::format& fmt);
-template <typename... args>
-void debug(boost::format& fmt, args... as);
 void debug(std::string str);
 template <typename... args>
 void debug(const char* fmt, args... as);
@@ -106,12 +99,6 @@ extern "C" {void readln(char *msg, size_t size); }
 
 template <typename... args>
 void debug(const char* fmt, args... as)
-{
-    debug(osv::sprintf(fmt, as...));
-}
-
-template <typename... args>
-void debug(boost::format& fmt, args... as)
 {
     debug(osv::sprintf(fmt, as...));
 }

--- a/include/osv/printf.hh
+++ b/include/osv/printf.hh
@@ -21,9 +21,6 @@ std::ostream& fprintf(std::ostream& os, boost::format& fmt, args... as);
 template <typename... args>
 std::string sprintf(const char* fmt, args... as);
 
-template <typename... args>
-std::string sprintf(boost::format& fmt, args... as);
-
 // implementation
 
 template <>
@@ -49,14 +46,6 @@ std::string sprintf(const char* fmt, args... as)
     boost::format f(fmt);
     std::ostringstream os;
     fprintf(os, f, as...);
-    return os.str();
-}
-
-template <typename... args>
-std::string sprintf(boost::format& fmt, args... as)
-{
-    std::ostringstream os;
-    fprintf(os, fmt, as...);
     return os.str();
 }
 

--- a/linux.cc
+++ b/linux.cc
@@ -8,7 +8,6 @@
 // linux syscalls
 
 #include <osv/debug.hh>
-#include <boost/format.hpp>
 #include <osv/sched.hh>
 #include <osv/mutex.h>
 #include <osv/waitqueue.hh>

--- a/loader.cc
+++ b/loader.cc
@@ -9,7 +9,6 @@
 #include "fs/fs.hh"
 #include <bsd/init.hh>
 #include <bsd/net.hh>
-#include <boost/format.hpp>
 #include <boost/algorithm/string.hpp>
 #include <cctype>
 #include <osv/elf.hh>

--- a/runtime.cc
+++ b/runtime.cc
@@ -32,7 +32,6 @@
 #include <sys/sysinfo.h>
 #include "processor.hh"
 #include <osv/debug.hh>
-#include <boost/format.hpp>
 #include <osv/mempool.hh>
 #include <osv/export.h>
 #include <pwd.h>
@@ -385,7 +384,7 @@ long sysconf(int name)
     case _SC_MINSIGSTKSZ: return MINSIGSTKSZ;
     case _SC_SIGSTKSZ: return SIGSTKSZ;
     default:
-        debug(fmt("sysconf(): stubbed for parameter %1%\n") % name);
+        debug("sysconf(): stubbed for parameter %ld\n", name);
         errno = EINVAL;
         return -1;
     }
@@ -442,7 +441,7 @@ int pclose(FILE *stream)
 
 void exit(int status)
 {
-    debug(fmt("program exited with status %d\n") % status);
+    debug("program exited with status %ld\n", status);
     osv::shutdown();
 }
 


### PR DESCRIPTION
This is another commit to remove code that directly or indirectly depends on std::locale.

This particular code eliminates the version of `osv::sprintf()` where the format argument is passed in as `boost::format` instance and replaces relevant usages of it with `void sprintf(const char* fmt, args... as)`.

The `void debug(boost::format& fmt, args... as)` is also eliminated and replaced with `void debug(const char* fmt, args... as)`.

Ref #1335