### PR TITLE
tests: Add test case for circular ELF data relocations

### DIFF
--- a/modules/tests/Makefile
+++ b/modules/tests/Makefile
@@ -70,6 +70,14 @@ $(out)/tests/tst-reloc.o: CFLAGS:=$(subst -fPIC,-fpie,$(CFLAGS))
 $(out)/tests/tst-reloc.so: $(src)/tests/tst-reloc.c
 	$(call quiet, $(CC) $(CFLAGS) $(LDFLAGS) -pie -o $@ $< $(LIBS), LD tests/tst-reloc.so)
 
+$(out)/tests/lib-circular-reloc1.so: $(src)/tests/lib-circular-reloc1.o
+$(out)/tests/lib-circular-reloc2.so: $(src)/tests/lib-circular-reloc2.o
+$(out)/tests/tst-elf-circular-reloc.so: \
+		$(src)/tests/tst-elf-circular-reloc.o \
+		$(out)/tests/lib-circular-reloc1.so \
+		$(out)/tests/lib-circular-reloc2.so
+	$(call quiet, cd $(out); $(CXX) $(CXXFLAGS) $(LDFLAGS) -shared -o $@ $< $(LIBS) tests/lib-circular-reloc1.so tests/lib-circular-reloc2.so, LD tests/tst-elf-circular-reloc.so)
+
 $(out)/tests/commands.o: $(src)/core/commands.cc
 	$(makedir)
 	$(call quiet, $(CXX) $(CXXFLAGS) -c -o $@ $<, CXX core/commands.cc => tests/commands.o)
@@ -147,7 +155,8 @@ tests := tst-pthread.so misc-ramdisk.so tst-vblk.so tst-bsd-evh.so \
 	tst-sigaction.so tst-syscall.so tst-ifaddrs.so tst-getdents.so \
 	tst-netlink.so misc-zfs-io.so misc-zfs-arc.so tst-pthread-create.so \
 	misc-futex-perf.so misc-syscall-perf.so tst-brk.so tst-reloc.so \
-	misc-vdso-perf.so tst-string-utils.so
+	misc-vdso-perf.so tst-string-utils.so tst-elf-circular-reloc.so \
+	lib-circular-reloc1.so lib-circular-reloc2.so
 #	tst-f128.so \
 
 

--- a/tests/lib-circular-reloc1.cc
+++ b/tests/lib-circular-reloc1.cc
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2025 Reliable System Software, Technische Universität Braunschweig.
+ *
+ * This work is open source software, licensed under the terms of the
+ * BSD license as described in the LICENSE file in the top-level directory.
+ */
+
+#include <stdio.h>
+
+extern void called_from_a(void);
+
+void
+called_from_b(void)
+{
+	puts(__func__);
+}
+
+void
+func_a(void)
+{
+	printf("%p\n", &called_from_a);
+	called_from_a();
+}

--- a/tests/lib-circular-reloc2.cc
+++ b/tests/lib-circular-reloc2.cc
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2025 Reliable System Software, Technische Universität Braunschweig.
+ *
+ * This work is open source software, licensed under the terms of the
+ * BSD license as described in the LICENSE file in the top-level directory.
+ */
+
+#include <stdio.h>
+
+extern void called_from_b(void);
+
+void
+called_from_a(void)
+{
+	puts(__func__);
+}
+
+void
+func_b(void)
+{
+	printf("%p\n", &called_from_b);
+	called_from_b();
+}

--- a/tests/tst-elf-circular-reloc.cc
+++ b/tests/tst-elf-circular-reloc.cc
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) 2025 Reliable System Software, Technische Universität Braunschweig.
+ *
+ * This work is open source software, licensed under the terms of the
+ * BSD license as described in the LICENSE file in the top-level directory.
+ */
+
+extern void func_a();
+extern void func_b();
+
+int
+main(void)
+{
+	func_a();
+	func_b();
+}


### PR DESCRIPTION
As suggested by @nyh, this adds a regression test case for the PR #1366, based on the minimal reproducer in this PR. With the patch from this PR applied, the `tst-elf-circular-reloc` test exits with a zero exit status. Without it, it fails to load with the ELF loader error message: “trying to execute or access missing symbol”.