### PR TITLE
msi: extract arch-agnostic logic into a common file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -901,6 +901,7 @@ drivers += drivers/pci-generic.o
 drivers += drivers/pci-device.o
 drivers += drivers/pci-function.o
 drivers += drivers/pci-bridge.o
+drivers += drivers/msi.o
 endif
 drivers += drivers/driver.o
 

--- a/arch/aarch64/exceptions.cc
+++ b/arch/aarch64/exceptions.cc
@@ -58,6 +58,17 @@ void interrupt_table::disable_irq(int id)
     gic::gic->mask_irq(id);
 }
 
+unsigned interrupt_table::register_handler(std::function<void ()> handler)
+{
+    //TODO: Implement it
+    return 0;
+}
+
+void interrupt_table::unregister_handler(unsigned vector)
+{
+    //TODO: Implement it
+}
+
 void interrupt_table::register_interrupt(interrupt *interrupt)
 {
     WITH_LOCK(_lock) {

--- a/arch/aarch64/exceptions.hh
+++ b/arch/aarch64/exceptions.hh
@@ -50,6 +50,9 @@ public:
     void register_interrupt(interrupt *interrupt);
     void unregister_interrupt(interrupt *interrupt);
 
+    unsigned register_handler(std::function<void ()> handler);
+    void unregister_handler(unsigned vector);
+
     /* invoke_interrupt returns false if unhandled */
     bool invoke_interrupt(unsigned int id);
 

--- a/arch/aarch64/msi.cc
+++ b/arch/aarch64/msi.cc
@@ -1,46 +1,35 @@
 /*
+ * Copyright (C) 2013 Cloudius Systems, Ltd.
  * Copyright (C) 2015 Huawei Technologies Duesseldorf GmbH
+ * Copyright (C) 2025 Waldemar Kozaczuk
  *
  * This work is open source software, licensed under the terms of the
  * BSD license as described in the LICENSE file in the top-level directory.
  */
 
-/* skeleton of MSI, not functional. */
-
 #include <osv/msi.hh>
+#include <osv/sched.hh>
+#include "gic-common.hh"
 
-msix_vector::msix_vector(pci::function *dev) {}
-msix_vector::~msix_vector() {}
-pci::function *msix_vector::get_pci_function(void) { return nullptr; }
-unsigned msix_vector::get_vector(void) { return 0; }
-void msix_vector::msix_unmask_entries(void) {}
-void msix_vector::msix_mask_entries(void) {}
-void msix_vector::add_entryid(unsigned entry_id) {}
-void msix_vector::interrupt(void) {}
-void msix_vector::set_handler(std::function<void ()> handler) {}
-void msix_vector::set_affinity(unsigned apic_id) {}
+using namespace pci;
 
-interrupt_manager::interrupt_manager(pci::function *dev) {}
-interrupt_manager::~interrupt_manager() {}
-
-bool interrupt_manager::easy_register(std::initializer_list<msix_binding> b)
+void msix_vector::set_affinity(sched::cpu *cpu)
 {
-    return false;
+    //TODO: Implement it
 }
-void interrupt_manager::easy_unregister() {}
 
-std::vector<msix_vector *> interrupt_manager::request_vectors(unsigned n) {
-    return _easy_vectors;
-}
-void interrupt_manager::free_vectors(const std::vector<msix_vector *> &v) {}
-bool interrupt_manager::assign_isr(msix_vector *, std::function<void ()> h)
+interrupt_manager::interrupt_manager(pci::function* dev)
+    : _dev(dev)
 {
-    return false;
+    //TODO: Implement it
 }
-bool interrupt_manager::setup_entry(unsigned entry_id, msix_vector *vector)
+
+interrupt_manager::~interrupt_manager()
 {
-    return false;
 }
-bool interrupt_manager::unmask_interrupts(const std::vector<msix_vector *> &v) {
-    return false;
+
+bool interrupt_manager::setup_entry(unsigned entry_id, msix_vector* msix)
+{
+    //TODO: Implement it
+    return (true);
 }

--- a/arch/x64/msi.cc
+++ b/arch/x64/msi.cc
@@ -7,78 +7,15 @@
 
 #include <stddef.h>
 #include <osv/msi.hh>
-#include <osv/trace.hh>
+#include <osv/sched.hh>
 #include "apic.hh"
-
-TRACEPOINT(trace_msix_interrupt, "vector=0x%02x", unsigned);
-TRACEPOINT(trace_msix_migrate, "vector=0x%02x apic_id=0x%x",
-                               unsigned, unsigned);
 
 using namespace pci;
 using namespace processor;
 
-msix_vector::msix_vector(pci::function* dev)
-    : _dev(dev)
+void msix_vector::set_affinity(sched::cpu *cpu)
 {
-    _vector = idt.register_handler([this] { interrupt(); });
-}
-
-msix_vector::~msix_vector()
-{
-    idt.unregister_handler(_vector);
-}
-
-pci::function* msix_vector::get_pci_function(void)
-{
-    return (_dev);
-}
-
-unsigned msix_vector::get_vector(void)
-{
-    return (_vector);
-}
-
-void msix_vector::msix_unmask_entries(void)
-{
-    for (auto entry_id : _entryids) {
-        if (_dev->is_msix()) {
-            _dev->msix_unmask_entry(entry_id);
-        } else {
-            _dev->msi_unmask_entry(entry_id);
-        }
-    }
-}
-
-void msix_vector::msix_mask_entries(void)
-{
-    for (auto entry_id : _entryids) {
-        if (_dev->is_msix()) {
-            _dev->msix_mask_entry(entry_id);
-        } else {
-            _dev->msi_mask_entry(entry_id);
-        }
-    }
-}
-
-void msix_vector::set_handler(std::function<void ()> handler)
-{
-    _handler = handler;
-}
-
-void msix_vector::add_entryid(unsigned entry_id)
-{
-    _entryids.push_back(entry_id);
-}
-
-void msix_vector::interrupt(void)
-{
-    trace_msix_interrupt(_vector);
-    _handler();
-}
-
-void msix_vector::set_affinity(unsigned apic_id)
-{
-    msi_message msix_msg = apic->compose_msix(_vector, apic_id);
+    msi_message msix_msg = apic->compose_msix(_vector, cpu->arch.apic_id);
     for (auto entry_id : _entryids) {
         _dev->msix_write_entry(entry_id, msix_msg._addr, msix_msg._data);
     }
@@ -91,136 +28,6 @@ interrupt_manager::interrupt_manager(pci::function* dev)
 
 interrupt_manager::~interrupt_manager()
 {
-
-}
-
-/**
- * Changes the affinity of the MSI-X vector to the same CPU where its service
- * routine thread is bound and then wakes that thread.
- *
- * @param current The CPU to which the MSI-X vector is currently bound
- * @param v MSI-X vector handle
- * @param t interrupt service routine thread
- */
-static inline void set_affinity_and_wake(
-    sched::cpu*& current, msix_vector* v, sched::thread* t)
-{
-    auto cpu = t->get_cpu();;
-
-    if (cpu != current) {
-
-        //
-        // According to PCI spec chapter 6.8.3.5 the MSI-X table entry may be
-        // updated only if the entry is masked and the new values are promissed
-        // to be read only when the entry is unmasked.
-        //
-        v->msix_mask_entries();
-
-        std::atomic_thread_fence(std::memory_order_seq_cst);
-
-        current = cpu;
-        trace_msix_migrate(v->get_vector(), cpu->arch.apic_id);
-        v->set_affinity(cpu->arch.apic_id);
-
-        std::atomic_thread_fence(std::memory_order_seq_cst);
-
-        v->msix_unmask_entries();
-    }
-
-    t->wake_with_irq_disabled();
-}
-
-bool interrupt_manager::easy_register(std::initializer_list<msix_binding> bindings)
-{
-    unsigned n = bindings.size();
-
-    std::vector<msix_vector*> assigned = request_vectors(n);
-
-    if (assigned.size() != n) {
-        free_vectors(assigned);
-        return (false);
-    }
-
-    // Enable the device msix capability,
-    // masks all interrupts...
-
-    if (_dev->is_msix()) {
-        _dev->msix_enable();
-    } else {
-        _dev->msi_enable();
-    }
-
-    int idx=0;
-
-    for (auto binding : bindings) {
-        msix_vector* vec = assigned[idx++];
-        auto isr = binding.isr;
-        auto t = binding.t;
-
-        bool assign_ok;
-
-        if (t) {
-            sched::cpu* current = nullptr;
-            assign_ok =
-                assign_isr(vec,
-                    [=]() mutable {
-                                    if (isr)
-                                        isr();
-                                    set_affinity_and_wake(current, vec, t);
-                                  });
-        } else {
-            assign_ok = assign_isr(vec, [=]() { if (isr) isr(); });
-        }
-
-        if (!assign_ok) {
-            free_vectors(assigned);
-            return false;
-        }
-        bool setup_ok = setup_entry(binding.entry, vec);
-        if (!setup_ok) {
-            free_vectors(assigned);
-            return false;
-        }
-    }
-
-    // Save reference for assigned vectors
-    _easy_vectors = assigned;
-    unmask_interrupts(assigned);
-
-    return (true);
-}
-
-void interrupt_manager::easy_unregister()
-{
-    free_vectors(_easy_vectors);
-    _easy_vectors.clear();
-}
-
-std::vector<msix_vector*> interrupt_manager::request_vectors(unsigned num_vectors)
-{
-    std::vector<msix_vector*> results;
-    unsigned num_entries;
-
-    if (_dev->is_msix()) {
-        num_entries = _dev->msix_get_num_entries();
-    } else {
-        num_entries = _dev->msi_get_num_entries();
-    }
-
-    auto num = std::min(num_vectors, num_entries);
-
-    for (unsigned i = 0; i < num; ++i) {
-        results.push_back(new msix_vector(_dev));
-    }
-
-    return (results);
-}
-
-bool interrupt_manager::assign_isr(msix_vector* vector, std::function<void ()> handler)
-{
-    vector->set_handler(handler);
-
-    return (true);
 }
 
 bool interrupt_manager::setup_entry(unsigned entry_id, msix_vector* msix)
@@ -243,21 +50,5 @@ bool interrupt_manager::setup_entry(unsigned entry_id, msix_vector* msix)
     }
 
     msix->add_entryid(entry_id);
-    return (true);
-}
-
-void interrupt_manager::free_vectors(const std::vector<msix_vector*>& vectors)
-{
-    for (auto msix : vectors) {
-        delete msix;
-    }
-}
-
-bool interrupt_manager::unmask_interrupts(const std::vector<msix_vector*>& vectors)
-{
-    for (auto msix : vectors) {
-        msix->msix_unmask_entries();
-    }
-
     return (true);
 }

--- a/bsd/sys/dev/ena/ena.cc
+++ b/bsd/sys/dev/ena/ena.cc
@@ -1251,7 +1251,7 @@ ena_request_io_irq(struct ena_adapter *adapter)
 		//to re-pin the interrupt vector
 		auto cpu = idx % sched::cpus.size();
 		std::atomic_thread_fence(std::memory_order_seq_cst);
-		vec->set_affinity(sched::cpus[cpu]->arch.apic_id);
+		vec->set_affinity(sched::cpus[cpu]);
 		std::atomic_thread_fence(std::memory_order_seq_cst);
 
 		ena_log(pdev, INFO, "pinned MSIX vector on queue %d - cpu %d\n", idx, cpu);

--- a/drivers/msi.cc
+++ b/drivers/msi.cc
@@ -1,0 +1,225 @@
+/*
+ * Copyright (C) 2013 Cloudius Systems, Ltd.
+ * Copyright (C) 2025 Waldemar Kozaczuk
+ *
+ * This work is open source software, licensed under the terms of the
+ * BSD license as described in the LICENSE file in the top-level directory.
+ */
+
+#include <stddef.h>
+#include <osv/msi.hh>
+#include <osv/trace.hh>
+
+TRACEPOINT(trace_msix_interrupt, "vector=0x%02x", unsigned);
+TRACEPOINT(trace_msix_migrate, "vector=0x%02x cpu_id=0x%x",
+                               unsigned, unsigned);
+
+using namespace pci;
+using namespace processor;
+
+msix_vector::msix_vector(pci::function* dev)
+    : _dev(dev)
+{
+    _vector = idt.register_handler([this] { interrupt(); });
+}
+
+msix_vector::~msix_vector()
+{
+    idt.unregister_handler(_vector);
+}
+
+pci::function* msix_vector::get_pci_function(void)
+{
+    return (_dev);
+}
+
+unsigned msix_vector::get_vector(void)
+{
+    return (_vector);
+}
+
+void msix_vector::msix_unmask_entries(void)
+{
+    for (auto entry_id : _entryids) {
+        if (_dev->is_msix()) {
+            _dev->msix_unmask_entry(entry_id);
+        } else {
+            _dev->msi_unmask_entry(entry_id);
+        }
+    }
+}
+
+void msix_vector::msix_mask_entries(void)
+{
+    for (auto entry_id : _entryids) {
+        if (_dev->is_msix()) {
+            _dev->msix_mask_entry(entry_id);
+        } else {
+            _dev->msi_mask_entry(entry_id);
+        }
+    }
+}
+
+void msix_vector::set_handler(std::function<void ()> handler)
+{
+    _handler = handler;
+}
+
+void msix_vector::add_entryid(unsigned entry_id)
+{
+    _entryids.push_back(entry_id);
+}
+
+void msix_vector::interrupt(void)
+{
+    trace_msix_interrupt(_vector);
+    _handler();
+}
+
+/**
+ * Changes the affinity of the MSI-X vector to the same CPU where its service
+ * routine thread is bound and then wakes that thread.
+ *
+ * @param current The CPU to which the MSI-X vector is currently bound
+ * @param v MSI-X vector handle
+ * @param t interrupt service routine thread
+ */
+static inline void set_affinity_and_wake(
+    sched::cpu*& current, msix_vector* v, sched::thread* t)
+{
+    auto cpu = t->get_cpu();;
+
+    if (cpu != current) {
+
+        //
+        // According to PCI spec chapter 6.8.3.5 the MSI-X table entry may be
+        // updated only if the entry is masked and the new values are promissed
+        // to be read only when the entry is unmasked.
+        //
+        v->msix_mask_entries();
+
+        std::atomic_thread_fence(std::memory_order_seq_cst);
+
+        current = cpu;
+        trace_msix_migrate(v->get_vector(), cpu->id);
+        v->set_affinity(cpu);
+
+        std::atomic_thread_fence(std::memory_order_seq_cst);
+
+        v->msix_unmask_entries();
+    }
+
+    t->wake_with_irq_disabled();
+}
+
+bool interrupt_manager::easy_register(std::initializer_list<msix_binding> bindings)
+{
+    unsigned n = bindings.size();
+    debug("interrupt_manager::easy_register()\n");
+
+    std::vector<msix_vector*> assigned = request_vectors(n);
+
+    if (assigned.size() != n) {
+        free_vectors(assigned);
+        return (false);
+    }
+
+    // Enable the device msix capability,
+    // masks all interrupts...
+
+    if (_dev->is_msix()) {
+        _dev->msix_enable();
+    } else {
+        _dev->msi_enable();
+    }
+
+    int idx=0;
+
+    for (auto binding : bindings) {
+        msix_vector* vec = assigned[idx++];
+        auto isr = binding.isr;
+        auto t = binding.t;
+        debugf("interrupt_manager::easy_register(), idx:%d\n", idx);
+
+        bool assign_ok;
+
+        if (t) {
+            sched::cpu* current = nullptr;
+            assign_ok =
+                assign_isr(vec,
+                    [=]() mutable {
+                                    if (isr)
+                                        isr();
+                                    set_affinity_and_wake(current, vec, t);
+                                  });
+        } else {
+            assign_ok = assign_isr(vec, [=]() { if (isr) isr(); });
+        }
+
+        debugf("interrupt_manager::easy_register(), idx:%d, assign_ok:%d\n", idx, assign_ok);
+        if (!assign_ok) {
+            free_vectors(assigned);
+            return false;
+        }
+        bool setup_ok = setup_entry(binding.entry, vec);
+        if (!setup_ok) {
+            free_vectors(assigned);
+            return false;
+        }
+    }
+
+    // Save reference for assigned vectors
+    _easy_vectors = assigned;
+    unmask_interrupts(assigned);
+
+    return (true);
+}
+
+void interrupt_manager::easy_unregister()
+{
+    free_vectors(_easy_vectors);
+    _easy_vectors.clear();
+}
+
+std::vector<msix_vector*> interrupt_manager::request_vectors(unsigned num_vectors)
+{
+    std::vector<msix_vector*> results;
+    unsigned num_entries;
+
+    if (_dev->is_msix()) {
+        num_entries = _dev->msix_get_num_entries();
+    } else {
+        num_entries = _dev->msi_get_num_entries();
+    }
+
+    auto num = std::min(num_vectors, num_entries);
+
+    for (unsigned i = 0; i < num; ++i) {
+        results.push_back(new msix_vector(_dev));
+    }
+
+    return (results);
+}
+
+bool interrupt_manager::assign_isr(msix_vector* vector, std::function<void ()> handler)
+{
+    vector->set_handler(handler);
+
+    return (true);
+}
+
+void interrupt_manager::free_vectors(const std::vector<msix_vector*>& vectors)
+{
+    for (auto msix : vectors) {
+        delete msix;
+    }
+}
+
+bool interrupt_manager::unmask_interrupts(const std::vector<msix_vector*>& vectors)
+{
+    for (auto msix : vectors) {
+        msix->msix_unmask_entries();
+    }
+
+    return (true);
+}

--- a/drivers/nvme.cc
+++ b/drivers/nvme.cc
@@ -482,7 +482,7 @@ bool driver::msix_register(unsigned iv,
     }
 
     if (assign_affinity && t) {
-        vec->set_affinity(t->get_cpu()->arch.apic_id);
+        vec->set_affinity(t->get_cpu());
     }
 
     if (iv < _msix_vectors.size()) {

--- a/include/osv/msi.hh
+++ b/include/osv/msi.hh
@@ -12,6 +12,10 @@
 
 #include <list>
 
+namespace sched {
+struct cpu;
+}
+
 class msix_vector {
 public:
     msix_vector(pci::function* dev);
@@ -25,7 +29,7 @@ public:
     void add_entryid(unsigned entry_id);
     void interrupt(void);
     void set_handler(std::function<void ()> handler);
-    void set_affinity(unsigned apic_id);
+    void set_affinity(sched::cpu *cpu);
 
 private:
     // Handler to invoke...


### PR DESCRIPTION
In preparation to resolve #1088, this patch extracts the architecture agnostic logic from arch/x64/msi.cc into a new common file - drivers/msi.cc. The arch-specific functionality comprising the msix_vector::set_affinity() and some interrupt_manager methods stays in the arch/<arch>/msi.cc files.

In addition, this patch changes the signature of the msix_vector::set_affinity() method by replacing the x86_64-specific apic_id with the generic sched::cpu() pointer.

Refers #1088