### PR TITLE
aarch64: support detecting and allocating msix bar

### DIFF
--- a/arch/aarch64/pci.cc
+++ b/arch/aarch64/pci.cc
@@ -30,8 +30,8 @@ static bool ecam;
  * QEMU silently discards programming the BARs to address zero.
  * Linux seems to skip the whole first page on ARM, so we do the same.
  */
-static u64 pci_io_off = 0x1000;
-static u64 pci_mem_off = 0;
+static u64 pci_io_next = 0x1000;
+static u64 pci_mem_next = 0;
 
 /* this maps PCI addresses as returned by build_config_address
  * to platform IRQ numbers. */
@@ -76,6 +76,7 @@ void set_pci_mem(u64 addr, size_t len)
 {
     pci_mem_base = (char *)addr;
     pci_mem_len = len;
+    pci_mem_next = addr;
 }
 
 u64 get_pci_mem(size_t *len)
@@ -120,23 +121,46 @@ static int get_pci_irq_from_bdfp(u32 bdfp)
     return irq_id;
 }
 
-u32 pci::bar::arch_add_bar(u32 val)
+u32 pci::function::arch_add_bar(u32 val, u32 pos, bool is_mmio, bool is_64, u64 addr_size)
 {
-    u64 *off = _is_mmio ? &pci_mem_off : &pci_io_off;
-    u64 addr = _is_mmio ? (u64)pci_mem_base + pci_mem_off : *off;
-
-    *off += _addr_size;
-    *off = align_up(*off, (size_t)16);
-
-    val &= _is_mmio ? ~pci::bar::PCI_BAR_MEM_ADDR_LO_MASK : ~pci::bar::PCI_BAR_PIO_ADDR_MASK;
-    val |= align_down(addr, (size_t)16);
-
-    _dev->pci_writel(_pos, val);
-
-    if (_is_64) {
-        _dev->pci_writel(_pos + 4, addr >> 32);
+    //Read pre-allocated address if any
+    u64 addr_64 = val & (is_mmio ? pci::function::PCI_BAR_MEM_ADDR_LO_MASK : pci::function::PCI_BAR_PIO_ADDR_MASK);
+    if (is_64) {
+        u32 addr_hi = pci_readl(pos + 4);
+        addr_64 |= ((u64)addr_hi << 32);
     }
 
+    //If address has not been alocated by firmware, then allocate it
+    if (!addr_64) {
+        assert(is_mmio ? pci_mem_next : pci_io_next);
+        addr_64 = is_mmio ? pci_mem_next : pci_io_next;
+
+        //According to the "Address and size of the BAR" in
+        //https://wiki.osdev.org/PCI#Base_Address_Registers
+        //which reads this: "The BAR register is naturally aligned and
+        //as such you can only modify the bits that are set. For example,
+        //if a device utilizes 16 MB it will have BAR0 filled with 0xFF000000
+        //(0x1000000 after decoding) and you can only modify the upper 8-bits."
+        //it can be implied that the bar has to be aligned to the maximum
+        //of its size and 16
+        size_t bar_size = std::max((size_t)16, (size_t)addr_size);
+        addr_64 = align_up(addr_64, bar_size);
+        if (is_mmio) {
+            pci_mem_next = addr_64 + bar_size;
+        } else {
+            pci_io_next = addr_64 + bar_size;
+        }
+
+        val |= (u32)addr_64;
+        pci_writel(pos, val);
+
+        if (is_64) {
+            pci_writel(pos + 4, addr_64 >> 32);
+        }
+    }
+
+    pci_d("arch_add_bar(): pos:%d, val:%x, mmio:%d, addr_64:%lx, addr_size:%lx",
+        pos, val, is_mmio, addr_64, addr_size);
     return val;
 }
 

--- a/arch/x64/pci.cc
+++ b/arch/x64/pci.cc
@@ -72,7 +72,7 @@ void write_pci_config_byte(u8 bus, u8 slot, u8 func, u8 offset, u8 val)
     outb(val, PCI_CONFIG_DATA + (offset & 0x03));
 }
 
-u32 pci::bar::arch_add_bar(u32 val)
+u32 pci::function::arch_add_bar(u32 val, u32 pos, bool is_mmio, bool is_64, u64 addr_size)
 {
     /* nothing to do on X86 since firmware already sets to sane values.
      * why is this not available on other archs (ARM) as well? Damn.

--- a/drivers/pci-device.cc
+++ b/drivers/pci-device.cc
@@ -38,18 +38,12 @@ namespace pci {
         function::enable_bars_decode(true, true);
 
         while (pos <= PCI_CFG_BAR_6) {
-            u32 bar_v = pci_readl(pos);
-
-            if (bar_v == 0) {
+            bar *pbar = this->add_bar(idx++, pos);
+            if (pbar) {
+                pos += pbar->is_64() ? idx++, 8 : 4;
+            } else {
                 pos += 4;
-                idx++;
-                continue;
             }
-
-            bar * pbar = new bar(this, pos);
-            add_bar(idx++, pbar);
-
-            pos += pbar->is_64() ? idx++, 8 : 4;
         }
 
         return true;


### PR DESCRIPTION
This patch fixes three issues in the pci logic in the aarch64 port to support detecting and allocating msix bar:

- detect valid bars using its size (non-zero) instead of the value
- align the allocated bar address to its size
- detect pre-allocated bars

Firstly, on aarch64, unlike x86_64, the PCI BAR address is often not allocated (qemu virt). The current logic in `device::parse_pci_config()` skips any bars whose value is 0. This, unfortunately, prevents it from detecting msix bars with value 0. In essence, when an address is not allocated, only the bits 3-1 may be set for mmio bars. This means that 0 is a legitimate value and indicates a non-prefetchable 32-bits wide bar (see https://wiki.osdev.org/PCI#Base_Address_Registers). So on aarch64 at least we need to read the bar size to detect if it is present. To accommodate it, we refactor the device::parse_pci_config() and move most of the logic from bar constructor to the function::add_bar().

Secondly, when allocating a bar, its address needs to be aligned to its size. This, unfortunately, is not explicitly specified anywhere to best of my knowledge but can be deduced from this in https://wiki.osdev.org/PCI#Base_Address_Registers: "The BAR register is naturally aligned and as such you can only modify the bits that are set. For example, if a device utilizes 16 MB it will have BAR0 filled with 0xFF000000 (0x1000000 after decoding) and you can only modify the upper 8-bits."
To accommodate this requirement, we rework the arch_add_bar() to properly allocate and align the address.

Thirdly, on some aarch64 platforms like graviton, the pci bars may be pre-allocated in which case the `function::arch_add_bar()` needs to be adjusted to account for this and skip allocation in such case.

Refers #1088