### PR TITLE
Implement MSI support on the aarch64 architecture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -999,6 +999,10 @@ endif
 ifeq ($(conf_drivers_mmio),1)
 drivers += drivers/virtio-mmio.o
 endif
+ifeq ($(conf_drivers_nvme),1)
+drivers += drivers/nvme.o
+drivers += drivers/nvme-queue.o
+endif
 drivers += drivers/virtio-vring.o
 drivers += drivers/virtio-rng.o
 drivers += drivers/virtio-blk.o

--- a/arch/aarch64/arch-dtb.hh
+++ b/arch/aarch64/arch-dtb.hh
@@ -91,9 +91,9 @@ int dtb_get_timer_irq();
  * gets the GIC v2 distributor and cpu interface.
  * return false on failure.
  */
-bool dtb_get_gic_v2(u64 *dist, size_t *dist_len, u64 *cpu, size_t *cpu_len);
+bool dtb_get_gic_v2(u64 *dist, size_t *dist_len, u64 *cpu, size_t *cpu_len, u64 *v2m, size_t *v2m_len);
 
-bool dtb_get_gic_v3(u64 *dist, size_t *dist_len, u64 *redist, size_t *redist_len);
+bool dtb_get_gic_v3(u64 *dist, size_t *dist_len, u64 *redist, size_t *redist_len, u64 *its, size_t *its_len);
 
 /* int dtb_get_cpus_count();
  *

--- a/arch/aarch64/arch-setup.cc
+++ b/arch/aarch64/arch-setup.cc
@@ -195,6 +195,9 @@ void arch_init_premain()
 #if CONF_drivers_virtio_fs
 #include "drivers/virtio-fs.hh"
 #endif
+#if CONF_drivers_nvme
+#include "drivers/nvme.hh"
+#endif
 
 void arch_init_drivers()
 {
@@ -246,6 +249,9 @@ void arch_init_drivers()
 #endif
 #if CONF_drivers_virtio_fs
     drvman->register_driver(virtio::fs::probe);
+#endif
+#if CONF_drivers_nvme
+    drvman->register_driver(nvme::driver::probe);
 #endif
     boot_time.event("drivers probe");
     drvman->load_all();

--- a/arch/aarch64/arch-setup.cc
+++ b/arch/aarch64/arch-setup.cc
@@ -128,25 +128,15 @@ void arch_setup_free_memory()
 #endif
 
     //Locate GICv2 or GICv3 information in DTB and construct corresponding GIC driver
-    //and map relevant physical memory
-    u64 dist, redist, cpuif;
-    size_t dist_len, redist_len, cpuif_len;
-    if (dtb_get_gic_v3(&dist, &dist_len, &redist, &redist_len)) {
-        gic::gic = new gic::gic_v3_driver(dist, redist);
-        /* linear_map [TTBR0 - GIC REDIST] */
-        mmu::linear_map((void *)redist, (mmu::phys)redist, redist_len, "gic_redist", mmu::page_size,
-                        mmu::mattr::dev);
-    } else if (dtb_get_gic_v2(&dist, &dist_len, &cpuif, &cpuif_len)) {
-        gic::gic = new gic::gic_v2_driver(dist, cpuif);
-        /* linear_map [TTBR0 - GIC CPUIF] */
-        mmu::linear_map((void *)cpuif, (mmu::phys)cpuif, cpuif_len, "gic_cpuif", mmu::page_size,
-                        mmu::mattr::dev);
+    u64 dist, redist, cpuif, its, v2m;
+    size_t dist_len, redist_len, cpuif_len, its_len, v2m_len;
+    if (dtb_get_gic_v3(&dist, &dist_len, &redist, &redist_len, &its, &its_len)) {
+        gic::gic = new gic::gic_v3_driver(dist, dist_len, redist, redist_len, its, its_len);
+    } else if (dtb_get_gic_v2(&dist, &dist_len, &cpuif, &cpuif_len, &v2m, &v2m_len)) {
+        gic::gic = new gic::gic_v2_driver(dist, dist_len, cpuif, cpuif_len, v2m, v2m_len);
     } else {
         abort("arch-setup: failed to get GICv3 nor GiCv2 information from dtb.\n");
     }
-    /* linear_map [TTBR0 - GIC DIST] */
-    mmu::linear_map((void *)dist, (mmu::phys)dist, dist_len, "gic_dist", mmu::page_size,
-                    mmu::mattr::dev);
 
 #if CONF_drivers_pci
     if (!opt_pci_disabled) {

--- a/arch/aarch64/exceptions.cc
+++ b/arch/aarch64/exceptions.cc
@@ -16,6 +16,7 @@
 #include "exceptions.hh"
 #include "fault-fixup.hh"
 #include "dump.hh"
+#include "gic-v3.hh"
 
 __thread exception_frame* current_interrupt_frame;
 class interrupt_table idt __attribute__((init_priority((int)init_prio::idt)));
@@ -39,6 +40,8 @@ interrupt_table::interrupt_table() {
 #if CONF_logger_debug
     debug_early_entry("interrupt_table::interrupt_table()");
 #endif
+    this->msi_vector_base = 0;
+    this->max_msi_vector = 0;
 
     gic::gic->init_on_primary_cpu();
 
@@ -58,15 +61,33 @@ void interrupt_table::disable_irq(int id)
     gic::gic->mask_irq(id);
 }
 
+void interrupt_table::enable_msi_vector(unsigned vector)
+{
+    gic::gic->initialize_msi_vector(vector);
+    gic::gic->unmask_irq(vector);
+}
+
 unsigned interrupt_table::register_handler(std::function<void ()> handler)
 {
-    //TODO: Implement it
-    return 0;
+    unsigned vector = next_msi_vector.fetch_add(1);
+    unsigned index = vector - msi_vector_base;
+    if (index >= max_msi_handlers) {
+        abort("The MSI vector %d too large\n", index);
+    }
+
+    msi_handlers[index] = handler;
+    enable_msi_vector(vector);
+    return vector;
 }
 
 void interrupt_table::unregister_handler(unsigned vector)
 {
-    //TODO: Implement it
+    unsigned index = vector - msi_vector_base;
+    if (index >= max_msi_handlers) {
+        abort("The MSI vector %d too large\n", index);
+    }
+    msi_handlers[index] = nullptr;
+    disable_irq(vector);
 }
 
 void interrupt_table::register_interrupt(interrupt *interrupt)
@@ -133,32 +154,61 @@ void interrupt_table::unregister_interrupt(interrupt *interrupt)
     }
 }
 
-bool interrupt_table::invoke_interrupt(unsigned int id)
+void interrupt_table::init_msi_vector_base(u32 initial)
+{
+    msi_vector_base = initial;
+    next_msi_vector.store(initial);
+}
+
+bool interrupt_table::invoke_interrupt(unsigned int iar)
 {
 #if CONF_lazy_stack_invariant
     assert(!arch::irq_enabled());
 #endif
     WITH_LOCK(osv::rcu_read_lock) {
-        assert(id < this->nr_irqs);
-        interrupt_desc *desc = this->irq_desc[id].read();
-
-        if (!desc || desc->handlers.empty()) {
-            return false;
-        }
-
-        int i, nr_shared = desc->handlers.size();
-        for (i = 0 ; i < nr_shared; i++) {
-            if (desc->acks[i]()) {
-                break;
+        // First see if it is an MSI vector and handle it
+        if (iar && iar >= msi_vector_base && iar <= max_msi_vector) {
+            unsigned handler_idx = iar - msi_vector_base;
+            if (handler_idx >= max_msi_handlers || !msi_handlers[handler_idx]) {
+                // This should never happen unless there is some bug
+                // in the MSI configuration code
+                debug_early_u64("misconfigured MSI interruptID iar=", iar);
+                assert(0);
+            } else {
+                msi_handlers[handler_idx]();
             }
-        }
-
-        if (i < nr_shared) {
-            desc->handlers[i]();
             return true;
         }
 
-        return false;
+        unsigned int irq = iar & 0x3ff;
+        if (irq >= gic::gic->nr_of_irqs()) {
+            // Note that special values 1022 and 1023 are used for
+            // group 1 and spurious interrupts respectively.
+            debug_early_u64("special InterruptID detected irq=", irq);
+            return false;
+        } else {
+            interrupt_desc *desc = this->irq_desc[irq].read();
+
+            if (!desc || desc->handlers.empty()) {
+                debug_early_u64("unhandled InterruptID irq=", irq);
+                return true;
+            }
+
+            int i, nr_shared = desc->handlers.size();
+            for (i = 0 ; i < nr_shared; i++) {
+                if (desc->acks[i]()) {
+                    break;
+                }
+            }
+
+            if (i < nr_shared) {
+                desc->handlers[i]();
+                return true;
+            }
+
+            debug_early_u64("unhandled InterruptID irq=", irq);
+            return true;
+        }
     }
 }
 
@@ -168,20 +218,14 @@ void interrupt(exception_frame* frame)
 {
     sched::fpu_lock fpu;
     SCOPE_LOCK(fpu);
-    /* remember frame in a global, need to change if going to nested */
+
+    // Rather that force the exception frame down the call stack,
+    // remember it in a global here. This works because our interrupts
+    // don't nest.
     current_interrupt_frame = frame;
 
     unsigned int iar = gic::gic->ack_irq();
-    unsigned int irq = iar & 0x3ff;
-
-    /* note that special values 1022 and 1023 are used for
-       group 1 and spurious interrupts respectively. */
-    if (irq >= gic::gic->nr_of_irqs()) {
-        debug_early_u64("special InterruptID detected irq=", irq);
-
-    } else {
-        if (!idt.invoke_interrupt(irq))
-            debug_early_u64("unhandled InterruptID irq=", irq);
+    if (idt.invoke_interrupt(iar)) {
         gic::gic->end_irq(iar);
     }
 

--- a/arch/aarch64/gic-common.cc
+++ b/arch/aarch64/gic-common.cc
@@ -7,10 +7,16 @@
  */
 
 #include <osv/mmio.hh>
+#include <osv/mmu.hh>
 
 #include "gic-common.hh"
 
 namespace gic {
+
+gic_dist::gic_dist(mmu::phys b, size_t l) : _base(b)
+{
+    mmu::linear_map((void *)_base, _base, l, "gic_dist", mmu::page_size, mmu::mattr::dev);
+}
 
 u32 gic_dist::read_reg(gicd_reg reg)
 {

--- a/arch/aarch64/gic-common.hh
+++ b/arch/aarch64/gic-common.hh
@@ -17,6 +17,10 @@
 #define GIC_SPI_BASE 32
 #define GIC_PPI_BASE 16
 
+namespace pci {
+class function;
+}
+
 namespace gic {
 
 constexpr int max_nr_irqs = 1020;
@@ -90,7 +94,7 @@ enum class irq_type : unsigned int {
 /* GIC Distributor Interface */
 class gic_dist {
 protected:
-    gic_dist(mmu::phys b) : _base(b) {}
+    gic_dist(mmu::phys b, size_t l);
 
 public:
     u32 read_reg(gicd_reg r);
@@ -129,6 +133,14 @@ public:
     virtual void end_irq(unsigned int iar) = 0;
 
     unsigned int nr_of_irqs() { return _nr_irqs; }
+
+    virtual void allocate_msi_dev_mapping(pci::function* dev) = 0;
+
+    virtual void initialize_msi_vector(unsigned int vector) = 0;
+    virtual void map_msi_vector(unsigned int vector, pci::function* dev, u32 target_cpu) = 0;
+    virtual void unmap_msi_vector(unsigned int vector, pci::function* dev) = 0;
+    virtual void msi_format(u64 *address, u32 *data, int vector) = 0;
+
 protected:
     unsigned int _nr_irqs;
     spinlock_t gic_lock;

--- a/arch/aarch64/gic-v3.cc
+++ b/arch/aarch64/gic-v3.cc
@@ -47,10 +47,18 @@
 #include <osv/mmio.hh>
 #include <osv/irqlock.hh>
 #include <osv/sched.hh>
+#include <osv/contiguous_alloc.hh>
+#include <osv/ilog2.hh>
+#include <osv/mmu.hh>
+#include <drivers/pci-function.hh>
+
+#include <algorithm>
 
 #include "processor.hh"
 #include "gic-v3.hh"
 #include "arm-clock.hh"
+
+extern class interrupt_table idt;
 
 #define isb() ({ asm volatile ("isb"); })
 
@@ -78,14 +86,67 @@ void gic_v3_dist::enable()
     wait_for_write_complete();
 }
 
+gic_v3_redist::gic_v3_redist(mmu::phys b, size_t l) : _base(b)
+{
+    mmu::linear_map((void *)_base, _base, l, "gic_redist", mmu::page_size, mmu::mattr::dev);
+}
+
+void gic_v3_redist::init_cpu_base(int smp_idx)
+{
+    if (!smp_idx) {
+        _cpu_bases = new mmu::phys[sched::cpus.size()];
+    }
+
+    uint64_t mpidr = processor::read_mpidr();
+
+    u64 offset = 0;
+    u64 typer;
+    do {
+        typer = mmio_getq((mmioaddr_t)_base + (offset + GICR_TYPER));
+
+        if (((mpidr & MPIDR_AFF3_MASK) >> 32) == GICR_TYPER_AFF3(typer) &&
+            ((mpidr & MPIDR_AFF2_MASK) >> 16) == GICR_TYPER_AFF2(typer) &&
+            ((mpidr & MPIDR_AFF1_MASK) >> 8) == GICR_TYPER_AFF1(typer) &&
+             (mpidr & MPIDR_AFF0_MASK) == GICR_TYPER_AFF0(typer)) {
+            break;
+        }
+        offset += GICR_STRIDE;
+        if (typer & GICR_TYPER_VLPIS) {
+            offset += GICR_STRIDE;
+        }
+    } while (!(typer & GICR_TYPER_LAST));
+
+    _cpu_bases[smp_idx] = _base + offset;
+}
+
+void gic_v3_redist::init_lpis(int smp_idx, u64 prop_base, u64 pend_base)
+{
+    //Set common LPI configuration table
+    write64_at_offset(smp_idx, GICR_PROPBASER, prop_base);
+    //Set redistributor specific LPI pending table
+    write64_at_offset(smp_idx, GICR_PENDBASER, pend_base);
+    //Enable LPIs
+    write_at_offset(smp_idx, GICR_CTLR, GICR_CTLR_EnableLPIs);
+}
+
 u32 gic_v3_redist::read_at_offset(int smp_idx, u32 offset)
 {
-    return mmio_getl((mmioaddr_t)_base + smp_idx * GICR_STRIDE + offset);
+    return mmio_getl((mmioaddr_t)_cpu_bases[smp_idx] + offset);
+}
+
+u64 gic_v3_redist::read64_at_offset(int smp_idx, u32 offset)
+{
+    return mmio_getq((mmioaddr_t)_cpu_bases[smp_idx] + offset);
 }
 
 void gic_v3_redist::write_at_offset(int smp_idx, u32 offset, u32 value)
 {
-    mmio_setl((mmioaddr_t)_base + smp_idx * GICR_STRIDE + offset, value);
+    mmio_setl((mmioaddr_t)_cpu_bases[smp_idx] + offset, value);
+}
+
+void gic_v3_redist::write64_at_offset(int smp_idx, u32 offset, u64 value)
+{
+    mmio_setq((mmioaddr_t)_cpu_bases[smp_idx] + offset, value);
 }
 
 void gic_v3_redist::wait_for_write_complete()
@@ -95,6 +156,20 @@ void gic_v3_redist::wait_for_write_complete()
     do {
         val = mmio_getl((mmioaddr_t)_base);
     } while (val & GICD_CTLR_WRITE_COMPLETE);
+}
+
+void gic_v3_redist::init_rdbase(int smp_idx, bool pta)
+{
+    if (!smp_idx) {
+        _rdbases = new mmu::phys[sched::cpus.size()];
+    }
+
+    if (pta) {
+        _rdbases[smp_idx] = (_cpu_bases[smp_idx]) >> 16;
+    } else {
+        u64 typer = read64_at_offset(smp_idx, GICR_TYPER);
+        _rdbases[smp_idx] = GICR_TYPER_PROC_NUM(typer);
+    }
 }
 
 static uint32_t get_cpu_affinity(void)
@@ -107,6 +182,223 @@ static uint32_t get_cpu_affinity(void)
         (mpidr & MPIDR_AFF0_MASK);
 
     return (uint32_t)aff;
+}
+
+gic_v3_its::gic_v3_its(mmu::phys b, size_t l) : _base(b)
+{
+    if (b && l) {
+        mmu::linear_map((void *)_base, _base, l, "gic_its", mmu::page_size,
+                        mmu::mattr::dev);
+    }
+}
+
+u64 gic_v3_its::read_reg64(gic_its_reg reg)
+{
+    return mmio_getq((mmioaddr_t)_base + (u32)reg);
+}
+
+u64 gic_v3_its::read_reg64_at_offset(gic_its_reg reg, u32 offset)
+{
+    return mmio_getq((mmioaddr_t)_base + (u32)reg + offset);
+}
+
+void gic_v3_its::write_reg(gic_its_reg reg, u32 value)
+{
+    mmio_setl((mmioaddr_t)_base + (u32)reg, value);
+}
+
+void gic_v3_its::write_reg64(gic_its_reg reg, u64 value)
+{
+    mmio_setq((mmioaddr_t)_base + (u32)reg, value);
+}
+
+void gic_v3_its::write_reg64_at_offset(gic_its_reg reg, u32 offset, u64 value)
+{
+    mmio_setq((mmioaddr_t)_base + (u32)reg + offset, value);
+}
+
+void gic_v3_its::read_type_register()
+{
+    _typer = read_reg64(gic_its_reg::GICITS_TYPER);
+}
+
+//The 4K queue is enough for 128 commands before it wraps around
+#define GIC_ITS_CMD_QUEUE_SIZE  0x1000 //4 KB
+//https://developer.arm.com/documentation/102923/0100/ITS/The-command-queue
+void gic_v3_its::initialize_cmd_queue()
+{
+    //Queue needs to be 64KB aligned
+    _cmd_queue = memory::alloc_phys_contiguous_aligned(GIC_ITS_CMD_QUEUE_SIZE, 0x10000);
+    memset(_cmd_queue, 0, GIC_ITS_CMD_QUEUE_SIZE);
+
+    u64 cmd_queue_pa = mmu::virt_to_phys(_cmd_queue);
+    u64 queue_size_in_pages = GIC_ITS_CMD_QUEUE_SIZE / mmu::page_size;
+    //
+    //Read https://developer.arm.com/documentation/ddi0601/2024-09/External-Registers/GITS-CBASER--ITS-Command-Queue-Descriptor
+    write_reg64(gic_its_reg::GICITS_CBASER, GITS_CBASER_VALID | cmd_queue_pa | (queue_size_in_pages - 1));
+    write_reg64(gic_its_reg::GICITS_CWRITER, 0);
+}
+
+void gic_v3_its::enqueue_cmd(its_cmd *cmd)
+{
+    u64 cread = read_reg64(gic_its_reg::GICITS_CREADR);
+    u64 cwrite = read_reg64(gic_its_reg::GICITS_CWRITER);
+    //
+    //Wait until queue is not full
+    while (cread == cwrite + sizeof(*cmd)) {
+        asm volatile ("isb sy");
+        cread = read_reg64(gic_its_reg::GICITS_CREADR);
+    }
+
+    its_cmd *cmd_to_write = (its_cmd *)(_cmd_queue + cwrite);
+    *cmd_to_write = *cmd;
+
+    cwrite += sizeof(*cmd);
+    if (cwrite == GIC_ITS_CMD_QUEUE_SIZE) {
+        cwrite = 0;
+    }
+
+    write_reg64(gic_its_reg::GICITS_CWRITER, cwrite);
+}
+
+#define CPUID_2_ICID(cpuId) (cpuId)
+
+//See 6.3.9 in GIC3/4 spec
+//"Maps the Device table entry associated with DeviceID to its associated ITT,
+// defined by itt_pa and itt_size."
+void gic_v3_its::cmd_mapd(u32 dev_id, u64 itt_pa, u64 itt_size)
+{
+    its_cmd cmd;
+    cmd.data[0] = ((u64)dev_id << 32) | (u32)gic_its_cmd::ITS_CMD_MAPD;
+    cmd.data[1] = itt_size;
+    cmd.data[2] = ITS_MAPD_V | itt_pa;
+    cmd.data[3] = 0;
+    enqueue_cmd(&cmd);
+}
+
+//See 6.3.11 in GIC3/4 spec
+//"Maps the event defined by EventID and DeviceID to its associated ITE, defined by ICID and pINTID in
+// the ITT associated with DeviceID"
+void gic_v3_its::cmd_mapti(u32 dev_id, int vector, int smp_idx)
+{
+    its_cmd cmd;
+    cmd.data[0] = ((u64)dev_id << 32) | (u32)gic_its_cmd::ITS_CMD_MAPTI;
+    u32 event_id = vector - GIC_LPI_INTS_START;
+    cmd.data[1] = ((u64)vector << 32) | event_id;
+    cmd.data[2] = CPUID_2_ICID(smp_idx);
+    cmd.data[3] = 0;
+    enqueue_cmd(&cmd);
+}
+
+//See 6.3.13 in GIC3/4 spec
+//"Updates the ICID field in the ITT entry for the event defined by DeviceID and EventID."
+void gic_v3_its::cmd_movi(u32 dev_id, int vector, int smp_idx)
+{
+    its_cmd cmd;
+    cmd.data[0] = ((u64)dev_id << 32) | (u32)gic_its_cmd::ITS_CMD_MOVI;
+    u32 event_id = vector - GIC_LPI_INTS_START;
+    cmd.data[1] = event_id;
+    cmd.data[2] = CPUID_2_ICID(smp_idx);
+    cmd.data[3] = 0;
+    enqueue_cmd(&cmd);
+}
+
+//See 6.3.6 in GIC3/4 spec
+//"Specifies that the ITS must ensure that any caching in the Redistributors associated with the specified
+// EventID is consistent with the LPI Configuration tables held in memory."
+void gic_v3_its::cmd_inv(u32 dev_id, int vector)
+{
+    its_cmd cmd;
+    cmd.data[0] = ((u64)dev_id << 32) | (u32)gic_its_cmd::ITS_CMD_INV;
+    u32 event_id = vector - GIC_LPI_INTS_START;
+    cmd.data[1] = event_id;
+    cmd.data[2] = cmd.data[3] = 0;
+    enqueue_cmd(&cmd);
+}
+
+//See 6.3.4 in GIC3/4 spec
+//"Instructs the appropriate Redistributor to remove the pending state of the interrupt."
+void gic_v3_its::cmd_discard(u32 dev_id, int vector)
+{
+    its_cmd cmd;
+    cmd.data[0] = ((u64)dev_id << 32) | (u32)gic_its_cmd::ITS_CMD_DISCARD;
+    u32 event_id = vector - GIC_LPI_INTS_START;
+    cmd.data[1] = event_id;
+    cmd.data[2] = cmd.data[3] = 0;
+    enqueue_cmd(&cmd);
+}
+
+//See 6.3.14 in GIC3/4 spec
+//"Ensures all outstanding ITS operations associated with physical interrupts for the Redistributor
+// specified by RDbase are globally observed before any further ITS commands are executed."
+void gic_v3_its::cmd_sync(mmu::phys rdbase)
+{
+    its_cmd cmd;
+    cmd.data[0] = (u64)gic_its_cmd::ITS_CMD_SYNC;
+    cmd.data[2] = rdbase << 16;
+    cmd.data[1] = cmd.data[3] = 0;
+    enqueue_cmd(&cmd);
+}
+
+//See 6.3.8 in GIC3/4 spec
+//"Maps the Collection table entry defined by ICID to the target Redistributor, defined by RDbase"
+void gic_v3_its::cmd_mapc(int smp_idx, mmu::phys rdbase)
+{
+    its_cmd cmd;
+    cmd.data[0] = (u32)gic_its_cmd::ITS_CMD_MAPC;
+    cmd.data[1] = 0;
+    cmd.data[2] = ITS_MAPC_V | (rdbase << 16) | CPUID_2_ICID(smp_idx);
+    cmd.data[3] = 0;
+    enqueue_cmd(&cmd);
+}
+
+void gic_v3_driver::init_lpis(int smp_idx)
+{
+    //Check if ITS is supported which is for example not a case on Firecracker
+    if (!_gits.base()) {
+        return;
+    }
+
+    //Identify number of LPIs supported by GIC and setup global configuration table
+    if (smp_idx == 0) {
+        //See https://developer.arm.com/documentation/ddi0601/2022-06/External-Registers/GICD-TYPER--Interrupt-Controller-Type-Register?lang=en
+        //Read bits 15:11 (num_LPIs) of GICD_TYPER
+        u32 typer = _gicd.read_reg(gicd_reg::GICD_TYPER);
+        u32 num_lpis = (typer >> 11) & GICD_TYPER_LPI_NUM_MASK;
+        if (num_lpis) {
+            _msi_vector_num = 1UL << (num_lpis + 1);
+        } else { //Determine using the IDBits field
+            u32 id_bits = (typer >> 19) & GICD_TYPER_IDBITS_MASK;
+            _msi_vector_num = (1UL << (id_bits + 1)) - GIC_LPI_INTS_START;
+        }
+        //TODO: Investigate using smaller number of LPIs using GICR_PROPBASER.IDbits
+        //Read https://developer.arm.com/documentation/102923/0100/Redistributors/Initial-configuration-of-a-Redistributor
+        //and https://developer.arm.com/documentation/ddi0601/2024-09/External-Registers/GICR-PROPBASER--Redistributor-Properties-Base-Address-Register
+        _msi_vector_num = std::max(_msi_vector_num, (u16)4096);
+
+        //Allocate common LPI configuration table
+        void *config_table = memory::alloc_phys_contiguous_aligned(_msi_vector_num, 4096);
+        memset(config_table, 0, _msi_vector_num);
+        _lpi_config_table = (u8*)config_table;
+
+        u64 id_bits = ilog2_roundup<u64>(_msi_vector_num + GIC_LPI_INTS_START) - 1;
+        _lpi_prop_base = mmu::virt_to_phys(config_table) | id_bits;
+
+        //Allocate LPI pending table for each redistributor
+        //From https://developer.arm.com/documentation/102923/0100/Redistributors:
+        //"Each Redistributor has its own LPI Pending table, and these tables are not shared between Redistributors."
+        _lpi_pend_bases = new u64[sched::cpus.size()];
+        size_t pending_table_size = (_msi_vector_num + GIC_LPI_INTS_START) / 8;
+        for (unsigned c = 0; c < sched::cpus.size(); c++) {
+            void *pending_table = memory::alloc_phys_contiguous_aligned(pending_table_size, 64 * 1024);
+            memset(pending_table, 0, pending_table_size);
+            //Read about PTZ here - https://developer.arm.com/documentation/ddi0601/2024-12/External-Registers/GICR-PENDBASER--Redistributor-LPI-Pending-Table-Base-Address-Register
+            _lpi_pend_bases[c] = mmu::virt_to_phys(pending_table) | GICR_PENDBASER_PTZ;
+        }
+    }
+
+    //Set LPI configuration, pending table for each redistributor
+    _gicrd.init_lpis(smp_idx, _lpi_prop_base, _lpi_pend_bases[smp_idx]);
 }
 
 /* to be called only from the boot CPU */
@@ -178,33 +470,33 @@ void gic_v3_driver::init_redist(int smp_idx)
     _mpids_by_smpid[smp_idx] = processor::read_mpidr();
 
     /* Wake up CPU redistributor */
-    u32 val = _gicr.read_at_offset(smp_idx, GICR_WAKER);
+    u32 val = _gicrd.read_at_offset(smp_idx, GICR_WAKER);
     val &= ~GICR_WAKER_ProcessorSleep;
-    _gicr.write_at_offset(smp_idx, GICR_WAKER, val);
+    _gicrd.write_at_offset(smp_idx, GICR_WAKER, val);
 
     /* Poll GICR_WAKER.ChildrenAsleep */
     do {
-        val = _gicr.read_at_offset(smp_idx, GICR_WAKER);
+        val = _gicrd.read_at_offset(smp_idx, GICR_WAKER);
     } while ((val & GICR_WAKER_ChildrenAsleep));
 
     /* Set PPI and SGI to a default value */
     for (unsigned int i = 0; i < GIC_SPI_BASE; i += GICD_I_PER_IPRIORITYn)
-        _gicr.write_at_offset(smp_idx, GICR_IPRIORITYR4(i), GICD_IPRIORITY_DEF);
+        _gicrd.write_at_offset(smp_idx, GICR_IPRIORITYR4(i), GICD_IPRIORITY_DEF);
 
     /* Deactivate SGIs and PPIs as the state is unknown at boot */
-    _gicr.write_at_offset(smp_idx, GICR_ICACTIVER0, GICD_DEF_ICACTIVERn);
+    _gicrd.write_at_offset(smp_idx, GICR_ICACTIVER0, GICD_DEF_ICACTIVERn);
 
     /* Disable all PPIs */
-    _gicr.write_at_offset(smp_idx, GICR_ICENABLER0, GICD_DEF_PPI_ICENABLERn);
+    _gicrd.write_at_offset(smp_idx, GICR_ICENABLER0, GICD_DEF_PPI_ICENABLERn);
 
     /* Configure SGIs and PPIs as non-secure Group 1 */
-    _gicr.write_at_offset(smp_idx, GICR_IGROUPR0, GICD_DEF_IGROUPRn);
+    _gicrd.write_at_offset(smp_idx, GICR_IGROUPR0, GICD_DEF_IGROUPRn);
 
     /* Enable all SGIs */
-    _gicr.write_at_offset(smp_idx, GICR_ISENABLER0, GICD_DEF_SGI_ISENABLERn);
+    _gicrd.write_at_offset(smp_idx, GICR_ISENABLER0, GICD_DEF_SGI_ISENABLERn);
 
     /* Wait for completion */
-    _gicr.wait_for_write_complete();
+    _gicrd.wait_for_write_complete();
 
     /* Enable system register access */
     val = READ_SYS_REG32(ICC_SRE_EL1);
@@ -229,32 +521,116 @@ void gic_v3_driver::init_redist(int smp_idx)
     //Enable cpu timer on secondary CPU
     if (smp_idx) {
         u32 val = 1UL << (get_timer_irq_id() % GICR_I_PER_ISENABLERn);
-        _gicr.write_at_offset(smp_idx, GICR_ISENABLER0, val);
+        _gicrd.write_at_offset(smp_idx, GICR_ISENABLER0, val);
+    }
+
+    if (!smp_idx) {
+        idt.init_msi_vector_base(GIC_LPI_INTS_START);
+        idt.set_max_msi_vector(GIC_LPI_INTS_START + _msi_vector_num - 1);
     }
 }
 
+//https://developer.arm.com/documentation/102923/0100/ITS/The-sizes-and-layout-of-Collection-and-Device-tables
+//"The location and size of the Collection and Device tables is configured
+// using the GITS_BASERn registers. Software must allocate memory for
+// these tables and configure the GITS_BASERn registers before enabling the ITS."
+void gic_v3_driver::init_its_device_or_collection_table(int idx)
+{
+    //Read https://developer.arm.com/documentation/ddi0601/2024-09/External-Registers/GITS-BASER-n---ITS-Table-Descriptors
+    u32 offset = idx * 8;
+    u64 base = _gits.read_reg64_at_offset(gic_its_reg::GICITS_BASER, offset);
+
+    u64 type = GITS_TABLE_TYPE(base); //Bits [58:56]
+    if (type != GITS_TABLE_DEVICES_TYPE && type != GITS_TABLE_COLLECTIONS_TYPE) {
+        return;
+    }
+
+    //
+    //"Software can allocate a flat (single level) table or two-level tables."
+    //We allocate a flat table
+    u64 page_size_type = GITS_PAGE_SIZE(base); //Bits [9:8]
+    u64 table_size = page_size_type == GITS_TABLE_PAGE_SIZE_4K ? 0x1000 :
+	           (page_size_type == GITS_TABLE_PAGE_SIZE_16K ? 0x4000 : 0x10000);
+
+    //if (type == GITS_TABLE_DEVICES_TYPE) {
+    //    //TODO: Calculate maximum devices count and save it somewhere
+    //}
+
+    void *table = memory::alloc_phys_contiguous_aligned(table_size, table_size);
+    memset(table, 0, table_size);
+
+    u64 table_pa = mmu::virt_to_phys(table);
+    base = (base & ~GITS_TABLE_BASE_PA_MASK) | table_pa;
+    _gits.write_reg64_at_offset(gic_its_reg::GICITS_BASER, offset, GITS_BASER_VALID | base);
+}
+
+//https://developer.arm.com/documentation/102923/0100/ITS/Initial-configuration-of-an-ITS
+void gic_v3_driver::init_its(int smp_idx)
+{
+    //Check if ITS is supported which is for example not a case on Firecracker
+    if (!_gits.base()) {
+        return;
+    }
+
+    if (smp_idx == 0) {
+        _gits.read_type_register();
+
+        //Initialize the Device and Collection tables
+        for (int table_idx = 0; table_idx < GITS_TABLE_NUM_MAX; table_idx++) {
+            init_its_device_or_collection_table(table_idx);
+        }
+
+        //Initialize command queue
+        _gits.initialize_cmd_queue();
+
+        // Enable ITS
+        _gits.write_reg(gic_its_reg::GICITS_CTLR, GITS_CTLR_ENABLED);
+    }
+
+    //Init on each cpu
+    _gicrd.init_rdbase(smp_idx, _gits.is_typer_pta());
+    mmu::phys rdbase = _gicrd.rdbase(smp_idx);
+
+    if (smp_idx == 0) {
+        // Init on primary CPU
+        _gits.cmd_mapc(smp_idx, rdbase);
+    } else {
+        //Init on secondary cpu
+        //We may experience race between many secondary CPUs
+        //during early SMP boot so let us protect with spinlock
+        WITH_LOCK(_smp_init_its_lock) {
+            _gits.cmd_mapc(smp_idx, rdbase);
+        }
+    }
+}
+
+#define GIC_LPI_ENABLE  0x01
 void gic_v3_driver::mask_irq(unsigned int irq)
 {
     WITH_LOCK(gic_lock) {
-        if (irq >= GIC_SPI_BASE) {
+        if (irq >= GIC_LPI_INTS_START) {
+            _lpi_config_table[irq - GIC_LPI_INTS_START] |= ~GIC_LPI_ENABLE;
+        } else if (irq >= GIC_SPI_BASE) {
             u32 val = 1UL << (irq % GICD_I_PER_ICENABLERn);
             _gicd.write_reg_at_offset((u32)gicd_reg_irq1::GICD_ICENABLER, 4 * (irq >> 5), val);
-         } else {
+        } else {
             u32 val = 1UL << (irq % GICR_I_PER_ICENABLERn);
-            _gicr.write_at_offset(sched::cpu::current()->id, GICR_ICENABLER0, val);
-         }
+            _gicrd.write_at_offset(sched::cpu::current()->id, GICR_ICENABLER0, val);
+        }
     }
 }
 
 void gic_v3_driver::unmask_irq(unsigned int irq)
 {
     WITH_LOCK(gic_lock) {
-        if (irq >= GIC_SPI_BASE) {
+        if (irq >= GIC_LPI_INTS_START) {
+            _lpi_config_table[irq - GIC_LPI_INTS_START] |= GIC_LPI_ENABLE;
+        } else if (irq >= GIC_SPI_BASE) {
             u32 val = 1UL << (irq % GICD_I_PER_ISENABLERn);
             _gicd.write_reg_at_offset((u32)gicd_reg_irq1::GICD_ISENABLER, 4 * (irq >> 5), val);
         } else {
             u32 val = 1UL << (irq % GICR_I_PER_ISENABLERn);
-            _gicr.write_at_offset(sched::cpu::current()->id, GICR_ISENABLER0, val);
+            _gicrd.write_at_offset(sched::cpu::current()->id, GICR_ISENABLER0, val);
         }
     }
 }
@@ -346,6 +722,96 @@ void gic_v3_driver::end_irq(unsigned int irq)
     /* Deactivate */
     WRITE_SYS_REG32(ICC_DIR_EL1, irq);
     isb();
+}
+
+u32 gic_v3_driver::pci_device_id(pci::function* dev)
+{
+    u8 bus, device, function;
+    dev->get_bdf(bus, device, function);
+    return (((u32)bus) << 8) | (((u32)device) << 3) | (u32)function;
+}
+
+void gic_v3_driver::allocate_msi_dev_mapping(pci::function* dev)
+{
+    WITH_LOCK(gic_lock) {
+        u32 device_id = pci_device_id(dev);
+
+        //Read https://developer.arm.com/documentation/102923/0100/ITS/Mapping-an-interrupt-to-a-Redistributor
+
+        //Check if there is an Interrupt Translation Table (ITT) for this device
+        //If not create it and map it
+        auto dev_itt = _itt_by_device_id.find(device_id);
+        if (dev_itt == _itt_by_device_id.end()) {
+            u64 entries_num = 1ull << ilog2_roundup<u64>(_msi_vector_num);
+            u64 itt_size = entries_num * (_gits.itt_entry_size() + 1);
+            itt_size = std::max(itt_size, (u64)256);
+
+            void *itt = memory::alloc_phys_contiguous_aligned(itt_size, 256);
+            memset(itt, 0, itt_size);
+            _itt_by_device_id.insert(std::make_pair(device_id, itt));
+
+            u64 itt_pa = mmu::virt_to_phys(itt);
+            _gits.cmd_mapd(device_id, itt_pa, ilog2_roundup<u64>(entries_num) - 1);
+        }
+    }
+}
+
+void gic_v3_driver::map_msi_vector(unsigned int vector, pci::function* dev, u32 target_cpu)
+{
+    WITH_LOCK(gic_lock) {
+        u32 device_id = pci_device_id(dev);
+
+        auto vector_cpu = _cpu_by_vector.find(vector);
+        if (vector_cpu == _cpu_by_vector.end()) {
+            //Read https://developer.arm.com/documentation/102923/0100/ITS/Mapping-an-interrupt-to-a-Redistributor
+
+            //Map event ID to collection ID|cpu
+            _gits.cmd_mapti(device_id, vector, target_cpu);
+            _gits.cmd_inv(device_id, vector);
+
+            _cpu_by_vector.insert(std::make_pair(vector, target_cpu));
+
+            //Sync redistributor
+            mmu::phys rdbase = _gicrd.rdbase(target_cpu);
+            _gits.cmd_sync(rdbase);
+        } else if (vector_cpu->second != target_cpu) { //We need to move interrupt to different redistributor (cpu)
+            //Read https://developer.arm.com/documentation/102923/0100/ITS/Migrating-interrupts-between-Redistributors
+
+            //Re-Map event ID to collection ID|cpu
+            _gits.cmd_movi(device_id, vector, target_cpu);
+            _gits.cmd_inv(device_id, vector);
+            //
+            //Sync old redistributor
+            mmu::phys rdbase = _gicrd.rdbase(vector_cpu->second);
+            _gits.cmd_sync(rdbase);
+
+            _cpu_by_vector.insert(std::make_pair(vector, target_cpu));
+        }
+    }
+}
+
+void gic_v3_driver::unmap_msi_vector(unsigned int vector, pci::function* dev)
+{
+    WITH_LOCK(gic_lock) {
+        auto vector_cpu = _cpu_by_vector.find(vector);
+        if (vector_cpu != _cpu_by_vector.end()) {
+            u32 device_id = pci_device_id(dev);
+
+            _gits.cmd_discard(device_id, vector);
+            _gits.cmd_inv(device_id, vector);
+
+            //Sync redistributor
+            mmu::phys rdbase = _gicrd.rdbase(vector_cpu->second);
+            _gits.cmd_sync(rdbase);
+        }
+    }
+}
+
+#define GITS_TRANSLATER 0x10040
+void gic_v3_driver::msi_format(u64 *address, u32 *data, int vector)
+{
+    *address = _gits.base() + GITS_TRANSLATER;
+    *data = vector - GIC_LPI_INTS_START;
 }
 
 }

--- a/conf/profiles/aarch64/all.mk
+++ b/conf/profiles/aarch64/all.mk
@@ -1,5 +1,6 @@
 include conf/profiles/$(arch)/virtio-mmio.mk
 include conf/profiles/$(arch)/virtio-pci.mk
 include conf/profiles/$(arch)/xen.mk
+include conf/profiles/$(arch)/nvme.mk
 
 conf_drivers_cadence?=1

--- a/conf/profiles/aarch64/base.mk
+++ b/conf/profiles/aarch64/base.mk
@@ -20,6 +20,11 @@ ifeq ($(conf_drivers_virtio_rng),1)
 export conf_drivers_virtio?=1
 endif
 
+export conf_drivers_nvme?=0
+ifeq ($(conf_drivers_nvme),1)
+export conf_drivers_pci?=1
+endif
+
 export conf_drivers_cadence?=0
 export conf_drivers_virtio?=0
 export conf_drivers_pci?=0

--- a/conf/profiles/aarch64/nvme.mk
+++ b/conf/profiles/aarch64/nvme.mk
@@ -1,0 +1,3 @@
+conf_drivers_pci?=1
+
+conf_drivers_nvme?=1

--- a/drivers/pci-function.cc
+++ b/drivers/pci-function.cc
@@ -623,9 +623,6 @@ namespace pci {
 
     void function::msix_enable()
     {
-#ifdef __aarch64__
-        return;
-#endif
         if (!is_msix() || _msix_enabled) {
             return;
         }

--- a/drivers/virtio-pci-device.cc
+++ b/drivers/virtio-pci-device.cc
@@ -45,17 +45,11 @@ void virtio_pci_device::init()
 
 void virtio_pci_device::register_interrupt(interrupt_factory irq_factory)
 {
-#ifdef AARCH64_PORT_STUB
-    // Currently MSI-X support for aach64 is stubbed (please see arch/aarch64/msi.cc)
-    // so until it becomes functional we register regular PCI interrupt
-    _irq.reset(irq_factory.create_pci_interrupt(*_dev));
-#else
     if (irq_factory.register_msi_bindings && _dev->is_msix()) {
         irq_factory.register_msi_bindings(_msi);
     } else {
         _irq.reset(irq_factory.create_pci_interrupt(*_dev));
     }
-#endif
 }
 
 virtio_legacy_pci_device::virtio_legacy_pci_device(pci::device *dev)
@@ -70,7 +64,6 @@ void virtio_legacy_pci_device::kick_queue(int queue)
 
 void virtio_legacy_pci_device::setup_queue(vring *queue)
 {
-#ifndef AARCH64_PORT_STUB
     if (_dev->is_msix()) {
         // Setup queue_id:entry_id 1:1 correlation...
         virtio_conf_writew(VIRTIO_MSI_QUEUE_VECTOR, queue->index());
@@ -79,7 +72,6 @@ void virtio_legacy_pci_device::setup_queue(vring *queue)
             return;
         }
     }
-#endif
     // Tell host about pfn
     // TODO: Yak, this is a bug in the design, on large memory we'll have PFNs > 32 bit
     // Dor to notify Rusty
@@ -182,7 +174,6 @@ void virtio_modern_pci_device::setup_queue(vring *queue)
 {
     auto queue_index = queue->index();
 
-#ifndef AARCH64_PORT_STUB
     if (_dev->is_msix()) {
         // Setup queue_id:entry_id 1:1 correlation...
         _common_cfg->virtio_conf_writew(COMMON_CFG_OFFSET_OF(queue_msix_vector), queue_index);
@@ -191,7 +182,6 @@ void virtio_modern_pci_device::setup_queue(vring *queue)
             return;
         }
     }
-#endif
 
     _queues_notify_offsets[queue_index] =
             _common_cfg->virtio_conf_readw(COMMON_CFG_OFFSET_OF(queue_notify_off));

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -149,7 +149,14 @@ def start_osv_qemu(options):
     else:
         boot_index = ",bootindex=0"
 
-    if options.arch == 'aarch64':
+    if options.arch == 'aarch64' and options.nvme:
+        if options.hypervisor == 'qemu':
+            args += ["-machine", "gic-version=%s" % options.gic_version, "-cpu", "cortex-a57"]
+        args += [
+        "-machine", "virt",
+        "-device", "nvme,serial=deadbeef,drive=nvm%s" % (boot_index),
+        "-drive", "file=%s,if=none,id=nvm,%s" % (options.image_file, aio)]
+    elif options.arch == 'aarch64':
         if options.hypervisor == 'qemu':
             args += ["-machine", "gic-version=max", "-cpu", "cortex-a57"]
         args += [


### PR DESCRIPTION
The series of these 4 commits implements the MSI support on the aarch64 architecture:
- implement GIC v3 ITS and GIC v2m to support MSI
- implement aarch64-specific MSI methods
- enable MSI/X for virtio PCI devices
- enable NVME support

For more details, please look at the commit messages.
