### PR TITLE
do not use boost::format and streams in osv::printf() and osv::debug()

### DIFF
--- a/arch/aarch64/smp.cc
+++ b/arch/aarch64/smp.cc
@@ -9,7 +9,6 @@
 #include <osv/debug.h>
 #include <osv/sched.hh>
 #include <osv/prio.hh>
-#include <osv/printf.hh>
 #include <osv/aligned_new.hh>
 #include <osv/export.h>
 #include "processor.hh"
@@ -47,7 +46,7 @@ void smp_init()
     if (nr_cpus < 1) {
         abort("smp_init: could not get cpus from device tree.\n");
     }
-    debug("%d CPUs detected\n", nr_cpus);
+    debugf("%d CPUs detected\n", nr_cpus);
     u64 *mpids = (u64 *)alloca(sizeof(u64) * nr_cpus);
     if (!dtb_get_cpus_mpid(mpids, nr_cpus)) {
         abort("smp_init: failed to get cpus mpids from device tree.\n");
@@ -74,7 +73,7 @@ void smp_launch()
     debug_early_entry("smp_launch");
 #endif
     for (auto c : sched::cpus) {
-        auto name = osv::sprintf("balancer%d", c->id);
+        auto name = std::string("balancer") + std::to_string(c->id);
         if (c->arch.smp_idx == 0) {
             sched::thread::current()->_detached_state->_cpu = c;
             // c->init_on_cpu() already done in main().

--- a/arch/common/fault-fixup.hh
+++ b/arch/common/fault-fixup.hh
@@ -1,3 +1,5 @@
+#include <algorithm>
+
 struct fault_fixup {
     ulong pc;
     ulong divert;

--- a/arch/x64/mmu.cc
+++ b/arch/x64/mmu.cc
@@ -15,6 +15,7 @@
 #include <osv/prio.hh>
 #include <osv/elf.hh>
 #include "exceptions.hh"
+#include <algorithm>
 
 void page_fault(exception_frame *ef)
 {

--- a/arch/x64/power.cc
+++ b/arch/x64/power.cc
@@ -36,12 +36,12 @@ void poweroff(void)
     if (acpi::is_enabled()) {
         ACPI_STATUS status = AcpiEnterSleepStatePrep(ACPI_STATE_S5);
         if (ACPI_FAILURE(status)) {
-            debug("AcpiEnterSleepStatePrep failed: %s\n", AcpiFormatException(status));
+            debugf("AcpiEnterSleepStatePrep failed: %s\n", AcpiFormatException(status));
             halt();
         }
         status = AcpiEnterSleepState(ACPI_STATE_S5);
         if (ACPI_FAILURE(status)) {
-            debug("AcpiEnterSleepState failed: %s\n", AcpiFormatException(status));
+            debugf("AcpiEnterSleepState failed: %s\n", AcpiFormatException(status));
             halt();
         }
     } else {

--- a/arch/x64/smp.cc
+++ b/arch/x64/smp.cc
@@ -92,7 +92,7 @@ void parse_madt()
     if (!nr_cpus) { // No MP table was found or no cpu was found in there -> assume uni-processor
         register_cpu(nr_cpus++, 0);
     }
-    debug("%u CPUs detected\n", nr_cpus);
+    debugf("%u CPUs detected\n", nr_cpus);
 }
 #endif
 
@@ -197,7 +197,7 @@ void parse_mp_table()
         register_cpu(nr_cpus++, 0);
     }
 
-    debug("%u CPUs detected\n", nr_cpus);
+    debugf("%u CPUs detected\n", nr_cpus);
 }
 
 void smp_init()
@@ -247,7 +247,7 @@ void smp_launch()
     processor::kvm_pv_eoi_init();
     auto boot_cpu = smp_initial_find_current_cpu();
     for (auto c : sched::cpus) {
-        auto name = osv::sprintf("balancer%d", c->id);
+        auto name = std::string("balancer") + std::to_string(c->id);
         if (c == boot_cpu) {
             sched::thread::current()->_detached_state->_cpu = c;
             // c->init_on_cpu() already done in main().

--- a/bsd/porting/bus.h
+++ b/bsd/porting/bus.h
@@ -200,7 +200,7 @@ static inline void disk_destroy(struct disk *dp)
 {
 }
 
-#define device_printf(dev, ...) debugf(__VA_ARGS__)
+#define device_printf(dev, ...) debugff(__VA_ARGS__)
 __BEGIN_DECLS
 void device_set_ivars(device_t dev, void *ivars);
 int device_get_children(device_t dev, device_t **devlistp, int *devcountp);

--- a/bsd/porting/shrinker.cc
+++ b/bsd/porting/shrinker.cc
@@ -85,10 +85,10 @@ void bsd_shrinker_init(void)
     struct eventhandler_list *list = eventhandler_find_list("vm_lowmem");
     struct eventhandler_entry *ep;
 
-    debug("BSD shrinker: event handler list found: %p\n", list);
+    debugf("BSD shrinker: event handler list found: %p\n", list);
 
     TAILQ_FOREACH(ep, &list->el_entries, ee_link) {
-        debug("\tBSD shrinker found: %p\n",
+        debugf("\tBSD shrinker found: %p\n",
                 ((struct eventhandler_entry_generic *)ep)->func);
 
         auto *_ee = (struct eventhandler_entry_generic *)ep;

--- a/core/app.cc
+++ b/core/app.cc
@@ -463,7 +463,7 @@ void application::run_main()
     optind = old_optind;
 
     if (_return_code) {
-        debug("program %s returned %d\n", _command.c_str(), _return_code);
+        debugf("program %s returned %d\n", _command.c_str(), _return_code);
     }
 
     if(_post_main) {

--- a/core/async.cc
+++ b/core/async.cc
@@ -9,7 +9,6 @@
 #include <osv/percpu.hh>
 #include <osv/sched.hh>
 #include <osv/trace.hh>
-#include <osv/printf.hh>
 
 #include <osv/irqlock.hh>
 #include <osv/preempt-lock.hh>
@@ -95,7 +94,7 @@ class async_worker {
 public:
     async_worker(sched::cpu* cpu)
         : _thread(sched::thread::make(std::bind(&async_worker::run, this),
-            sched::thread::attr().pin(cpu).name(osv::sprintf("async_worker%d", cpu->id))))
+            sched::thread::attr().pin(cpu).name(std::string("async_worker") + std::to_string(cpu->id))))
         , _timer(*_thread)
         , _cpu(cpu)
     {

--- a/core/commands.cc
+++ b/core/commands.cc
@@ -102,7 +102,6 @@ void expand_environ_vars(std::string& word)
         std::string new_word = word.substr(0, pos);
         std::string key = word.substr(pos+1);
         auto tmp = getenv(key.c_str());
-        //debug("    new_word=%s, key=%s, tmp=%s\n", new_word.c_str(), key.c_str(), tmp);
         if (tmp) {
             new_word += tmp;
         }
@@ -184,7 +183,7 @@ static void runscript_process_options(std::vector<std::vector<std::string> >& re
             if (key.length() > 0) {
                 // we have something to set
                 expand_environ_vars(value);
-                debug("Setting in environment: %s=%s\n", key, value);
+                debugff("Setting in environment: %s=%s\n", key.c_str(), value.c_str());
                 setenv(key.c_str(), value.c_str(), 1);
             }
         }

--- a/core/debug.cc
+++ b/core/debug.cc
@@ -7,8 +7,6 @@
 
 #include <cstring>
 #include <cstdarg>
-#include <iostream>
-#include <iomanip>
 #include "drivers/console.hh"
 #include <osv/sched.hh>
 #include <osv/debug.hh>
@@ -171,6 +169,14 @@ void debug(std::string str)
     }
 }
 
+void debugf(const char* fmt...)
+{
+    va_list ap;
+    va_start(ap, fmt);
+    debug(osv::vsprintf(fmt, ap));
+    va_end(ap);
+}
+
 void enable_verbose()
 {
     verbose = true;
@@ -188,7 +194,7 @@ void flush_debug_buffer()
 
 extern "C" {
 
-    void debugf(const char *fmt, ...)
+    void debugff(const char *fmt, ...)
     {
         char msg[512];
 

--- a/core/dhcp.cc
+++ b/core/dhcp.cc
@@ -28,6 +28,8 @@
 #include <osv/clock.hh>
 #include <libc/network/__dns.hh>
 
+#include <algorithm>
+
 using namespace boost::asio;
 
 dhcp::dhcp_worker net_dhcp_worker;

--- a/core/elf.cc
+++ b/core/elf.cc
@@ -701,7 +701,7 @@ symbol_module object::symbol(unsigned idx, bool ignore_missing)
     }
     if (!ret.symbol) {
         if (ignore_missing) {
-            debug("%s: ignoring missing symbol %s\n", pathname().c_str(), demangle(name).c_str());
+            debugf("%s: ignoring missing symbol %s\n", pathname().c_str(), demangle(name).c_str());
         } else {
             abort("%s: failed looking up symbol %s\n", pathname().c_str(), demangle(name).c_str());
         }
@@ -1087,7 +1087,7 @@ void object::load_needed(std::vector<std::shared_ptr<object>>& loaded_objects)
             // unloaded until this object is unloaded.
             _needed.push_back(std::move(obj));
         } else {
-            debug("could not load %s\n", lib);
+            debugf("could not load %s\n", lib);
         }
     }
 }

--- a/core/mempool.cc
+++ b/core/mempool.cc
@@ -1189,7 +1189,7 @@ static std::vector<stats::pool_stats> l1_pool_stats;
 struct l1 {
     l1(sched::cpu* cpu)
         : _fill_thread(sched::thread::make([] { fill_thread(); },
-            sched::thread::attr().pin(cpu).name(osv::sprintf("page_pool_l1_%d", cpu->id))))
+            sched::thread::attr().pin(cpu).name(std::string("page_pool_l1_") + std::to_string(cpu->id))))
     {
         cpu_id = cpu->id;
         _fill_thread->start();

--- a/core/mmu.cc
+++ b/core/mmu.cc
@@ -1986,15 +1986,15 @@ linear_vma::~linear_vma() {
 }
 
 std::string sysfs_linear_maps() {
-    std::ostringstream os;
+    std::string output;
     WITH_LOCK(linear_vma_set_mutex.for_read()) {
         for(auto *vma : linear_vma_set) {
             char mattr = vma->_mem_attr == mmu::mattr::normal ? 'n' : 'd';
-            osv::fprintf(os, "%18x %18x %12x rwxp %c %s\n",
+            output += osv::sprintf("%18p %18p %12x rwxp %c %s\n",
                 vma->_virt_addr, (void*)vma->_phys_addr, vma->_size, mattr, vma->_name.c_str());
         }
     }
-    return os.str();
+    return output;
 }
 
 void linear_map(void* _virt, phys addr, size_t size, const char* name,
@@ -2087,25 +2087,25 @@ error mincore(const void *addr, size_t length, unsigned char *vec)
 
 std::string procfs_maps()
 {
-    std::ostringstream os;
+    std::string output;
     WITH_LOCK(vma_list_mutex.for_read()) {
         for (auto& vma : vma_list) {
             char read    = vma.perm() & perm_read  ? 'r' : '-';
             char write   = vma.perm() & perm_write ? 'w' : '-';
             char execute = vma.perm() & perm_exec  ? 'x' : '-';
             char priv    = 'p';
-            osv::fprintf(os, "%x-%x %c%c%c%c ", vma.start(), vma.end(), read, write, execute, priv);
+            output += osv::sprintf("%012x-%012x %c%c%c%c ", vma.start(), vma.end(), read, write, execute, priv);
             if (vma.flags() & mmap_file) {
                 const file_vma &f_vma = static_cast<file_vma&>(vma);
                 unsigned dev_id_major = major(f_vma.file_dev_id());
                 unsigned dev_id_minor = minor(f_vma.file_dev_id());
-                osv::fprintf(os, "%08x %02x:%02x %ld %s\n", f_vma.offset(), dev_id_major, dev_id_minor, f_vma.file_inode(), f_vma.file()->f_dentry->d_path);
+                output += osv::sprintf("%08x %02x:%02x %ld %s\n", f_vma.offset(), dev_id_major, dev_id_minor, f_vma.file_inode(), f_vma.file()->f_dentry->d_path);
             } else {
-                osv::fprintf(os, "00000000 00:00 0\n");
+                output += osv::sprintf("00000000 00:00 0\n");
             }
         }
     }
-    return os.str();
+    return output;
 }
 
 }

--- a/core/net_channel.cc
+++ b/core/net_channel.cc
@@ -16,6 +16,7 @@
 #include <bsd/sys/net/netisr.h>
 
 #include <osv/net_trace.hh>
+#include <algorithm>
 
 void net_channel::process_queue()
 {

--- a/core/options.cc
+++ b/core/options.cc
@@ -5,9 +5,9 @@
  * BSD license as described in the LICENSE file in the top-level directory.
  */
 
-#include <iostream>
 #include <functional>
 #include <cassert>
+#include <stdexcept>
 #include <osv/options.hh>
 
 namespace options {

--- a/core/percpu-worker.cc
+++ b/core/percpu-worker.cc
@@ -122,7 +122,7 @@ void workman::pcpu_init()
     auto c = sched::cpu::current();
     // Create PCPU Sheriff
     *_work_sheriff = sched::thread::make([] { workman::call_of_duty(); },
-        sched::thread::attr().pin(c).name(osv::sprintf("percpu%d", c->id)));
+        sched::thread::attr().pin(c).name(std::string("percpu") + std::to_string(c->id)));
 
     (*_work_sheriff)->start();
 }

--- a/core/printf.cc
+++ b/core/printf.cc
@@ -5,14 +5,40 @@
  * BSD license as described in the LICENSE file in the top-level directory.
  */
 
+#include <cstdarg>
 #include <osv/printf.hh>
 
 namespace osv {
 
-template <>
-std::ostream& fprintf(std::ostream& os, boost::format& fmt)
+std::string sprintf(const char* fmt...)
 {
-    return os << fmt;
+    char *output;
+    va_list ap;
+    va_start(ap, fmt);
+    auto ret = vasprintf(&output, fmt, ap);
+    va_end(ap);
+
+    if (ret >= 0 && output) {
+        auto res = std::string(output);
+        free(output);
+        return res;
+    } else {
+        return "";
+    }
+}
+
+std::string vsprintf(const char* fmt, va_list ap)
+{
+    char *output;
+    auto ret = vasprintf(&output, fmt, ap);
+
+    if (ret >= 0 && output) {
+        auto res = std::string(output);
+        free(output);
+        return res;
+    } else {
+        return "";
+    }
 }
 
 }

--- a/core/rcu.cc
+++ b/core/rcu.cc
@@ -64,7 +64,7 @@ sched::cpu::notifier cpu_notifier([] {
 });
 
 cpu_quiescent_state_thread::cpu_quiescent_state_thread(sched::cpu* cpu)
-    : _t(sched::thread::make([=] { work(); }, sched::thread::attr().pin(cpu).name(osv::sprintf("rcu%d", cpu->id))))
+    : _t(sched::thread::make([=] { work(); }, sched::thread::attr().pin(cpu).name(std::string("rcu") + std::to_string(cpu->id))))
 {
     (*percpu_quiescent_state_thread).reset(*_t);
     _t->start();

--- a/core/sampler.cc
+++ b/core/sampler.cc
@@ -149,7 +149,7 @@ void start_sampler(config new_config) throw()
         assert(!_started);
     }
 
-    debug("Starting sampler, period = %d ns\n", to_nanoseconds(new_config.period));
+    debugf("Starting sampler, period = %d ns\n", to_nanoseconds(new_config.period));
 
     _controller.reset(*sched::thread::current());
 

--- a/core/sched.cc
+++ b/core/sched.cc
@@ -27,6 +27,7 @@
 #include <osv/app.hh>
 #include <osv/symbols.hh>
 #include <osv/stubbing.hh>
+#include <algorithm>
 
 MAKE_SYMBOL(sched::thread::current);
 MAKE_SYMBOL(sched::cpu::current);
@@ -164,7 +165,7 @@ cpu::cpu(unsigned _id)
 void cpu::init_idle_thread()
 {
     running_since = osv::clock::uptime::now();
-    std::string name = osv::sprintf("idle%d", id);
+    std::string name = std::string("idle") + std::to_string(id);
     idle_thread = thread::make([this] { idle(); }, thread::attr().pin(this).name(name));
     idle_thread->set_priority(thread::priority_idle);
 }

--- a/core/trace.cc
+++ b/core/trace.cc
@@ -214,7 +214,7 @@ tracepoint_base::tracepoint_base(unsigned _id, const std::type_info& tp_type,
 {
     auto inserted = known_ids().insert(id).second;
     if (!inserted) {
-        debug("duplicate tracepoint id %d (%s)\n", std::get<0>(id), name);
+        debugf("duplicate tracepoint id %d (%s)\n", std::get<0>(id), name);
         abort();
     }
     probes_ptr.assign(new std::vector<probe*>);

--- a/core/xen_intr.cc
+++ b/core/xen_intr.cc
@@ -108,7 +108,7 @@ void xen_irq::do_irq()
 void xen_irq::_cpu_init(sched::cpu *c)
 {
     *(_thread.for_cpu(c)) = sched::thread::make([this] { xen_irq::do_irq(); },
-            sched::thread::attr().pin(c).name(osv::sprintf("xenirq%d", c->id)));
+            sched::thread::attr().pin(c).name(std::string("xenirq") + std::to_string(c->id)));
     (*(_thread.for_cpu(c)))->start();
 }
 

--- a/drivers/ahci.cc
+++ b/drivers/ahci.cc
@@ -535,7 +535,7 @@ void hba::scan()
         add_port(pnr, p);
         read_partition_table(dev);
 
-        debug("AHCI: Add sata device port %d as %s, devsize=%lld\n", pnr, dev_name.c_str(), dev->size);
+        debugf("AHCI: Add sata device port %d as %s, devsize=%lld\n", pnr, dev_name.c_str(), dev->size);
     }
 }
 

--- a/drivers/pci-function.hh
+++ b/drivers/pci-function.hh
@@ -9,6 +9,7 @@
 #define PCI_FUNCTION_H
 
 #include <map>
+#include <vector>
 
 #include <osv/mmio.hh>
 #include <osv/types.h>

--- a/drivers/pvpanic.cc
+++ b/drivers/pvpanic.cc
@@ -40,8 +40,8 @@ void probe_and_setup()
     }
 
     if (ACPI_FAILURE(status)) {
-        debug("pvpanic:AcpiEvaluateObject() failed: %s\n",
-              AcpiFormatException(status));
+        debugf("pvpanic:AcpiEvaluateObject() failed: %s\n",
+               AcpiFormatException(status));
         return;
     }
 

--- a/drivers/ramdisk.c
+++ b/drivers/ramdisk.c
@@ -148,8 +148,8 @@ ramdisk_init(void)
 	pthread_mutex_init(&sc->bio_mutex, NULL);
 	pthread_cond_init(&sc->bio_wait, NULL);
 
-	debugf("RAM disk at 0x%p (%zdK bytes)\n",
-	       sc->addr, sc->size/1024);
+	debugff("RAM disk at 0x%p (%zdK bytes)\n",
+	        sc->addr, sc->size/1024);
     
 	error = pthread_create(&ramdisk_thread, NULL, ramdisk_thread_fn, sc);
 	if (error) {

--- a/drivers/random.cc
+++ b/drivers/random.cc
@@ -205,7 +205,7 @@ random_device::~random_device()
 void randomdev_init()
 {
     new random_device();
-    debug("random: <%s> initialized\n", random_adaptor->ident);
+    debugf("random: <%s> initialized\n", random_adaptor->ident);
 }
 
 }

--- a/drivers/virtio-pci-device.cc
+++ b/drivers/virtio-pci-device.cc
@@ -6,6 +6,7 @@
  */
 
 #include "drivers/virtio-pci-device.hh"
+#include <algorithm>
 
 namespace virtio {
 

--- a/drivers/virtio-scsi.cc
+++ b/drivers/virtio-scsi.cc
@@ -124,7 +124,7 @@ void scsi::add_lun(u16 target, u16 lun)
     dev->max_io_size = _config.max_sectors * VIRTIO_SCSI_SECTOR_SIZE;
     read_partition_table(dev);
 
-    debug("virtio-scsi: Add scsi device target=%d, lun=%-3d as %s, devsize=%lld\n", target, lun, dev_name.c_str(), devsize);
+    debugf("virtio-scsi: Add scsi device target=%d, lun=%-3d as %s, devsize=%lld\n", target, lun, dev_name.c_str(), devsize);
 }
 
 bool scsi::ack_irq()

--- a/drivers/vmw-pvscsi.cc
+++ b/drivers/vmw-pvscsi.cc
@@ -324,7 +324,7 @@ void pvscsi::add_lun(u16 target, u16 lun)
     dev->max_io_size = config.max_sectors * SCSI_SECTOR_SIZE;
     read_partition_table(dev);
 
-    debug("vmw-pvscsi: Add pvscsi device target=%d, lun=%-3d as %s, devsize=%lld\n", target, lun, dev_name.c_str(), devsize);
+    debugf("vmw-pvscsi: Add pvscsi device target=%d, lun=%-3d as %s, devsize=%lld\n", target, lun, dev_name.c_str(), devsize);
 }
 
 hw_driver* pvscsi::probe(hw_device* hw_dev)

--- a/drivers/xenfront-xenbus.cc
+++ b/drivers/xenfront-xenbus.cc
@@ -59,7 +59,7 @@ xenbus::xenbus()
     xs_attach(&_xenstore_device);
 
     xs_scanf(XST_NIL, "domid", "", NULL, "%d", &_domid);
-    _node_path = osv::sprintf("/local/domain/%d", _domid); 
+    _node_path = std::string("/local/domain/") + std::to_string(_domid);
 
     xenbusb_softc *xenbusb_scp = new xenbusb_softc;
     _bsd_dev.softc = xenbusb_scp;
@@ -82,7 +82,7 @@ void xenbus::wait_for_devices()
             _pending_devices.wait(&_children_mutex, 1000_ms);
         }
         for (auto device : _pending_children) {
-            debug("Device %s bringup failed\n", device->get_name());
+            debugf("Device %s bringup failed\n", device->get_name());
         }
     }
 }
@@ -163,7 +163,7 @@ void XENBUSB_ENUMERATE_TYPE(device_t _bus, const char *type)
         u_int dev_count;
         const char **devices;
 
-        std::string node = osv::sprintf("device/%d", type);
+        auto node = std::string("device/") + type;
 
         if (xs_directory(XST_NIL, bus->get_node_path().c_str(), node.c_str(), &dev_count, &devices)) {
             return;

--- a/fs/devfs/device.cc
+++ b/fs/devfs/device.cc
@@ -109,7 +109,7 @@ void read_partition_table(struct device *dev)
 	int index;
 
 	if (bread(dev, 0, &bp) != 0) {
-		debugf("read_partition_table failed for %s\n", dev->name);
+		debugff("read_partition_table failed for %s\n", dev->name);
 		return;
 	}
 

--- a/fs/procfs/procfs_vnops.cc
+++ b/fs/procfs/procfs_vnops.cc
@@ -71,28 +71,27 @@ static std::string procfs_stats()
     int zero = 0;
 
     return osv::sprintf("%d (%s) %c "
-                     "%d %d %d %d %d "
-                     "%lu %lu %lu %lu %lu "
-                     "%lu %lu %ld %ld "
-                     "%ld %ld %ld %ld "
-                     "%lu %lu "
-                     "%lu %lu "
-                     "%p %p %p %p %p "
-                     "%lu %lx %lu %lu "
-                     "%d %d %d "
-                     "%lu %d %d %d",
-                     pid, program_invocation_short_name, state,
-                     ppid, pgrp, session, tty, tpgid,
-                     flags, min_flt, cmin_flt, maj_flt, cmaj_flt,
-                     utime, stime, cutime, cstime,
-                     priority, nice, nlwp, nextalarm,
-                     start_time, vsize,
-                     rss, rss_rlim,
-                     start_code, end_code, start_stack, kstk_esp, kstk_eip,
-                     pending, blocked, sigign, sigcatch,
-                     wchan, zero, zero,
-                     exit_signal, cpu, rt_priority, policy
-                );
+                        "%d %d %d %d %d "
+                        "%lu %lu %lu %lu %lu "
+                        "%lu %lu %ld %ld "
+                        "%ld %ld %ld %ld "
+                        "%lu %lu "
+                        "%lu %lu "
+                        "%p %p %p %p %p "
+                        "%lu %lx %lu %lu "
+                        "%d %d %d "
+                        "%lu %d %d %d",
+                        pid, program_invocation_short_name, state,
+                        ppid, pgrp, session, tty, tpgid,
+                        flags, min_flt, cmin_flt, maj_flt, cmaj_flt,
+                        utime, stime, cutime, cstime,
+                        priority, nice, nlwp, nextalarm,
+                        start_time, vsize,
+                        rss, rss_rlim,
+                        start_code, end_code, start_stack, kstk_esp, kstk_eip,
+                        pending, blocked, sigign, sigcatch,
+                        wchan, zero, zero,
+                        exit_signal, cpu, rt_priority, policy);
 }
 
 static std::string procfs_status()
@@ -103,11 +102,10 @@ static std::string procfs_status()
     // information about cpus and memory intended for numa library
     // For details about the format read here: http://man7.org/linux/man-pages/man5/proc.5.html
     // and here: http://man7.org/linux/man-pages/man7/cpuset.7.html (mask and list format)
-    return osv::sprintf("Cpus_allowed:\t%s\n"
-                     "Cpus_allowed_list:\t0-%d\n"
-                     "Mems_allowed:\t00000001\n"
-                     "Mems_allowed_list:\t0\n",
-                     pseudofs::cpumap().c_str(), sched::cpus.size() - 1);
+    return std::string("Cpus_allowed:\t") + pseudofs::cpumap() + "\n"
+                       "Cpus_allowed_list:\t0-" + std::to_string(sched::cpus.size() - 1) + "\n"
+                       "Mems_allowed:\t00000001\n"
+                       "Mems_allowed_list:\t0\n";
 }
 
 static std::string procfs_mounts()

--- a/fs/pseudofs/pseudofs.cc
+++ b/fs/pseudofs/pseudofs.cc
@@ -186,12 +186,11 @@ string cpumap()
     uint32_t first_set = 0xffffffff >> (32 - cpu_count % 32);
     int remaining_cpus_sets = cpu_count / 32;
 
-    std::ostringstream os;
-    osv::fprintf(os, "%08x", first_set);
+    auto output = osv::sprintf("%08x", first_set);
     for (; remaining_cpus_sets > 0; remaining_cpus_sets--) {
-        osv::fprintf(os, ",%08x", 0xffffffff);
+        output += osv::sprintf(",%08x", 0xffffffff);
     }
-    return os.str();
+    return output;
 }
 
 string meminfo(const char* format)

--- a/fs/rofs/rofs_vfsops.cc
+++ b/fs/rofs/rofs_vfsops.cc
@@ -28,8 +28,6 @@
 #include <osv/debug.h>
 #include <osv/contiguous_alloc.hh>
 #include <fs/vfs/vfs_id.h>
-#include <iomanip>
-#include <iostream>
 
 static int rofs_mount(struct mount *mp, const char *dev, int flags, const void *data);
 static int rofs_sync(struct mount *mp);
@@ -219,12 +217,12 @@ rofs_unmount(struct mount *mp, int flags)
     delete rofs;
 
 #if defined(ROFS_DIAGNOSTICS_ENABLED)
-    debugf("ROFS: spent %.2f ms reading from disk\n", ((double) rofs_block_read_ms.load()) / 1000);
-    debugf("ROFS: read %d 512-byte blocks from disk\n", rofs_block_read_count.load());
-    debugf("ROFS: allocated %d 512-byte blocks of cache memory\n", rofs_block_allocated.load());
+    debugff("ROFS: spent %.2f ms reading from disk\n", ((double) rofs_block_read_ms.load()) / 1000);
+    debugff("ROFS: read %d 512-byte blocks from disk\n", rofs_block_read_count.load());
+    debugff("ROFS: allocated %d 512-byte blocks of cache memory\n", rofs_block_allocated.load());
     long total_cache_reads = rofs_cache_reads.load();
     double hit_ratio = total_cache_reads > 0 ? (rofs_cache_reads.load() - rofs_cache_misses.load()) / ((double)total_cache_reads) : 0;
-    debugf("ROFS: hit ratio is %.2f%%\n", hit_ratio * 100);
+    debugff("ROFS: hit ratio is %.2f%%\n", hit_ratio * 100);
 #endif
     return error;
 }

--- a/fs/sysfs/sysfs_vnops.cc
+++ b/fs/sysfs/sysfs_vnops.cc
@@ -8,7 +8,6 @@
 #include <unistd.h>
 #include <osv/mount.h>
 #include <mntent.h>
-#include <osv/printf.hh>
 #include <osv/mempool.hh>
 
 #include "fs/pseudofs/pseudofs.hh"
@@ -38,20 +37,20 @@ static string sysfs_free_page_ranges()
     stats::page_ranges_stats stats;
     stats::get_page_ranges_stats(stats);
 
-    std::ostringstream os;
+    std::string output("");
     if (stats.order[page_ranges_max_order].ranges_num) {
-        osv::fprintf(os, "huge %04d %012ld\n", //TODO: Show in GB/MB/KB
+        output += osv::sprintf("huge %04d %012ld\n", //TODO: Show in GB/MB/KB
            stats.order[page_ranges_max_order].ranges_num, stats.order[page_ranges_max_order].bytes);
     }
 
     for (int order = page_ranges_max_order; order--; ) {
         if (stats.order[order].ranges_num) {
-            osv::fprintf(os, "  %02d %04d %012ld\n",
+            output += osv::sprintf("  %02d %04d %012ld\n",
                order + 1, stats.order[order].ranges_num, stats.order[order].bytes);
         }
     }
 
-    return os.str();
+    return output;
 }
 
 static string sysfs_memory_pools()
@@ -59,18 +58,17 @@ static string sysfs_memory_pools()
     stats::pool_stats stats;
     stats::get_global_l2_stats(stats);
 
-    std::ostringstream os;
-    osv::fprintf(os, "global l2 (in batches) %02d %02d %02d %02d\n",
+    auto output = osv::sprintf("global l2 (in batches) %02d %02d %02d %02d\n",
         stats._max, stats._watermark_lo, stats._watermark_hi, stats._nr);
 
     for (auto cpu : sched::cpus) {
         stats::pool_stats stats;
         stats::get_l1_stats(cpu->id, stats);
-        osv::fprintf(os, "cpu %d l1 (in pages) %03d %03d %03d %03d\n",
+        output += osv::sprintf("cpu %d l1 (in pages) %03d %03d %03d %03d\n",
             cpu->id, stats._max, stats._watermark_lo, stats._watermark_hi, stats._nr);
     }
 
-    return os.str();
+    return output;
 }
 
 static int
@@ -91,7 +89,7 @@ sysfs_mount(mount* mp, const char *dev, int flags, const void* data)
 
     auto cpu = make_shared<pseudo_dir_node>(inode_count++);
     cpu->add("online", inode_count++, [] {
-       return osv::sprintf("0-%d", sched::cpus.size() - 1);
+       return std::string("0-") + std::to_string(sched::cpus.size() - 1);
     });
     system->add("cpu", cpu);
 

--- a/include/osv/debug.h
+++ b/include/osv/debug.h
@@ -33,7 +33,7 @@ typedef enum logger_severity_e {
 
 __BEGIN_DECLS
 void debug(const char *msg);
-void debugf(const char *, ...);
+void debugff(const char *, ...);
 void debug_write(const char *msg, size_t len);
 
 /* a lockless version that doesn't take any locks before printing,

--- a/include/osv/debug.hh
+++ b/include/osv/debug.hh
@@ -8,7 +8,6 @@
 #ifndef DEBUG_H
 #define DEBUG_H
 
-#include <iostream>
 #include <map>
 #include <string>
 #include <cstdarg>
@@ -92,16 +91,9 @@ extern "C" {
 void flush_debug_buffer();
 void enable_verbose();
 void debug(std::string str);
-template <typename... args>
-void debug(const char* fmt, args... as);
+void debugf(const char* fmt...);
 
 extern "C" {void readln(char *msg, size_t size); }
-
-template <typename... args>
-void debug(const char* fmt, args... as)
-{
-    debug(osv::sprintf(fmt, as...));
-}
 
 extern bool opt_power_off_on_abort;
 void abort(const char *fmt, ...) __attribute__((noreturn));

--- a/include/osv/printf.hh
+++ b/include/osv/printf.hh
@@ -8,46 +8,12 @@
 #ifndef PRINTF_HH_
 #define PRINTF_HH_
 
-#include <boost/format.hpp>
 #include <string>
-#include <sstream>
-#include <iostream>
 
 namespace osv {
 
-template <typename... args>
-std::ostream& fprintf(std::ostream& os, boost::format& fmt, args... as);
-
-template <typename... args>
-std::string sprintf(const char* fmt, args... as);
-
-// implementation
-
-template <>
-std::ostream& fprintf(std::ostream& os, boost::format& fmt);
-
-template <typename arg0, typename... args>
-inline
-std::ostream& fprintf(std::ostream& os, boost::format& fmt, const arg0& a0, args... as)
-{
-    return fprintf(os, fmt % a0, as...);
-}
-
-template <typename... args>
-std::ostream& fprintf(std::ostream& os, const char* fmt, args... as)
-{
-    boost::format f(fmt);
-    return fprintf(os, f, as...);
-}
-
-template <typename... args>
-std::string sprintf(const char* fmt, args... as)
-{
-    boost::format f(fmt);
-    std::ostringstream os;
-    fprintf(os, f, as...);
-    return os.str();
-}
+std::string sprintf(const char* fmt...);
+std::string vsprintf(const char* fmt, va_list ap);
 
 } // namespace osv
 

--- a/include/osv/stubbing.hh
+++ b/include/osv/stubbing.hh
@@ -18,12 +18,14 @@ static inline void debug_always(std::string str)
     fill_debug_buffer(str.c_str(), str.length());
     console::write(str.c_str(), str.length());
 }
-template <typename... args>
-static inline void debug_always(const char* fmt, args... as)
-{
-    debug_always(osv::sprintf(fmt, as...));
-}
 
+static inline void debug_always(const char* fmt...)
+{
+    va_list ap;
+    va_start(ap, fmt);
+    debug_always(osv::vsprintf(fmt, ap));
+    va_end(ap);
+}
 
 #define DO_ONCE(thing) do {				\
 	static bool _x;					\

--- a/libc/signal.cc
+++ b/libc/signal.cc
@@ -364,7 +364,7 @@ int kill(pid_t pid, int sig)
     unsigned sigidx = sig - 1;
     if (is_sig_dfl(signal_actions[sigidx])) {
         // Our default is to power off.
-        debug("Uncaught signal %d (\"%s\"). Powering off.\n",
+        debugf("Uncaught signal %d (\"%s\"). Powering off.\n",
                 sig, strsignal(sig));
         osv::poweroff();
     } else if(!is_sig_ign(signal_actions[sigidx])) {

--- a/libc/user.cc
+++ b/libc/user.cc
@@ -20,6 +20,7 @@
 
 #include <osv/debug.hh>
 #include "libc.hh"
+#include <cassert>
 
 uid_t getuid()
 {

--- a/loader.cc
+++ b/loader.cc
@@ -307,7 +307,7 @@ static void parse_options(int loader_argc, char** loader_argv)
             printf("Ignoring '--console' options after the first.");
         }
         opt_console = v.front();
-        debug("console=%s\n", opt_console);
+        debugf("console=%s\n", opt_console.c_str());
     }
 
     if (options::option_value_exists(options_values, "rootfs")) {
@@ -339,7 +339,7 @@ static void parse_options(int loader_argc, char** loader_argv)
 
     if (options::option_value_exists(options_values, "env")) {
         for (auto t : options::extract_option_values(options_values, "env")) {
-            debug("Setting in environment: %s\n", t);
+            debugf("Setting in environment: %s\n", t.c_str());
             putenv(strdup(t.c_str()));
         }
     }
@@ -432,7 +432,7 @@ static void load_zfs_library(std::function<void()> on_load_fun = nullptr)
            on_load_fun();
         }
     } else {
-        debug("Could not load and/or initialize %s.\n", libsolaris_path);
+        debugf("Could not load and/or initialize %s.\n", libsolaris_path);
     }
 }
 
@@ -573,7 +573,7 @@ void* do_main_thread(void *_main_args)
     }
 
     if (!opt_chdir.empty()) {
-        debug("Chdir to: '%s'\n", opt_chdir.c_str());
+        debugf("Chdir to: '%s'\n", opt_chdir.c_str());
 
         if (chdir(opt_chdir.c_str()) != 0) {
             perror("chdir");
@@ -635,7 +635,7 @@ void* do_main_thread(void *_main_args)
             std::string fn("/init/");
             fn += namelist[i]->d_name;
             auto cmdline = read_file(fn);
-            debug("Running from %s: %s\n", fn.c_str(), cmdline.c_str());
+            debugf("Running from %s: %s\n", fn.c_str(), cmdline.c_str());
             bool ok;
             auto new_commands = osv::parse_command_line(cmdline, ok);
             free(namelist[i]);
@@ -688,7 +688,7 @@ void* do_main_thread(void *_main_args)
 
     for (auto app : detached) {
         app->request_termination();
-        debug("Requested termination of %s, waiting...\n", app->get_command());
+        debugf("Requested termination of %s, waiting...\n", app->get_command().c_str());
     }
 
     application::join_all();
@@ -699,7 +699,7 @@ void main_cont(int loader_argc, char** loader_argv)
 {
     osv::firmware_probe();
 
-    debug("Firmware vendor: %s\n", osv::firmware_vendor().c_str());
+    debugf("Firmware vendor: %s\n", osv::firmware_vendor().c_str());
 
     elf::create_main_program();
 

--- a/modules/cloud-init/cassandra-module.cc
+++ b/modules/cloud-init/cassandra-module.cc
@@ -43,14 +43,14 @@ void cassandra_module::handle(const YAML::Node& doc)
     // Runtime config:
     dict.insert({"seeds", reflector_seeds(dict)});
 
-    debug("cloud-init: cassandra: Configuration:\n");
+    debugf("cloud-init: cassandra: Configuration:\n");
     for (auto&& kv : dict) {
-        debug("  '%s' => '%s'\n", kv.first, kv.second);
+        debugf("  '%s' => '%s'\n", kv.first.c_str(), kv.second.c_str());
     }
 
     ifstream input(template_filename);
     if (!input.is_open()) {
-        debug("cloud-init: cassandra: warning: '%s' template not found.\n", template_filename);
+        debugf("cloud-init: cassandra: warning: '%s' template not found.\n", template_filename);
         return;
     }
     template_source source(input);
@@ -58,7 +58,7 @@ void cassandra_module::handle(const YAML::Node& doc)
 
     ofstream output(config_filename, ios::out);
     if (!output.is_open()) {
-        debug("cloud-init: cassandra: warning: unable to open '%s'. Configuration failed.", config_filename);
+        debugf("cloud-init: cassandra: warning: unable to open '%s'. Configuration failed.", config_filename);
         return;
     }
     output << source.expand(dict);
@@ -85,7 +85,7 @@ Json cassandra_module::wait_for_seeds(map<string, string> dict)
 
     constexpr auto reflector_service = "reflector2.datastax.com";
 
-    debug("cloud-init: cassandra: Using %s as reflector.\n", reflector_service);
+    debugf("cloud-init: cassandra: Using %s as reflector.\n", reflector_service);
 
     string url = string("/reflector2.php")
                + "?indexid="           + dict["launch-index"]
@@ -113,7 +113,7 @@ Json cassandra_module::wait_for_seeds(map<string, string> dict)
             return response;
         }
         constexpr auto seconds = 5;
-        debug("No seeds, retrying in %d seconds ...\n", seconds);
+        debugf("No seeds, retrying in %d seconds ...\n", seconds);
         this_thread::sleep_for(chrono::seconds(seconds));
     }
 }

--- a/modules/cloud-init/cloud-init.cc
+++ b/modules/cloud-init/cloud-init.cc
@@ -259,7 +259,7 @@ void mount_module::handle(const YAML::Node& doc)
 void hostname_module::handle(const YAML::Node& doc)
 {
     auto hostname = doc.as<string>();
-    debug("cloudinit hostname: %s\n", hostname.c_str());
+    debugf("cloudinit hostname: %s\n", hostname.c_str());
     set_hostname_renew_dhcp(hostname);
 }
 
@@ -306,7 +306,7 @@ void osvinit::load_from_cloud(bool ignore_missing_source)
         throw osvinit_exception("Failed getting cloud-init information "+std::string(e.what()));
     }
     if (user_data.empty()) {
-        debug("User data is empty\n");
+        debugf("User data is empty\n");
         return;
     }
 

--- a/modules/cloud-init/main.cc
+++ b/modules/cloud-init/main.cc
@@ -59,19 +59,19 @@ static bool config_disk(const char* outfile) {
         std::vector<std::string> cmd = {"/usr/bin/iso-read.so", "-e", srcfile, "-o", outfile, disk};
         osv::run(cmd[0], cmd, &app_ret);
         if (app_ret != 0) {
-            debug("cloud-init: warning, %s exited with code %d (%s is not ISO image?)\n", cmd[0], app_ret, disk);
+            debugf("cloud-init: warning, %s exited with code %d (%s is not ISO image?)\n", cmd[0].c_str(), app_ret, disk);
             continue;
         }
         ret = stat(outfile, &sb);
         if (ret != 0) {
-            debug("cloud-init: disk %s, stat(%s) failed, errno=%d\n", disk, outfile, errno);
+            debugf("cloud-init: disk %s, stat(%s) failed, errno=%d\n", disk, outfile, errno);
             continue;
         }
         if ((sb.st_mode & S_IFMT) != S_IFREG) {
-            debug("cloud-init: disk %s, %s is not a file\n", disk, outfile);
+            debugf("cloud-init: disk %s, %s is not a file\n", disk, outfile);
             return false;
         }
-        debug("cloud-init: copied file %s -> %s from ISO image %s\n", srcfile, outfile, disk);
+        debugf("cloud-init: copied file %s -> %s from ISO image %s\n", srcfile, outfile, disk);
         return true;
     }
     return false;

--- a/runtime.cc
+++ b/runtime.cc
@@ -384,7 +384,7 @@ long sysconf(int name)
     case _SC_MINSIGSTKSZ: return MINSIGSTKSZ;
     case _SC_SIGSTKSZ: return SIGSTKSZ;
     default:
-        debug("sysconf(): stubbed for parameter %ld\n", name);
+        debugf("sysconf(): stubbed for parameter %ld\n", name);
         errno = EINVAL;
         return -1;
     }
@@ -441,7 +441,7 @@ int pclose(FILE *stream)
 
 void exit(int status)
 {
-    debug("program exited with status %ld\n", status);
+    debugf("program exited with status %ld\n", status);
     osv::shutdown();
 }
 

--- a/tests/misc-lfring.cc
+++ b/tests/misc-lfring.cc
@@ -46,12 +46,12 @@ public:
         delete thread2;
 
         bool success = true;
-        debug("Results:\n");
+        debugf("Results:\n");
         for (int i=0; i < max_random; i++) {
             unsigned pushed = _stats[0][i];
             unsigned popped = _stats[1][i];
 
-            debug("    value=%-08d pushed=%-08d popped=%-08d\n", i,
+            debugf("    value=%-08d pushed=%-08d popped=%-08d\n", i,
                 pushed, popped);
 
             if (pushed != popped) {
@@ -139,12 +139,12 @@ public:
         delete thread4;
 
         bool success = true;
-        debug("Results:\n");
+        debugf("Results:\n");
         for (int i=0; i < max_random; i++) {
             unsigned pushed = _stats[0][i] + _stats[1][i] + _stats[2][i];
             unsigned popped = _stats[3][i];
 
-            debug("    value=%-08d pushed=%-08d popped=%-08d\n", i,
+            debugf("    value=%-08d pushed=%-08d popped=%-08d\n", i,
                 pushed, popped);
 
             if (pushed != popped) {
@@ -193,7 +193,7 @@ s64 nanotime() {
 int main(int argc, char **argv)
 {
     // Test
-    debug("[~] Testing mpsc-queue:\n");
+    debugf("[~] Testing mpsc-queue:\n");
     test_mpsc_queue *t3 = new test_mpsc_queue();
     t3->init();
     s64 beg = nanotime();
@@ -202,30 +202,30 @@ int main(int argc, char **argv)
     delete t3;
     if (rc) {
         double dT = (double)(end-beg)/1000000000.0;
-        debug("[+] mpsc-queue test passed:\n");
-        debug("[+] duration: %.6fs\n", dT);
-        debug("[+] throughput: %.0f ops/s\n", (double)(test_mpsc_queue::elements_to_process*6)/dT);
+        debugf("[+] mpsc-queue test passed:\n");
+        debugf("[+] duration: %.6fs\n", dT);
+        debugf("[+] throughput: %.0f ops/s\n", (double)(test_mpsc_queue::elements_to_process*6)/dT);
     } else {
-        debug("[-] mpsc-queue failed\n");
+        debugf("[-] mpsc-queue failed\n");
         return 1;
     }
 
 
-    debug("[~] Testing spsc ringbuffer:\n");
+    debugf("[~] Testing spsc ringbuffer:\n");
     test_spsc_ring t1;
     beg = nanotime();
     rc = t1.run();
     end = nanotime();
     if (rc) {
         double dT = (double)(end-beg)/1000000000.0;
-        debug("[+] spsc test passed:\n");
-        debug("[+] duration: %.6fs\n", dT);
-        debug("[+] throughput: %.0f ops/s\n", (double)(test_spsc_ring::elements_to_process*2)/dT);
+        debugf("[+] spsc test passed:\n");
+        debugf("[+] duration: %.6fs\n", dT);
+        debugf("[+] throughput: %.0f ops/s\n", (double)(test_spsc_ring::elements_to_process*2)/dT);
     } else {
-        debug("[-] spsc test failed\n");
+        debugf("[-] spsc test failed\n");
         return 1;
     }
 
-    debug("[+] finished.\n");
+    debugf("[+] finished.\n");
     return 0;
 }

--- a/tests/misc-mutex.cc
+++ b/tests/misc-mutex.cc
@@ -10,6 +10,7 @@
 #include <osv/spinlock.h>
 #include <osv/clock.hh>
 #include <osv/rwlock.h>
+#include <iostream>
 
 #include <string.h>
 

--- a/tests/misc-zfs-arc.cc
+++ b/tests/misc-zfs-arc.cc
@@ -6,6 +6,7 @@
  */
 
 #include <osv/debug.hh>
+#define BOOST_LEXICAL_CAST_ASSUME_C_LOCALE 1
 
 #include "stat.hh"
 #include <assert.h>

--- a/tests/tst-app.cc
+++ b/tests/tst-app.cc
@@ -27,11 +27,11 @@ int child(std::string command, int argc, char const *argv[])
         latch termination_requested;
 
         app->on_termination_request([&] {
-            debug("Termination requested.\n");
+            debugf("Termination requested.\n");
             termination_requested.count_down();
         });
 
-        debug("Waiting for termination request...\n");
+        debugf("Waiting for termination request...\n");
         termination_requested.await();
         return 0;
     }
@@ -46,7 +46,7 @@ int child(std::string command, int argc, char const *argv[])
 
 void test_termination_request_before_callback_is_registerred()
 {
-    debug("%s\n", __FUNCTION__);
+    debugf("%s\n", __FUNCTION__);
 
     auto app = application::run({prog, WAIT_UNTIL_TERMINATION});
     app->request_termination();
@@ -56,7 +56,7 @@ void test_termination_request_before_callback_is_registerred()
 
 void test_termination_request_after_callback_is_registerred()
 {
-    debug("%s\n", __FUNCTION__);
+    debugf("%s\n", __FUNCTION__);
 
     auto app = application::run({prog, WAIT_UNTIL_TERMINATION});
     std::this_thread::sleep_for(std::chrono::milliseconds(50));
@@ -67,7 +67,7 @@ void test_termination_request_after_callback_is_registerred()
 
 void test_return_code_is_propagated()
 {
-    debug("%s\n", __FUNCTION__);
+    debugf("%s\n", __FUNCTION__);
 
     const int code = 123;
     auto app = application::run({prog, RETURN, std::to_string(code)});

--- a/tests/tst-condvar.cc
+++ b/tests/tst-condvar.cc
@@ -21,10 +21,10 @@ void assert_idle(condvar *c)
 
 int main(int argc, char **argv)
 {
-    debug("Running condition variable tests\n");
+    debugf("Running condition variable tests\n");
 
     // Test trivial single-thread tests
-    debug("test1\n");
+    debugf("test1\n");
     condvar cond = CONDVAR_INITIALIZER;
     assert_idle(&cond);
     // See that wake for condition variable nobody wait on do not cause havoc
@@ -33,7 +33,7 @@ int main(int argc, char **argv)
     assert_idle(&cond);
 
     // A basic two-thread test - one thread waits for the other
-    debug("test2\n");
+    debugf("test2\n");
     mutex m;
     int res=0;
     sched::thread *t1 = sched::thread::make([&cond,&m,&res] {
@@ -64,7 +64,7 @@ int main(int argc, char **argv)
     // and a second condition variable) another thread wakes them all
     // with wake_all or wake_one.
     constexpr int N = 50;
-    debug("test3, with %d threads\n", N);
+    debugf("test3, with %d threads\n", N);
     int ready = 0;
     condvar done = CONDVAR_INITIALIZER;
     sched::thread *threads[N];
@@ -103,7 +103,7 @@ int main(int argc, char **argv)
             done.wait(&m);
         }
         m.unlock();
-        debug("waking all\n");
+        debugf("waking all\n");
         m.lock();
         assert (ready >= N);
         cond.wake_all();
@@ -113,7 +113,7 @@ int main(int argc, char **argv)
             done.wait(&m);
         }
         m.unlock();
-        debug("waking one by one\n");
+        debugf("waking one by one\n");
         m.lock();
         assert (ready >= 2*N);
         m.unlock();
@@ -141,7 +141,7 @@ int main(int argc, char **argv)
     }
     assert_idle(&cond);
 
-    debug("Measuring unwaited wake_all (one thread): ");
+    debugf("Measuring unwaited wake_all (one thread): ");
     int iterations = 100000000;
     condvar cv;
     auto start = std::chrono::high_resolution_clock::now();
@@ -149,13 +149,13 @@ int main(int argc, char **argv)
         cv.wake_all();
     }
     auto end = std::chrono::high_resolution_clock::now();
-    debug ("%d ns\n", std::chrono::duration_cast<std::chrono::nanoseconds>
+    debugf("%d ns\n", std::chrono::duration_cast<std::chrono::nanoseconds>
         (end-start).count()/iterations);
 
 
     unsigned int nthreads = 2;
     if (sched::cpus.size() >= nthreads) {
-        debug("Measuring unwaited wake_all (two threads): ");
+        debugf("Measuring unwaited wake_all (two threads): ");
         iterations = 100000000;
         sched::thread *threads2[nthreads];
         std::atomic<u64> time(0);
@@ -175,10 +175,10 @@ int main(int argc, char **argv)
             threads2[i]->join();
             delete threads2[i];
         }
-        debug ("%d ns\n", time/iterations/nthreads);
+        debugf("%d ns\n", time/iterations/nthreads);
     }
 
 
-    debug("condvar tests succeeded\n");
+    debugf("condvar tests succeeded\n");
     return 0;
 }

--- a/tests/tst-fpu.cc
+++ b/tests/tst-fpu.cc
@@ -32,7 +32,7 @@ bool test()
             }
         }
     }
-    debug("3 -> %f\n", sins[3]);
+    debugf("3 -> %f\n", sins[3]);
     return !bad;
 }
 
@@ -69,7 +69,7 @@ int main(int ac, char **av)
     constexpr unsigned nr_threads = 16;
     std::vector<sched::thread*> threads;
 
-    debug("starting fpu test\n");
+    debugf("starting fpu test\n");
     std::atomic<int> tests{}, fails{};
     for (unsigned i = 0; i < nr_threads; ++i) {
         auto t = sched::thread::make([&] {

--- a/tests/tst-preempt.cc
+++ b/tests/tst-preempt.cc
@@ -17,7 +17,7 @@ namespace sched {
 
 int main(int argc, char **argv)
 {
-    debug("Running preemption tests\n");
+    debugf("Running preemption tests\n");
 
     // Test 1: check that new threads start preemptable, i.e., with
     // preempt_counter==0. We had a bug where we didn't zero the .tbss
@@ -30,6 +30,6 @@ int main(int argc, char **argv)
     t1->start();
     delete t1;
 
-    debug("Preemption tests succeeded\n");
+    debugf("Preemption tests succeeded\n");
 
 }

--- a/tests/tst-run.cc
+++ b/tests/tst-run.cc
@@ -15,7 +15,7 @@ static void report(bool ok, const char* msg)
 {
     ++tests;
     fails += !ok;
-    debug("%s: %s\n", (ok ? "PASS" : "FAIL"), msg);
+    debugf("%s: %s\n", (ok ? "PASS" : "FAIL"), msg);
 }
 
 extern "C" long gettid();

--- a/tests/tst-timer.hh
+++ b/tests/tst-timer.hh
@@ -32,20 +32,20 @@ public:
     {
         auto t1 = clock::get()->time();
         auto t2 = clock::get()->time();
-        debug("Timer test: clock@t1 %1%\n", t1);
-        debug("Timer test: clock@t2 %1%\n", t2);
+        debugf("Timer test: clock@t1 %ld\n", t1);
+        debugf("Timer test: clock@t2 %ld\n", t2);
 
         timespec ts = {};
         ts.tv_nsec = 100;
         t1 = clock::get()->time();
         nanosleep(&ts, nullptr);
         t2 = clock::get()->time();
-        debug("Timer test: nanosleep(100) -> %d\n", t2 - t1);
+        debugf("Timer test: nanosleep(100) -> %d\n", t2 - t1);
         ts.tv_nsec = 100000;
         t1 = clock::get()->time();
         nanosleep(&ts, nullptr);
         t2 = clock::get()->time();
-        debug("Timer test: nanosleep(100000) -> %d\n", t2 - t1);
+        debugf("Timer test: nanosleep(100000) -> %d\n", t2 - t1);
     }
 
     static const int max_testers = 5000;
@@ -68,7 +68,7 @@ public:
     // stress test the timer class
     void test2(void)
     {
-        debug("Starting stress test\n");
+        debugf("Starting stress test\n");
         for (int i=0; i<max_testers; i++) {
             _testers[i] = sched::thread::make([&] { this->stress_thread(); });
             _testers[i]->start();
@@ -79,7 +79,7 @@ public:
             _testers[i]->join();
             delete _testers[i];
         }
-        debug("End stress test\n");
+        debugf("End stress test\n");
     }
 
     sched::thread *_testers[max_testers];

--- a/tests/tst-tls.cc
+++ b/tests/tst-tls.cc
@@ -129,7 +129,7 @@ static void before_main(void) __attribute__((constructor));
 static void before_main(void)
 {
     report(v7 == 987UL, "v7 in init function", true);
-    report(v9 == 0, "v8 in init function", true);
+    report(v9 == 0, "v9 in init function", true);
 }
 #endif
 

--- a/tests/tst-tracepoint.cc
+++ b/tests/tst-tracepoint.cc
@@ -35,7 +35,7 @@ int main(int ac, char** av)
 {
     test_object obj;
     trace_1(10, 20);
-    debug("trace_1 signature: %s", signature_string(trace_1.signature()).c_str());
+    debugf("trace_1 signature: %s", signature_string(trace_1.signature()).c_str());
     assert(signature_string(trace_1.signature()) == "Iq");
     struct {
         u32 a0;


### PR DESCRIPTION
- reimplement some usage of `osv::sprintf()` by using `std::to_string()` instead

- eliminate `osv::fprintf*() `functions and replace most of their usages with new `osv::sprintf()`

- eliminate usage of `std::ostringstream` and `std::stringstream` in some cases by simple concatenation of `std::string`

- replace template-based `std::string sprintf(const char* fmt, args... as)` with new `std::string sprintf(const char* fmt...)`

- add `std::string vsprintf(const char* fmt, va_list ap)`

- replace `void debug(const char* fmt, args... as)` and its usages with new `void debugf(const char* fmt...)` that delegates to `osv::vsprintf()`

- rename the C version of `void debugf(const char *fmt, ...)` to `void debugff(const char *fmt, ...)` to avoid name collision and adjust references in the code

- add any missing headers

This is another commit to remove code that directly or indirectly depends on std::locale.

Ref #1335