### PR TITLE
aarch64: handle dynamic TLS descriptors

### DIFF
--- a/arch/aarch64/arch-cpu.hh
+++ b/arch/aarch64/arch-cpu.hh
@@ -33,7 +33,15 @@ struct arch_cpu {
     u64 mpid;    /* actual MPID as read from the cpu */
 };
 
+//This is an assembly-friendly descriptor of DTV stored in the _tls property
+//The _tls is a C++ std::vector
+struct dtv {
+    u64 last_index; //Index of the last TLS segment in _tls
+    char **first;   //Address of the 1st TLS segment
+};
+
 struct arch_thread {
+    struct dtv _dtv;
     char exception_stack[CONF_threads_default_exception_stack_size] __attribute__((aligned(16)));
 };
 

--- a/arch/aarch64/arch-switch.hh
+++ b/arch/aarch64/arch-switch.hh
@@ -159,6 +159,8 @@ void thread::setup_tcb()
         // TLS layout
         _app_runtime->app.lib()->copy_local_tls(kernel_tls);
     }
+
+    _tcb->dtv = &_arch._dtv;
 }
 
 void thread::free_tcb()
@@ -168,6 +170,12 @@ void thread::free_tcb()
 
 void thread::free_syscall_stack()
 {
+}
+
+void thread::update_dtv()
+{
+    _arch._dtv.last_index = _tls.size() - 1;
+    _arch._dtv.first = &_tls[0];
 }
 
 void thread_main_c(thread* t)

--- a/arch/aarch64/arch-tls.hh
+++ b/arch/aarch64/arch-tls.hh
@@ -15,8 +15,8 @@
 
 /* the structure (roughly) corresponds to the tcbhead_t in glibc */
 struct thread_control_block {
-    void *tls_base; /* dtv */
-    void *privat;   /* private */
+    void *tls_base; // Address of the per-thread static TLS block (kernel, pie, etc)
+    void *dtv;      // Address of the DTV (Dynamic Thread Vector)
 };
 
 #endif /* ARCH_TLS_HH */

--- a/arch/aarch64/tlsdesc.S
+++ b/arch/aarch64/tlsdesc.S
@@ -8,3 +8,78 @@
 __tlsdesc_static:
 	ldr x0,[x0,#8]
 	ret
+
+.global __tlsdesc_dynamic
+.type __tlsdesc_dynamic,@function
+__tlsdesc_dynamic:
+//FAST PATH
+        stp x1,x2,[sp, #-16]! // save the 4 registers we will be using in fast path
+        stp x3,x4,[sp, #-16]!
+
+        ldr x0,[x0,#8]        // p - pointer to the module_and_offset struct passed as an argument to this function
+        ldr x2,[x0]           // store p->module in x2
+        mrs x1,tpidr_el0
+        ldr x3,[x1,#8]        // point to the dtv address stored in thread_control_block (see arch-tls.hh)
+        ldr x4,[x3]           // load last_index - 1st field in the dtv struct x3 points to
+        cmp x4,x2             // compare last_index with p->module
+        b.lt 1f               // execute slow path to setup tls for p->module IF last_index < p->module
+        ldr x4,[x3,#8]        // load first - 2nd field in the dtv struct - address of 1st element of the _tls vector (see sched.hh)
+        lsl x2,x2,#3          // multiply p->module by 8 to get correct index of an entry with address of this module tls block
+        ldr x4,[x4,x2]        // load the address of this module tls block to x4
+        cmp x4,#0             // test if this module tls block has been setup for this thread
+        b.eq 1f               // execute slow path to setup tls for p->module IF x4 is 0
+                              // --- at this point this module TLS block for this thread has been setup
+2:      ldr x2,[x0,#8]        // load p->offset
+        add x0,x4,x2          // add p->offset to this module TLS block address and store in x0
+        sub x0,x0,x1          // subtract tpidr_el0 (stored in x1) per TLS descriptor contract and return it
+
+        ldp x3,x4,[sp],#16
+        ldp x1,x2,[sp],#16
+        ret
+
+//SLOW PATH
+1:      stp	x29, x30, [sp, #-48]!
+        mov     x29, sp
+
+        //Save all regular registers on the stack
+        stp x0, xzr, [sp, #-16]!
+
+        stp x1, x2, [sp, #-16]!
+        stp x3, x4, [sp, #-16]!
+        stp x5, x6, [sp, #-16]!
+        stp x7, x8, [sp, #-16]!
+        stp x9, x10, [sp, #-16]!
+        stp x11, x12, [sp, #-16]!
+        stp x13, x14, [sp, #-16]!
+        stp x15, x16, [sp, #-16]!
+        stp x17, x18, [sp, #-16]!
+        stp x19, x20, [sp, #-16]!
+        stp x21, x22, [sp, #-16]!
+        stp x23, x24, [sp, #-16]!
+        stp x25, x26, [sp, #-16]!
+        stp x27, x28, [sp, #-16]!
+
+        //The __tls_dynamic_setup will save all FPU registers as well
+        bl __tls_dynamic_setup
+
+        ldp x27, x28, [sp], #16
+        ldp x25, x26, [sp], #16
+        ldp x23, x24, [sp], #16
+        ldp x21, x22, [sp], #16
+        ldp x19, x20, [sp], #16
+        ldp x17, x18, [sp], #16
+        ldp x15, x16, [sp], #16
+        ldp x13, x14, [sp], #16
+        ldp x11, x12, [sp], #16
+        ldp x9, x10, [sp], #16
+        ldp x7, x8, [sp], #16
+        ldp x5, x6, [sp], #16
+        ldp x3, x4, [sp], #16
+        ldp x1, x2, [sp], #16
+
+        mov x4, x0            // put address of newly allocated TLS block into x4
+        ldp x0, xzr, [sp], #16
+
+        ldp x29, x30, [sp], #48
+
+        b 2b

--- a/arch/x64/arch-switch.hh
+++ b/arch/x64/arch-switch.hh
@@ -371,6 +371,10 @@ void* thread::get_syscall_stack_top()
     return _state._syscall_stack_descriptor.stack_top;
 }
 
+void thread::update_dtv()
+{
+}
+
 void thread_main_c(thread* t)
 {
     arch::irq_enable();

--- a/core/sched.cc
+++ b/core/sched.cc
@@ -1111,6 +1111,7 @@ thread::thread(std::function<void ()> func, attr attr, bool main, bool app)
             }
         }
     }
+    update_dtv();
 
     WITH_LOCK(thread_map_mutex) {
         if (!main) {
@@ -1611,7 +1612,8 @@ void* thread::setup_tls(ulong module, const void* tls_template,
         size_t init_size, size_t uninit_size)
 {
     _tls.resize(std::max(module + 1, _tls.size()));
-    _tls[module]  = new char[init_size + uninit_size];
+    _tls[module] = new char[init_size + uninit_size];
+    update_dtv();
     auto p = _tls[module];
     memcpy(p, tls_template, init_size);
     memset(p + init_size, 0, uninit_size);

--- a/include/osv/elf.hh
+++ b/include/osv/elf.hh
@@ -27,6 +27,11 @@
 /// PLT entries so OSv APIs like preempt_disable() can be used
 #define OSV_ELF_MLOCK_OBJECT() asm(".pushsection .note.osv-mlock, \"a\"; .long 0, 0, 0; .popsection")
 
+struct module_and_offset {
+    ulong module;
+    ulong offset;
+};
+
 /**
  * elf namespace
  */

--- a/include/osv/sched.hh
+++ b/include/osv/sched.hh
@@ -376,6 +376,7 @@ struct thread_switch_data {
    thread_state* new_thread_state = nullptr;
 };
 #endif
+
 /**
  * OSv thread
  */
@@ -733,6 +734,7 @@ private:
     void setup_tcb();
     void free_tcb();
     void free_syscall_stack();
+    void update_dtv();
     void complete() __attribute__((__noreturn__));
     template <class Action>
     inline void do_wake_with(Action action, unsigned allowed_initial_states_mask);

--- a/modules/tests/Makefile
+++ b/modules/tests/Makefile
@@ -142,7 +142,8 @@ tests := tst-pthread.so misc-ramdisk.so tst-vblk.so tst-bsd-evh.so \
 	tst-calloc.so tst-crypt.so tst-non-fpic.so tst-small-malloc.so \
 	tst-getopt.so tst-getopt-pie.so tst-non-pie.so tst-semaphore.so \
 	tst-elf-init.so tst-realloc.so tst-setjmp.so \
-	libtls.so libtls_gold.so tst-tls.so tst-tls-gold.so tst-tls-pie.so \
+	libtls.so libtls_gold.so lib-misc-tls.so tst-tls.so \
+	tst-tls-gold.so tst-tls-pie.so tst-tls-pie-dlopen.so \
 	tst-sigaction.so tst-syscall.so tst-ifaddrs.so tst-getdents.so \
 	tst-netlink.so misc-zfs-io.so misc-zfs-arc.so tst-pthread-create.so \
 	misc-futex-perf.so misc-syscall-perf.so tst-brk.so tst-reloc.so \
@@ -164,8 +165,7 @@ internal-api-tests := tst-app.so tst-async.so tst-bsd-evh.so \
 	tst-vfs.so tst-wait-for.so tst-without-namespace.so
 
 ifeq ($(arch),x64)
-tests += tst-mmx-fpu.so tst-tls-desc.so tst-tls-pie-desc.so libtls_desc.so \
-	tst-tls-pie-dlopen.so
+tests += tst-mmx-fpu.so tst-tls-desc.so tst-tls-pie-desc.so libtls_desc.so
 endif
 
 tests += testrunner.so

--- a/tests/lib-misc-tls.cc
+++ b/tests/lib-misc-tls.cc
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2025 Waldemar Kozaczuk
+ *
+ * This work is open source software, licensed under the terms of the
+ * BSD license as described in the LICENSE file in the top-level directory.
+ */
+
+__thread int var_lib_tls;
+
+extern "C"
+void external_library(int N)
+{
+    for (register int i = 0; i < N; i++) {
+        // To force gcc to not optimize this loop away
+        asm volatile("" : : : "memory");
+        ++var_lib_tls;
+    }
+}

--- a/tests/misc-tls.cc
+++ b/tests/misc-tls.cc
@@ -17,6 +17,8 @@
 
 #include <chrono>
 #include <iostream>
+#include <dlfcn.h>
+#include <cassert>
 
 __thread int var_tls;
 int var_global;
@@ -44,5 +46,17 @@ int main()
     sec = end - start;
     std::cout << "var_tls iteration (ns): " << (sec.count() / N / 1e-9) << "\n";
 
+    auto handle = dlopen("/tests/lib-misc-tls.so", RTLD_NOW);
+    assert(handle);
+    void (*external_library)(int) = reinterpret_cast<void(*)(int)>(dlsym(handle, "external_library"));
+    assert(external_library);
+
+    start = std::chrono::system_clock::now();
+    external_library(N);
+    end = std::chrono::system_clock::now();
+    sec = end - start;
+    std::cout << "var_lib_tls iteration (ns): " << (sec.count() / N / 1e-9) << "\n";
+
+    dlclose(handle);
     return 0;
 }

--- a/tests/tst-tls.cc
+++ b/tests/tst-tls.cc
@@ -111,7 +111,6 @@ int main(int argc, char** argv)
     report(ex2 == 433, "ex2 modified");
     report(ex3 == 766, "ex3 modified");
 #endif
-    //printf("Before FAIL: v1:%d, v2:%d\n", v1, v5);
     report(v1 == 124, "v1 modified");
     report(v5 == 568, "v5 modified");
 


### PR DESCRIPTION
Currently, the aarch64 port only supports so-called static TLS descriptors. This means that thread local variables in the application executable and libraries can be accessed as long as the ELF objects they are in are relocated during the initial dynamic linker loading phase. In other words, they are located in the memory blocks allocated as part of the so-called static TLS block.

Now, some applications, like java, dynamically open their libraries (using dlopen()), and on aarch64 the TLS variables must be accessed using so-called dynamic TLS descriptors. On x86_64 such dynamic access is supported by `__tls_get_addr()`, but on aarch64 the default is to use TLS descriptors (see this paper for details - https://www.fsfla.org/~lxoliva/writeups/TLS/paper-lk2006.pdf)

To that extent, this patch implements the necessary changes to the logic of handling the `R_AARCH64_TLSDESC` relocations. Specifically, we modify the `object::arch_relocate_tls_desc()` to detect if we need to use dynamic or static TLS descriptor. If the former, we setup the relocation entry to use new `__tlsdesc_dynamic` resolver function and a pointer to a module_and_offset struct holding module index and TLS offset. The address of the module_and_offset will be passed as a sole argument to the resolver function when code accessing the relevant thread local variable is run.

We also add the implementation of the `__tlsdesc_dynamic` resolver function in assembly (see tlsdesc.s). In essence, it implements the fast path - when TLS block has been already setup for given thread, and a slow path - when TLS block has been already setup. The slow path calls new function - `__tls_dynamic_setup` - that allocates new TLS block. In order to access an address of the corresponding TLS block from assembly, we define simple DTV descriptor (see arch/aarch/arch-cpu.hh) that points to the `thread::_tls` variable of type `std::vector`.

Finally, we modify the misc-tls.cc to measure the performance of the dynamic TLS access when a variable is located in the `dlopen()`-ed shared library.

Based on this test run of the Apple M2 Mac Mini, the dynamic TLS access is ~50% slower than the static one:

```
OSv v0.57.0-276-g8e57effc
eth0: 192.168.122.15
Booted up in 20.64 ms
Cmdline: /tests/misc-tls.so
var_global iteration (ns): 2.09624
var_tls iteration (ns): 1.79472
var_lib_tls iteration (ns): 2.92301
```

Fixes #1350