### PR TITLE
support access to TLS variables located in dlopen-ed objects

### DIFF
--- a/modules/tests/Makefile
+++ b/modules/tests/Makefile
@@ -164,7 +164,8 @@ internal-api-tests := tst-app.so tst-async.so tst-bsd-evh.so \
 	tst-vfs.so tst-wait-for.so tst-without-namespace.so
 
 ifeq ($(arch),x64)
-tests += tst-mmx-fpu.so tst-tls-desc.so tst-tls-pie-desc.so libtls_desc.so
+tests += tst-mmx-fpu.so tst-tls-desc.so tst-tls-pie-desc.so libtls_desc.so \
+	tst-tls-pie-dlopen.so
 endif
 
 tests += testrunner.so
@@ -184,6 +185,7 @@ $(out)/tests/tst-tls.so: COMMON += -fuse-ld=bfd
 $(out)/tests/tst-tls-pie.so: COMMON += -fuse-ld=bfd
 $(out)/tests/tst-tls-desc.so: COMMON += -fuse-ld=bfd
 $(out)/tests/tst-tls-pie-desc.so: COMMON += -fuse-ld=bfd
+$(out)/tests/tst-tls-pie-dlopen.so: COMMON += -fuse-ld=bfd
 
 $(out)/tests/tst-dlfcn.so: COMMON += -rdynamic -ldl
 
@@ -196,7 +198,7 @@ $(out)/tests/tst-tls.so: \
 $(out)/tests/tst-tls-pie.o: CXXFLAGS:=$(subst -fPIC,-fpie,$(CXXFLAGS))
 $(out)/tests/tst-tls-pie.o: $(src)/tests/tst-tls.cc
 	$(makedir)
-	$(call quiet, $(CXX) $(CXXFLAGS) -c -o $@ $<, CXX tests/tst-tls-pie.cc)
+	$(call quiet, $(CXX) $(CXXFLAGS) -c -o $@ $<, CXX tests/tst-tls.cc => tests/tst-tls-pie.o)
 $(out)/tests/tst-tls-pie.so: \
 		$(out)/tests/tst-tls-pie.o \
 		$(out)/tests/libtls.so
@@ -206,7 +208,7 @@ $(out)/tests/tst-tls-pie.so: \
 $(out)/tests/tst-tls-desc.o: CXXFLAGS += -mtls-dialect=gnu2 -fPIC -D__SHARED_OBJECT__=1
 $(out)/tests/tst-tls-desc.o: $(src)/tests/tst-tls.cc
 	$(makedir)
-	$(call quiet, $(CXX) $(CXXFLAGS) -c -o $@ $<, CXX tests/tst-tls-desc.cc)
+	$(call quiet, $(CXX) $(CXXFLAGS) -c -o $@ $<, CXX tests/tst-tls.cc => tests/tst-tls-desc.0)
 $(out)/tests/tst-tls-desc.so: \
 		$(out)/tests/tst-tls-desc.o \
 		$(out)/tests/libtls_desc.so
@@ -216,7 +218,7 @@ $(out)/tests/tst-tls-desc.so: \
 $(out)/tests/tst-tls-pie-desc.o: CXXFLAGS += -mtls-dialect=gnu2 -fPIC -D__SHARED_OBJECT__=1
 $(out)/tests/tst-tls-pie-desc.o: $(src)/tests/tst-tls.cc
 	$(makedir)
-	$(call quiet, $(CXX) $(CXXFLAGS) -c -o $@ $<, CXX tests/tst-tls-pie-desc.cc)
+	$(call quiet, $(CXX) $(CXXFLAGS) -c -o $@ $<, CXX tests/tst-tls.cc => tests/tst-tls-pie-desc.o)
 $(out)/tests/tst-tls-pie-desc.so: \
 		$(out)/tests/tst-tls-pie-desc.o \
 		$(out)/tests/libtls_desc.so
@@ -227,6 +229,15 @@ $(out)/tests/libtls_desc.so: CXXFLAGS += -mtls-dialect=gnu2
 $(out)/tests/libtls_desc.so: $(src)/tests/libtls.cc
 	$(makedir)
 	$(call quiet, $(CXX) $(CXXFLAGS) $(LDFLAGS) -shared -o $@ $< $(LIBS), LD tests/libtls_desc.so)
+
+$(out)/tests/tst-tls-pie-dlopen.o: CXXFLAGS:=$(subst -fPIC,-fpie,$(CXXFLAGS)) -D__DLOPEN__=1
+$(out)/tests/tst-tls-pie-dlopen.o: $(src)/tests/tst-tls.cc
+	$(makedir)
+	$(call quiet, $(CXX) $(CXXFLAGS) -c -o $@ $<, CXX tests/tst-tls.cc => tests/tst-tls-pie-dlopen.o)
+$(out)/tests/tst-tls-pie-dlopen.so: \
+		$(out)/tests/tst-tls-pie-dlopen.o
+	$(makedir)
+	$(call quiet, cd $(out); $(CXX) $(CXXFLAGS) $(LDFLAGS) -export-dynamic -pthread -fpie -o $@ $< $(LIBS), LD tests/tst-tls-pie-dlopen.so)
 
 $(out)/tests/libtls_gold.so: COMMON += -fuse-ld=gold
 $(out)/tests/libtls_gold.so: $(out)/tests/libtls.o

--- a/tests/libtls.cc
+++ b/tests/libtls.cc
@@ -15,6 +15,7 @@ __thread int ex3 = 765;
 extern __thread int v1;
 extern __thread int v5;
 
+extern "C"
 void external_library()
 {
     // ex1 and ex3 get accessed by _tls_get_addr()


### PR DESCRIPTION
The original intention of this patch was to provide a unit test to verify the handling of TLS variables in `dlopen`-ed shared libraries.

This does not work on aarch64 because we do not support so-called dynamic TLS descriptors yet. On x64 this functionality should work in theory but I have found some small gaps and one important bug.

Firstly, to support `dlsym()` of TLS variables, we enhance the `obj::relocated_addr()` to handle `STT_TLS`.

Secondly, we fixed an important bug in the logic when setting up the so-called local-exec TLS. The `init_static_tls()` iterates over all ELF objects to identify if any of them use TLS and setup initial- or local-exec TLS accordingly. It turns out that if a PIE using local exec is relocated without any DT_NEEDED dependencies using TLS, dynamic linker never marks the object to have TLS (see `_static_tls` variable) and `init_static_tls()` will skip setting local exec. This is the exact scenario when `tst-tls-pie-dlopen.so` dlopen-s `libtsl.so`. To fix this, we tweak the `init_static_tls()` to handle the scenario where initial-exec is empty but local-exec is not. We also fix the `arch_relocate_rela()` to call `alloc_static_tls()` in the cases when the object is a dynamically linked executable - PIE.

Lastly, this patch modifies `tst-tls.cc` to support verifying access of TLS variables when libtls.so is dlopen-ed and variables are resolved using `dlsym()`.