### PR TITLE
make: generate default kernel config if missing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,11 @@ outlink = build/$(mode)
 outlink2 = build/last
 
 ifneq ($(MAKECMDGOALS),menuconfig)
+# Include the kernel configuration file if present, otherwise generate a default one
+ifeq (,$(wildcard $(out)/gen/config/kernel_conf.mk))
+    $(info Generating default kernel configuration file)
+    $(shell make -f conf/Makefile -j1 config 1>/dev/null)
+endif
 include $(out)/gen/config/kernel_conf.mk
 endif
 #

--- a/conf/Makefile
+++ b/conf/Makefile
@@ -29,7 +29,7 @@ endif
 quiet = $(if $V, $1, @echo " $2"; $1)
 
 out = build/$(mode).$(arch)
-default_config : $(out)/.config
+default_config: $(out)/.config
 
 .PHONY: override_dot_file
 ifneq (,$(conf_dot_file))


### PR DESCRIPTION
This patch fixes the main makefile to allow building the kernel using make directly instead of the build script.

To build kernel with default configuration:
```
make
```

To configure and then build kernel:
```
make menuconfig && make
```

Fixes #1344