### PR TITLE
aarch64: do not enable interrupts before entering low-power standby state

### DIFF
--- a/arch/aarch64/processor.hh
+++ b/arch/aarch64/processor.hh
@@ -42,8 +42,13 @@ inline void irq_disable_notrace()
 }
 
 inline void wait_for_interrupt() {
-    irq_enable();
-    wfi();
+    // Must be called when interrupts are disabled
+    // Perform full system Data Synchronization Barrier
+    // Enter low power 'Wait For Interrupt' mode
+    // On exit from 'Wait For Interrupt' mode enable interrupts
+    // Put the instruction barrier between 'wfi' and 'msr' to enforce
+    // they are executed in this order
+    asm volatile( "dsb sy; wfi; isb; msr daifclr, #2; " ::: "memory");
 }
 
 inline void halt_no_interrupts() {


### PR DESCRIPTION
This patch fixes the bug described by #1354 where you can find more details.

In essence, we change the `arch::wait_for_interrupt()` called by `cpu::do_idle()` to reverse the order of the `wfi` instruction and the `msr daifclr, #2` that enables interrupts. As a result, when `arch::wait_for_interrupt()` is called, the following happens in this order:
- perform full system Data Synchronization Barrier
- enter low power 'Wait For Interrupt' mode
- execute the instruction barrier between 'wfi' and 'msr' to ensure they are executed in this order
- on exit from 'Wait For Interrupt' mode enable interrupts

This change guarantees that interrupts are not prematurely consumed before cpu enters the low-powered "wait for interrupt" mode. Instead, we let interrupts wake the cpu when in such mode and follow by enabling interrupts.

Per the ARM Cortex-M Programming Guide to Memory Barrier Instructions document: "A DSB should be used to ensure that there are no outstanding memory transactions prior to executing the WFI or WFE instruction."

Fixes #1354