### PR TITLE
Implement MSI support on the aarch64 architecture V2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -999,6 +999,10 @@ endif
 ifeq ($(conf_drivers_mmio),1)
 drivers += drivers/virtio-mmio.o
 endif
+ifeq ($(conf_drivers_nvme),1)
+drivers += drivers/nvme.o
+drivers += drivers/nvme-queue.o
+endif
 drivers += drivers/virtio-vring.o
 drivers += drivers/virtio-rng.o
 drivers += drivers/virtio-blk.o

--- a/arch/aarch64/arch-dtb.hh
+++ b/arch/aarch64/arch-dtb.hh
@@ -91,9 +91,9 @@ int dtb_get_timer_irq();
  * gets the GIC v2 distributor and cpu interface.
  * return false on failure.
  */
-bool dtb_get_gic_v2(u64 *dist, size_t *dist_len, u64 *cpu, size_t *cpu_len);
+bool dtb_get_gic_v2(u64 *dist, size_t *dist_len, u64 *cpu, size_t *cpu_len, u64 *v2m, size_t *v2m_len);
 
-bool dtb_get_gic_v3(u64 *dist, size_t *dist_len, u64 *redist, size_t *redist_len);
+bool dtb_get_gic_v3(u64 *dist, size_t *dist_len, u64 *redist, size_t *redist_len, u64 *its, size_t *its_len);
 
 /* int dtb_get_cpus_count();
  *

--- a/arch/aarch64/arch-setup.cc
+++ b/arch/aarch64/arch-setup.cc
@@ -198,6 +198,9 @@ void arch_init_premain()
 #if CONF_drivers_virtio_fs
 #include "drivers/virtio-fs.hh"
 #endif
+#if CONF_drivers_nvme
+#include "drivers/nvme.hh"
+#endif
 
 void arch_init_drivers()
 {
@@ -252,6 +255,9 @@ void arch_init_drivers()
 #endif
 #if CONF_drivers_virtio_fs
     drvman->register_driver(virtio::fs::probe);
+#endif
+#if CONF_drivers_nvme
+    drvman->register_driver(nvme::driver::probe);
 #endif
     boot_time.event("drivers probe");
     drvman->load_all();

--- a/arch/aarch64/arch-setup.cc
+++ b/arch/aarch64/arch-setup.cc
@@ -128,25 +128,15 @@ void arch_setup_free_memory()
 #endif
 
     //Locate GICv2 or GICv3 information in DTB and construct corresponding GIC driver
-    //and map relevant physical memory
-    u64 dist, redist, cpuif;
-    size_t dist_len, redist_len, cpuif_len;
-    if (dtb_get_gic_v3(&dist, &dist_len, &redist, &redist_len)) {
-        gic::gic = new gic::gic_v3_driver(dist, redist);
-        /* linear_map [TTBR0 - GIC REDIST] */
-        mmu::linear_map((void *)redist, (mmu::phys)redist, redist_len, "gic_redist", mmu::page_size,
-                        mmu::mattr::dev);
-    } else if (dtb_get_gic_v2(&dist, &dist_len, &cpuif, &cpuif_len)) {
-        gic::gic = new gic::gic_v2_driver(dist, cpuif);
-        /* linear_map [TTBR0 - GIC CPUIF] */
-        mmu::linear_map((void *)cpuif, (mmu::phys)cpuif, cpuif_len, "gic_cpuif", mmu::page_size,
-                        mmu::mattr::dev);
+    u64 dist, redist, cpuif, its, v2m;
+    size_t dist_len, redist_len, cpuif_len, its_len, v2m_len;
+    if (dtb_get_gic_v3(&dist, &dist_len, &redist, &redist_len, &its, &its_len)) {
+        gic::gic = new gic::gic_v3_driver(dist, dist_len, redist, redist_len, its, its_len);
+    } else if (dtb_get_gic_v2(&dist, &dist_len, &cpuif, &cpuif_len, &v2m, &v2m_len)) {
+        gic::gic = new gic::gic_v2_driver(dist, dist_len, cpuif, cpuif_len, v2m, v2m_len);
     } else {
         abort("arch-setup: failed to get GICv3 nor GiCv2 information from dtb.\n");
     }
-    /* linear_map [TTBR0 - GIC DIST] */
-    mmu::linear_map((void *)dist, (mmu::phys)dist, dist_len, "gic_dist", mmu::page_size,
-                    mmu::mattr::dev);
 
 #if CONF_drivers_pci
     if (!opt_pci_disabled) {

--- a/arch/aarch64/exceptions.hh
+++ b/arch/aarch64/exceptions.hh
@@ -17,6 +17,7 @@
 #include <osv/mutex.h>
 #include <osv/interrupt.hh>
 #include <vector>
+#include <atomic>
 
 #include "gic-common.hh"
 
@@ -56,9 +57,19 @@ public:
     /* invoke_interrupt returns false if unhandled */
     bool invoke_interrupt(unsigned int id);
 
-protected:
+    void init_msi_vector_base(u32 initial);
+    void set_max_msi_vector(u32 max) { _max_msi_vector = max; }
+
+private:
     void enable_irq(int id);
     void disable_irq(int id);
+
+    void enable_msi_vector(unsigned vector);
+
+    std::atomic<u32> _next_msi_vector;
+    u32 _max_msi_vector;
+    u32 _msi_vector_base;
+    std::function<void ()> _msi_handlers[gic::max_msi_handlers] = {};
 
     unsigned int nr_irqs; /* number of supported InterruptIDs, read from gic */
     osv::rcu_ptr<interrupt_desc> irq_desc[gic::max_nr_irqs];

--- a/arch/aarch64/gic-common.cc
+++ b/arch/aarch64/gic-common.cc
@@ -7,10 +7,16 @@
  */
 
 #include <osv/mmio.hh>
+#include <osv/mmu.hh>
 
 #include "gic-common.hh"
 
 namespace gic {
+
+gic_dist::gic_dist(mmu::phys b, size_t l) : _base(b)
+{
+    mmu::linear_map((void *)_base, _base, l, "gic_dist", mmu::page_size, mmu::mattr::dev);
+}
 
 u32 gic_dist::read_reg(gicd_reg reg)
 {

--- a/arch/aarch64/gic-v2.cc
+++ b/arch/aarch64/gic-v2.cc
@@ -7,12 +7,15 @@
  */
 
 #include <osv/mmio.hh>
-#include <osv/irqlock.hh>
+#include <osv/mmu.hh>
 #include <osv/kernel_config_logger_debug.h>
+#include <drivers/pci-function.hh>
 
 #include "processor.hh"
 #include "gic-v2.hh"
 #include "arm-clock.hh"
+
+extern class interrupt_table idt;
 
 namespace gic {
 
@@ -56,6 +59,11 @@ void gic_v2_dist::write_reg_grp(gicd_reg_irq2 reg, unsigned int irq, u8 value)
     old |= value << shift;
 
     mmio_setl((mmioaddr_t)_base + offset, old);
+}
+
+gic_v2_cpu::gic_v2_cpu(mmu::phys b, size_t l) : _base(b)
+{
+    mmu::linear_map((void *)_base, _base, l, "gic_cpuif", mmu::page_size, mmu::mattr::dev);
 }
 
 u32 gic_v2_cpu::read_reg(gicc_reg reg)
@@ -144,23 +152,41 @@ void gic_v2_driver::init_cpuif(int smp_idx)
 #endif
 }
 
+#define GIC2_V2M_TYPER_REG 0x8
+#define GIC2_V2M_MSI_BASE_MASK 0b11111111111ul //Mask with 11bits or 12
+void gic_v2_driver::init_v2m()
+{
+    if (!_v2m_base) {
+        return;
+    }
+    //GICv2m is somewhat documented in https://documentation-service.arm.com/static/5fae4f00ca04df4095c1c988?token=
+    //chapter 9 (Appendix E) - GICV2M ARCHITECTURE)
+    u64 typer = mmio_getl((mmioaddr_t)(_v2m_base + GIC2_V2M_TYPER_REG));
+
+    u64 msi_base = (typer >> 16) & GIC2_V2M_MSI_BASE_MASK;
+    idt.init_msi_vector_base(msi_base);
+
+    u64 msi_vector_num = typer & GIC2_V2M_MSI_BASE_MASK;
+    idt.set_max_msi_vector(msi_base + msi_vector_num - 1);
+}
+
 void gic_v2_driver::mask_irq(unsigned int id)
 {
-    WITH_LOCK(gic_lock) {
+    WITH_IRQ_LOCK(_gic_lock) {
         _gicd.write_reg_grp(gicd_reg_irq1::GICD_ICENABLER, id, 1);
     }
 }
 
 void gic_v2_driver::unmask_irq(unsigned int id)
 {
-    WITH_LOCK(gic_lock) {
+    WITH_IRQ_LOCK(_gic_lock) {
         _gicd.write_reg_grp(gicd_reg_irq1::GICD_ISENABLER, id, 1);
     }
 }
 
 void gic_v2_driver::set_irq_type(unsigned int id, irq_type type)
 {
-    WITH_LOCK(gic_lock) {
+    WITH_IRQ_LOCK(_gic_lock) {
         _gicd.write_reg_grp(gicd_reg_irq2::GICD_ICFGR, id, (u32)type << 1);
     }
 }
@@ -175,28 +201,21 @@ void gic_v2_driver::send_sgi(sgi_filter filter, int smp_idx, unsigned int vector
 {
     u32 sgir = 0;
     assert(vector <= 0x0f);
-    irq_save_lock_type irq_lock;
 
-    //We disable interrupts before taking a lock to prevent scenarios
-    //when interrupt arrives after gic_lock is taken and interrupt handler
-    //ends up calling send_sgi() (nested example) and stays spinning forever
-    //in attempt to take a lock again
-    WITH_LOCK(irq_lock) {
-        WITH_LOCK(gic_lock) {
-            switch (filter) {
-            case sgi_filter::SGI_TARGET_LIST:
-                sgir = 1U << (((u32)smp_idx) + 16u);
-                break;
-            case sgi_filter::SGI_TARGET_ALL_BUT_SELF:
-                sgir = 1 << 24u;
-                break;
-            case sgi_filter::SGI_TARGET_SELF:
-                sgir = 2 << 24u;
-                break;
-            }
-            asm volatile ("dmb ishst");
-            _gicd.write_reg(gicd_reg::GICD_SGIR, sgir | vector);
+    WITH_IRQ_LOCK(_gic_lock) {
+        switch (filter) {
+        case sgi_filter::SGI_TARGET_LIST:
+            sgir = 1U << (((u32)smp_idx) + 16u);
+            break;
+        case sgi_filter::SGI_TARGET_ALL_BUT_SELF:
+            sgir = 1 << 24u;
+            break;
+        case sgi_filter::SGI_TARGET_SELF:
+            sgir = 2 << 24u;
+            break;
         }
+        asm volatile ("dmb ishst");
+        _gicd.write_reg(gicd_reg::GICD_SGIR, sgir | vector);
     }
 }
 
@@ -210,4 +229,23 @@ void gic_v2_driver::end_irq(unsigned int iar)
     _gicc.write_reg(gicc_reg::GICC_EOIR, iar);
 }
 
+void gic_v2_driver::map_msi_vector(unsigned int vector, pci::function* dev, u32 target_cpu)
+{
+    WITH_IRQ_LOCK(_gic_lock) {
+        unsigned int reg = vector / 4;
+        u32 cpuMask = _gicd.read_reg_at_offset((u32)gicd_reg_irq8::GICD_ITARGETSR, reg * 4);
+
+        unsigned int bitOffset = (vector % 4) * 8;
+        cpuMask &= ~(0b11111111 << bitOffset);
+        cpuMask |= ((1 << target_cpu) << bitOffset);
+        _gicd.write_reg_at_offset((u32)gicd_reg_irq8::GICD_ITARGETSR, reg * 4, cpuMask);
+    }
+}
+
+#define GIC_V2M_MSI_SETSPI_NS        0x40
+void gic_v2_driver::msi_format(u64 *address, u32 *data, int vector)
+{
+    *address = _v2m_base + GIC_V2M_MSI_SETSPI_NS;
+    *data = vector;
+}
 }

--- a/arch/aarch64/gic-v3.cc
+++ b/arch/aarch64/gic-v3.cc
@@ -45,12 +45,19 @@
  */
 
 #include <osv/mmio.hh>
-#include <osv/irqlock.hh>
 #include <osv/sched.hh>
+#include <osv/contiguous_alloc.hh>
+#include <osv/ilog2.hh>
+#include <osv/mmu.hh>
+#include <drivers/pci-function.hh>
+
+#include <algorithm>
 
 #include "processor.hh"
 #include "gic-v3.hh"
 #include "arm-clock.hh"
+
+extern class interrupt_table idt;
 
 #define isb() ({ asm volatile ("isb"); })
 
@@ -78,14 +85,67 @@ void gic_v3_dist::enable()
     wait_for_write_complete();
 }
 
+gic_v3_redist::gic_v3_redist(mmu::phys b, size_t l) : _base(b)
+{
+    mmu::linear_map((void *)_base, _base, l, "gic_redist", mmu::page_size, mmu::mattr::dev);
+}
+
+void gic_v3_redist::init_cpu_base(int smp_idx)
+{
+    if (!smp_idx) {
+        _cpu_bases = new mmu::phys[sched::cpus.size()];
+    }
+
+    uint64_t mpidr = processor::read_mpidr();
+
+    u64 offset = 0;
+    u64 typer;
+    do {
+        typer = mmio_getq((mmioaddr_t)_base + (offset + GICR_TYPER));
+
+        if (((mpidr & MPIDR_AFF3_MASK) >> 32) == GICR_TYPER_AFF3(typer) &&
+            ((mpidr & MPIDR_AFF2_MASK) >> 16) == GICR_TYPER_AFF2(typer) &&
+            ((mpidr & MPIDR_AFF1_MASK) >> 8) == GICR_TYPER_AFF1(typer) &&
+             (mpidr & MPIDR_AFF0_MASK) == GICR_TYPER_AFF0(typer)) {
+            break;
+        }
+        offset += GICR_STRIDE;
+        if (typer & GICR_TYPER_VLPIS) {
+            offset += GICR_STRIDE;
+        }
+    } while (!(typer & GICR_TYPER_LAST));
+
+    _cpu_bases[smp_idx] = _base + offset;
+}
+
+void gic_v3_redist::init_lpis(int smp_idx, u64 prop_base, u64 pend_base)
+{
+    //Set common LPI configuration table
+    write64_at_offset(smp_idx, GICR_PROPBASER, prop_base);
+    //Set redistributor specific LPI pending table
+    write64_at_offset(smp_idx, GICR_PENDBASER, pend_base);
+    //Enable LPIs
+    write_at_offset(smp_idx, GICR_CTLR, GICR_CTLR_EnableLPIs);
+}
+
 u32 gic_v3_redist::read_at_offset(int smp_idx, u32 offset)
 {
-    return mmio_getl((mmioaddr_t)_base + smp_idx * GICR_STRIDE + offset);
+    return mmio_getl((mmioaddr_t)_cpu_bases[smp_idx] + offset);
+}
+
+u64 gic_v3_redist::read64_at_offset(int smp_idx, u32 offset)
+{
+    return mmio_getq((mmioaddr_t)_cpu_bases[smp_idx] + offset);
 }
 
 void gic_v3_redist::write_at_offset(int smp_idx, u32 offset, u32 value)
 {
-    mmio_setl((mmioaddr_t)_base + smp_idx * GICR_STRIDE + offset, value);
+    mmio_setl((mmioaddr_t)_cpu_bases[smp_idx] + offset, value);
+}
+
+void gic_v3_redist::write64_at_offset(int smp_idx, u32 offset, u64 value)
+{
+    mmio_setq((mmioaddr_t)_cpu_bases[smp_idx] + offset, value);
 }
 
 void gic_v3_redist::wait_for_write_complete()
@@ -95,6 +155,20 @@ void gic_v3_redist::wait_for_write_complete()
     do {
         val = mmio_getl((mmioaddr_t)_base);
     } while (val & GICD_CTLR_WRITE_COMPLETE);
+}
+
+void gic_v3_redist::init_rdbase(int smp_idx, bool pta)
+{
+    if (!smp_idx) {
+        _rdbases = new mmu::phys[sched::cpus.size()];
+    }
+
+    if (pta) {
+        _rdbases[smp_idx] = (_cpu_bases[smp_idx]) >> 16;
+    } else {
+        u64 typer = read64_at_offset(smp_idx, GICR_TYPER);
+        _rdbases[smp_idx] = GICR_TYPER_PROC_NUM(typer);
+    }
 }
 
 static uint32_t get_cpu_affinity(void)
@@ -107,6 +181,223 @@ static uint32_t get_cpu_affinity(void)
         (mpidr & MPIDR_AFF0_MASK);
 
     return (uint32_t)aff;
+}
+
+gic_v3_its::gic_v3_its(mmu::phys b, size_t l) : _base(b)
+{
+    if (b && l) {
+        mmu::linear_map((void *)_base, _base, l, "gic_its", mmu::page_size,
+                        mmu::mattr::dev);
+    }
+}
+
+u64 gic_v3_its::read_reg64(gic_its_reg reg)
+{
+    return mmio_getq((mmioaddr_t)_base + (u32)reg);
+}
+
+u64 gic_v3_its::read_reg64_at_offset(gic_its_reg reg, u32 offset)
+{
+    return mmio_getq((mmioaddr_t)_base + (u32)reg + offset);
+}
+
+void gic_v3_its::write_reg(gic_its_reg reg, u32 value)
+{
+    mmio_setl((mmioaddr_t)_base + (u32)reg, value);
+}
+
+void gic_v3_its::write_reg64(gic_its_reg reg, u64 value)
+{
+    mmio_setq((mmioaddr_t)_base + (u32)reg, value);
+}
+
+void gic_v3_its::write_reg64_at_offset(gic_its_reg reg, u32 offset, u64 value)
+{
+    mmio_setq((mmioaddr_t)_base + (u32)reg + offset, value);
+}
+
+void gic_v3_its::read_type_register()
+{
+    _typer = read_reg64(gic_its_reg::GICITS_TYPER);
+}
+
+//The 4K queue is enough for 128 commands before it wraps around
+#define GIC_ITS_CMD_QUEUE_SIZE  0x1000 //4 KB
+//https://developer.arm.com/documentation/102923/0100/ITS/The-command-queue
+void gic_v3_its::initialize_cmd_queue()
+{
+    //Queue needs to be 64KB aligned
+    _cmd_queue = memory::alloc_phys_contiguous_aligned(GIC_ITS_CMD_QUEUE_SIZE, 0x10000);
+    memset(_cmd_queue, 0, GIC_ITS_CMD_QUEUE_SIZE);
+
+    u64 cmd_queue_pa = mmu::virt_to_phys(_cmd_queue);
+    u64 queue_size_in_pages = GIC_ITS_CMD_QUEUE_SIZE / mmu::page_size;
+    //
+    //Read https://developer.arm.com/documentation/ddi0601/2024-09/External-Registers/GITS-CBASER--ITS-Command-Queue-Descriptor
+    write_reg64(gic_its_reg::GICITS_CBASER, GITS_CBASER_VALID | cmd_queue_pa | (queue_size_in_pages - 1));
+    write_reg64(gic_its_reg::GICITS_CWRITER, 0);
+}
+
+void gic_v3_its::enqueue_cmd(its_cmd *cmd)
+{
+    u64 cread = read_reg64(gic_its_reg::GICITS_CREADR);
+    u64 cwrite = read_reg64(gic_its_reg::GICITS_CWRITER);
+    //
+    //Wait until queue is not full
+    while (cread == cwrite + sizeof(*cmd)) {
+        asm volatile ("isb sy");
+        cread = read_reg64(gic_its_reg::GICITS_CREADR);
+    }
+
+    its_cmd *cmd_to_write = (its_cmd *)(_cmd_queue + cwrite);
+    *cmd_to_write = *cmd;
+
+    cwrite += sizeof(*cmd);
+    if (cwrite == GIC_ITS_CMD_QUEUE_SIZE) {
+        cwrite = 0;
+    }
+
+    write_reg64(gic_its_reg::GICITS_CWRITER, cwrite);
+}
+
+#define CPUID_2_ICID(cpuId) (cpuId)
+
+//See 6.3.9 in GIC3/4 spec
+//"Maps the Device table entry associated with DeviceID to its associated ITT,
+// defined by itt_pa and itt_size."
+void gic_v3_its::cmd_mapd(u32 dev_id, u64 itt_pa, u64 itt_size)
+{
+    its_cmd cmd;
+    cmd.data[0] = ((u64)dev_id << 32) | (u32)gic_its_cmd::ITS_CMD_MAPD;
+    cmd.data[1] = itt_size;
+    cmd.data[2] = ITS_MAPD_V | itt_pa;
+    cmd.data[3] = 0;
+    enqueue_cmd(&cmd);
+}
+
+//See 6.3.11 in GIC3/4 spec
+//"Maps the event defined by EventID and DeviceID to its associated ITE, defined by ICID and pINTID in
+// the ITT associated with DeviceID"
+void gic_v3_its::cmd_mapti(u32 dev_id, int vector, int smp_idx)
+{
+    its_cmd cmd;
+    cmd.data[0] = ((u64)dev_id << 32) | (u32)gic_its_cmd::ITS_CMD_MAPTI;
+    u32 event_id = vector - GIC_LPI_INTS_START;
+    cmd.data[1] = ((u64)vector << 32) | event_id;
+    cmd.data[2] = CPUID_2_ICID(smp_idx);
+    cmd.data[3] = 0;
+    enqueue_cmd(&cmd);
+}
+
+//See 6.3.13 in GIC3/4 spec
+//"Updates the ICID field in the ITT entry for the event defined by DeviceID and EventID."
+void gic_v3_its::cmd_movi(u32 dev_id, int vector, int smp_idx)
+{
+    its_cmd cmd;
+    cmd.data[0] = ((u64)dev_id << 32) | (u32)gic_its_cmd::ITS_CMD_MOVI;
+    u32 event_id = vector - GIC_LPI_INTS_START;
+    cmd.data[1] = event_id;
+    cmd.data[2] = CPUID_2_ICID(smp_idx);
+    cmd.data[3] = 0;
+    enqueue_cmd(&cmd);
+}
+
+//See 6.3.6 in GIC3/4 spec
+//"Specifies that the ITS must ensure that any caching in the Redistributors associated with the specified
+// EventID is consistent with the LPI Configuration tables held in memory."
+void gic_v3_its::cmd_inv(u32 dev_id, int vector)
+{
+    its_cmd cmd;
+    cmd.data[0] = ((u64)dev_id << 32) | (u32)gic_its_cmd::ITS_CMD_INV;
+    u32 event_id = vector - GIC_LPI_INTS_START;
+    cmd.data[1] = event_id;
+    cmd.data[2] = cmd.data[3] = 0;
+    enqueue_cmd(&cmd);
+}
+
+//See 6.3.4 in GIC3/4 spec
+//"Instructs the appropriate Redistributor to remove the pending state of the interrupt."
+void gic_v3_its::cmd_discard(u32 dev_id, int vector)
+{
+    its_cmd cmd;
+    cmd.data[0] = ((u64)dev_id << 32) | (u32)gic_its_cmd::ITS_CMD_DISCARD;
+    u32 event_id = vector - GIC_LPI_INTS_START;
+    cmd.data[1] = event_id;
+    cmd.data[2] = cmd.data[3] = 0;
+    enqueue_cmd(&cmd);
+}
+
+//See 6.3.14 in GIC3/4 spec
+//"Ensures all outstanding ITS operations associated with physical interrupts for the Redistributor
+// specified by RDbase are globally observed before any further ITS commands are executed."
+void gic_v3_its::cmd_sync(mmu::phys rdbase)
+{
+    its_cmd cmd;
+    cmd.data[0] = (u64)gic_its_cmd::ITS_CMD_SYNC;
+    cmd.data[2] = rdbase << 16;
+    cmd.data[1] = cmd.data[3] = 0;
+    enqueue_cmd(&cmd);
+}
+
+//See 6.3.8 in GIC3/4 spec
+//"Maps the Collection table entry defined by ICID to the target Redistributor, defined by RDbase"
+void gic_v3_its::cmd_mapc(int smp_idx, mmu::phys rdbase)
+{
+    its_cmd cmd;
+    cmd.data[0] = (u32)gic_its_cmd::ITS_CMD_MAPC;
+    cmd.data[1] = 0;
+    cmd.data[2] = ITS_MAPC_V | (rdbase << 16) | CPUID_2_ICID(smp_idx);
+    cmd.data[3] = 0;
+    enqueue_cmd(&cmd);
+}
+
+void gic_v3_driver::init_lpis(int smp_idx)
+{
+    //Check if ITS is supported which is for example not a case on Firecracker
+    if (!_gits.base()) {
+        return;
+    }
+
+    //Identify number of LPIs supported by GIC and setup global configuration table
+    if (smp_idx == 0) {
+        //See https://developer.arm.com/documentation/ddi0601/2022-06/External-Registers/GICD-TYPER--Interrupt-Controller-Type-Register?lang=en
+        //Read bits 15:11 (num_LPIs) of GICD_TYPER
+        u32 typer = _gicd.read_reg(gicd_reg::GICD_TYPER);
+        u32 num_lpis = (typer >> 11) & GICD_TYPER_LPI_NUM_MASK;
+        if (num_lpis) {
+            _msi_vector_num = 1UL << (num_lpis + 1);
+        } else { //Determine using the IDBits field
+            u32 id_bits = (typer >> 19) & GICD_TYPER_IDBITS_MASK;
+            _msi_vector_num = (1UL << (id_bits + 1)) - GIC_LPI_INTS_START;
+        }
+        //TODO: Investigate using smaller number of LPIs using GICR_PROPBASER.IDbits
+        //Read https://developer.arm.com/documentation/102923/0100/Redistributors/Initial-configuration-of-a-Redistributor
+        //and https://developer.arm.com/documentation/ddi0601/2024-09/External-Registers/GICR-PROPBASER--Redistributor-Properties-Base-Address-Register
+        _msi_vector_num = std::max(_msi_vector_num, (u16)4096);
+
+        //Allocate common LPI configuration table
+        void *config_table = memory::alloc_phys_contiguous_aligned(_msi_vector_num, 4096);
+        memset(config_table, 0, _msi_vector_num);
+        _lpi_config_table = (u8*)config_table;
+
+        u64 id_bits = ilog2_roundup<u64>(_msi_vector_num + GIC_LPI_INTS_START) - 1;
+        _lpi_prop_base = mmu::virt_to_phys(config_table) | id_bits;
+
+        //Allocate LPI pending table for each redistributor
+        //From https://developer.arm.com/documentation/102923/0100/Redistributors:
+        //"Each Redistributor has its own LPI Pending table, and these tables are not shared between Redistributors."
+        _lpi_pend_bases = new u64[sched::cpus.size()];
+        size_t pending_table_size = (_msi_vector_num + GIC_LPI_INTS_START) / 8;
+        for (unsigned c = 0; c < sched::cpus.size(); c++) {
+            void *pending_table = memory::alloc_phys_contiguous_aligned(pending_table_size, 64 * 1024);
+            memset(pending_table, 0, pending_table_size);
+            //Read about PTZ here - https://developer.arm.com/documentation/ddi0601/2024-12/External-Registers/GICR-PENDBASER--Redistributor-LPI-Pending-Table-Base-Address-Register
+            _lpi_pend_bases[c] = mmu::virt_to_phys(pending_table) | GICR_PENDBASER_PTZ;
+        }
+    }
+
+    //Set LPI configuration, pending table for each redistributor
+    _gicrd.init_lpis(smp_idx, _lpi_prop_base, _lpi_pend_bases[smp_idx]);
 }
 
 /* to be called only from the boot CPU */
@@ -178,33 +469,33 @@ void gic_v3_driver::init_redist(int smp_idx)
     _mpids_by_smpid[smp_idx] = processor::read_mpidr();
 
     /* Wake up CPU redistributor */
-    u32 val = _gicr.read_at_offset(smp_idx, GICR_WAKER);
+    u32 val = _gicrd.read_at_offset(smp_idx, GICR_WAKER);
     val &= ~GICR_WAKER_ProcessorSleep;
-    _gicr.write_at_offset(smp_idx, GICR_WAKER, val);
+    _gicrd.write_at_offset(smp_idx, GICR_WAKER, val);
 
     /* Poll GICR_WAKER.ChildrenAsleep */
     do {
-        val = _gicr.read_at_offset(smp_idx, GICR_WAKER);
+        val = _gicrd.read_at_offset(smp_idx, GICR_WAKER);
     } while ((val & GICR_WAKER_ChildrenAsleep));
 
     /* Set PPI and SGI to a default value */
     for (unsigned int i = 0; i < GIC_SPI_BASE; i += GICD_I_PER_IPRIORITYn)
-        _gicr.write_at_offset(smp_idx, GICR_IPRIORITYR4(i), GICD_IPRIORITY_DEF);
+        _gicrd.write_at_offset(smp_idx, GICR_IPRIORITYR4(i), GICD_IPRIORITY_DEF);
 
     /* Deactivate SGIs and PPIs as the state is unknown at boot */
-    _gicr.write_at_offset(smp_idx, GICR_ICACTIVER0, GICD_DEF_ICACTIVERn);
+    _gicrd.write_at_offset(smp_idx, GICR_ICACTIVER0, GICD_DEF_ICACTIVERn);
 
     /* Disable all PPIs */
-    _gicr.write_at_offset(smp_idx, GICR_ICENABLER0, GICD_DEF_PPI_ICENABLERn);
+    _gicrd.write_at_offset(smp_idx, GICR_ICENABLER0, GICD_DEF_PPI_ICENABLERn);
 
     /* Configure SGIs and PPIs as non-secure Group 1 */
-    _gicr.write_at_offset(smp_idx, GICR_IGROUPR0, GICD_DEF_IGROUPRn);
+    _gicrd.write_at_offset(smp_idx, GICR_IGROUPR0, GICD_DEF_IGROUPRn);
 
     /* Enable all SGIs */
-    _gicr.write_at_offset(smp_idx, GICR_ISENABLER0, GICD_DEF_SGI_ISENABLERn);
+    _gicrd.write_at_offset(smp_idx, GICR_ISENABLER0, GICD_DEF_SGI_ISENABLERn);
 
     /* Wait for completion */
-    _gicr.wait_for_write_complete();
+    _gicrd.wait_for_write_complete();
 
     /* Enable system register access */
     val = READ_SYS_REG32(ICC_SRE_EL1);
@@ -229,32 +520,116 @@ void gic_v3_driver::init_redist(int smp_idx)
     //Enable cpu timer on secondary CPU
     if (smp_idx) {
         u32 val = 1UL << (get_timer_irq_id() % GICR_I_PER_ISENABLERn);
-        _gicr.write_at_offset(smp_idx, GICR_ISENABLER0, val);
+        _gicrd.write_at_offset(smp_idx, GICR_ISENABLER0, val);
+    }
+
+    if (!smp_idx) {
+        idt.init_msi_vector_base(GIC_LPI_INTS_START);
+        idt.set_max_msi_vector(GIC_LPI_INTS_START + _msi_vector_num - 1);
     }
 }
 
+//https://developer.arm.com/documentation/102923/0100/ITS/The-sizes-and-layout-of-Collection-and-Device-tables
+//"The location and size of the Collection and Device tables is configured
+// using the GITS_BASERn registers. Software must allocate memory for
+// these tables and configure the GITS_BASERn registers before enabling the ITS."
+void gic_v3_driver::init_its_device_or_collection_table(int idx)
+{
+    //Read https://developer.arm.com/documentation/ddi0601/2024-09/External-Registers/GITS-BASER-n---ITS-Table-Descriptors
+    u32 offset = idx * 8;
+    u64 base = _gits.read_reg64_at_offset(gic_its_reg::GICITS_BASER, offset);
+
+    u64 type = GITS_TABLE_TYPE(base); //Bits [58:56]
+    if (type != GITS_TABLE_DEVICES_TYPE && type != GITS_TABLE_COLLECTIONS_TYPE) {
+        return;
+    }
+
+    //
+    //"Software can allocate a flat (single level) table or two-level tables."
+    //We allocate a flat table
+    u64 page_size_type = GITS_PAGE_SIZE(base); //Bits [9:8]
+    u64 table_size = page_size_type == GITS_TABLE_PAGE_SIZE_4K ? 0x1000 :
+	           (page_size_type == GITS_TABLE_PAGE_SIZE_16K ? 0x4000 : 0x10000);
+
+    //if (type == GITS_TABLE_DEVICES_TYPE) {
+    //    //TODO: Calculate maximum devices count and save it somewhere
+    //}
+
+    void *table = memory::alloc_phys_contiguous_aligned(table_size, table_size);
+    memset(table, 0, table_size);
+
+    u64 table_pa = mmu::virt_to_phys(table);
+    base = (base & ~GITS_TABLE_BASE_PA_MASK) | table_pa;
+    _gits.write_reg64_at_offset(gic_its_reg::GICITS_BASER, offset, GITS_BASER_VALID | base);
+}
+
+//https://developer.arm.com/documentation/102923/0100/ITS/Initial-configuration-of-an-ITS
+void gic_v3_driver::init_its(int smp_idx)
+{
+    //Check if ITS is supported which is for example not a case on Firecracker
+    if (!_gits.base()) {
+        return;
+    }
+
+    if (smp_idx == 0) {
+        _gits.read_type_register();
+
+        //Initialize the Device and Collection tables
+        for (int table_idx = 0; table_idx < GITS_TABLE_NUM_MAX; table_idx++) {
+            init_its_device_or_collection_table(table_idx);
+        }
+
+        //Initialize command queue
+        _gits.initialize_cmd_queue();
+
+        // Enable ITS
+        _gits.write_reg(gic_its_reg::GICITS_CTLR, GITS_CTLR_ENABLED);
+    }
+
+    //Init on each cpu
+    _gicrd.init_rdbase(smp_idx, _gits.is_typer_pta());
+    mmu::phys rdbase = _gicrd.rdbase(smp_idx);
+
+    if (smp_idx == 0) {
+        // Init on primary CPU
+        _gits.cmd_mapc(smp_idx, rdbase);
+    } else {
+        //Init on secondary cpu
+        //We may experience race between many secondary CPUs
+        //during early SMP boot so let us protect with spinlock
+        WITH_IRQ_LOCK(_smp_init_its_lock) {
+            _gits.cmd_mapc(smp_idx, rdbase);
+        }
+    }
+}
+
+#define GIC_LPI_ENABLE  0x01
 void gic_v3_driver::mask_irq(unsigned int irq)
 {
-    WITH_LOCK(gic_lock) {
-        if (irq >= GIC_SPI_BASE) {
+    WITH_IRQ_LOCK(_gic_lock) {
+        if (irq >= GIC_LPI_INTS_START) {
+            _lpi_config_table[irq - GIC_LPI_INTS_START] |= ~GIC_LPI_ENABLE;
+        } else if (irq >= GIC_SPI_BASE) {
             u32 val = 1UL << (irq % GICD_I_PER_ICENABLERn);
             _gicd.write_reg_at_offset((u32)gicd_reg_irq1::GICD_ICENABLER, 4 * (irq >> 5), val);
-         } else {
+        } else {
             u32 val = 1UL << (irq % GICR_I_PER_ICENABLERn);
-            _gicr.write_at_offset(sched::cpu::current()->id, GICR_ICENABLER0, val);
-         }
+            _gicrd.write_at_offset(sched::cpu::current()->id, GICR_ICENABLER0, val);
+        }
     }
 }
 
 void gic_v3_driver::unmask_irq(unsigned int irq)
 {
-    WITH_LOCK(gic_lock) {
-        if (irq >= GIC_SPI_BASE) {
+    WITH_IRQ_LOCK(_gic_lock) {
+        if (irq >= GIC_LPI_INTS_START) {
+            _lpi_config_table[irq - GIC_LPI_INTS_START] |= GIC_LPI_ENABLE;
+        } else if (irq >= GIC_SPI_BASE) {
             u32 val = 1UL << (irq % GICD_I_PER_ISENABLERn);
             _gicd.write_reg_at_offset((u32)gicd_reg_irq1::GICD_ISENABLER, 4 * (irq >> 5), val);
         } else {
             u32 val = 1UL << (irq % GICR_I_PER_ISENABLERn);
-            _gicr.write_at_offset(sched::cpu::current()->id, GICR_ISENABLER0, val);
+            _gicrd.write_at_offset(sched::cpu::current()->id, GICR_ISENABLER0, val);
         }
     }
 }
@@ -266,7 +641,7 @@ void gic_v3_driver::set_irq_type(unsigned int id, irq_type type)
         return;
     }
 
-    WITH_LOCK(gic_lock) {
+    WITH_IRQ_LOCK(_gic_lock) {
         auto offset = 4 * ((id) >> 4);
         auto val = _gicd.read_reg_at_offset((u32)gicd_reg_irq2::GICD_ICFGR, offset);
         u32 oldmask = (val >> ((id % GICD_I_PER_ICFGRn) * 2)) & GICD_ICFGR_MASK;
@@ -314,16 +689,9 @@ void gic_v3_driver::send_sgi(sgi_filter filter, int smp_idx, unsigned int vector
                         ((aff0 >> 4) << ICC_SGIxR_EL1_RS_SHIFT) | (1 << (aff0 & 0xf));
     }
 
-    //We disable interrupts before taking a lock to prevent scenarios
-    //when interrupt arrives after gic_lock is taken and interrupt handler
-    //ends up calling send_sgi() (nested example) and stays spinning forever
-    //in attempt to take a lock again
     /* Generate interrupt */
-    irq_save_lock_type irq_lock;
-    WITH_LOCK(irq_lock) {
-        WITH_LOCK(gic_lock) {
-            WRITE_SYS_REG64(ICC_SGI1R_EL1, sgi_register);
-        }
+    WITH_IRQ_LOCK(_gic_lock) {
+        WRITE_SYS_REG64(ICC_SGI1R_EL1, sgi_register);
     }
 }
 
@@ -346,6 +714,125 @@ void gic_v3_driver::end_irq(unsigned int irq)
     /* Deactivate */
     WRITE_SYS_REG32(ICC_DIR_EL1, irq);
     isb();
+}
+
+u32 gic_v3_driver::pci_device_id(pci::function* dev)
+{
+    u8 bus, device, function;
+    dev->get_bdf(bus, device, function);
+    return (((u32)bus) << 8) | (((u32)device) << 3) | (u32)function;
+}
+
+void gic_v3_driver::allocate_msi_dev_mapping(pci::function* dev)
+{
+    //Read https://developer.arm.com/documentation/102923/0100/ITS/Mapping-an-interrupt-to-a-Redistributor
+
+    //Check if there is an Interrupt Translation Table (ITT) for this device
+    //If not create and register it in ITS
+    u32 device_id = pci_device_id(dev);
+
+    //Iterate over existing entries to see if one for this device
+    //already exists and return; otherwise find an index to where to
+    //store new entry
+    unsigned itt_index = 0;
+    WITH_IRQ_LOCK(_gic_lock) {
+        for (; itt_index < max_msi_handlers; itt_index++) {
+            if (_itt_by_device_id[itt_index].first == device_id) {
+                //We already have an itt entry for this device
+                return;
+            } else if (!_itt_by_device_id[itt_index].second) {
+                //Empty slot - stop
+                _itt_by_device_id[itt_index].second = (void*)1; //Mark it reserved
+                break;
+            }
+        }
+    }
+
+    //We cannot support more devices than number of vectors limited
+    //by max_msi_handlers
+    assert(itt_index < max_msi_handlers);
+
+    u64 entries_num = 1ull << ilog2_roundup<u64>(_msi_vector_num);
+    u64 itt_size = entries_num * (_gits.itt_entry_size() + 1);
+    itt_size = std::max(itt_size, (u64)256);
+
+    //We explicitly allocate memory below to make sure it happens
+    //when interrupts are enabled
+    void *itt = memory::alloc_phys_contiguous_aligned(itt_size, 256);
+    memset(itt, 0, itt_size);
+
+    //Register translation entry in ITS
+    u64 itt_pa = mmu::virt_to_phys(itt);
+    _irq_lock.lock();
+    WITH_LOCK(_gic_lock) {
+        _itt_by_device_id[itt_index] = std::make_pair(device_id, itt);
+        _gits.cmd_mapd(device_id, itt_pa, ilog2_roundup<u64>(entries_num) - 1);
+    }
+    _irq_lock.unlock();
+}
+
+void gic_v3_driver::map_msi_vector(unsigned int vector, pci::function* dev, u32 target_cpu)
+{
+    auto index = vector - GIC_LPI_INTS_START;
+    assert(index < max_msi_handlers);
+
+    WITH_IRQ_LOCK(_gic_lock) {
+        u32 device_id = pci_device_id(dev);
+
+        auto vector_cpu = _cpu_by_vector[index];
+        if (!vector_cpu) {
+            //Read https://developer.arm.com/documentation/102923/0100/ITS/Mapping-an-interrupt-to-a-Redistributor
+
+            //Map event ID to collection ID|cpu
+            _gits.cmd_mapti(device_id, vector, target_cpu);
+            _gits.cmd_inv(device_id, vector);
+
+            _cpu_by_vector[index] = target_cpu + 1;
+
+            //Sync redistributor
+            mmu::phys rdbase = _gicrd.rdbase(target_cpu);
+            _gits.cmd_sync(rdbase);
+        } else if ((vector_cpu - 1) != target_cpu) { //We need to move interrupt to different redistributor (cpu)
+            //Read https://developer.arm.com/documentation/102923/0100/ITS/Migrating-interrupts-between-Redistributors
+
+            //Re-Map event ID to collection ID|cpu
+            _gits.cmd_movi(device_id, vector, target_cpu);
+            _gits.cmd_inv(device_id, vector);
+            //
+            //Sync old redistributor
+            mmu::phys rdbase = _gicrd.rdbase(vector_cpu - 1);
+            _gits.cmd_sync(rdbase);
+
+            _cpu_by_vector[index] = target_cpu + 1;
+        }
+    }
+}
+
+void gic_v3_driver::unmap_msi_vector(unsigned int vector, pci::function* dev)
+{
+    auto index = vector - GIC_LPI_INTS_START;
+    assert(index < max_msi_handlers);
+
+    WITH_IRQ_LOCK(_gic_lock) {
+        auto vector_cpu = _cpu_by_vector[index];
+        if (vector_cpu) {
+            u32 device_id = pci_device_id(dev);
+
+            _gits.cmd_discard(device_id, vector);
+            _gits.cmd_inv(device_id, vector);
+
+            //Sync redistributor
+            mmu::phys rdbase = _gicrd.rdbase(vector_cpu - 1);
+            _gits.cmd_sync(rdbase);
+        }
+    }
+}
+
+#define GITS_TRANSLATER 0x10040
+void gic_v3_driver::msi_format(u64 *address, u32 *data, int vector)
+{
+    *address = _gits.base() + GITS_TRANSLATER;
+    *data = vector - GIC_LPI_INTS_START;
 }
 
 }

--- a/arch/aarch64/gic-v3.hh
+++ b/arch/aarch64/gic-v3.hh
@@ -48,6 +48,7 @@
 #define GIC_V3_HH
 
 #include "gic-common.hh"
+#include <osv/spinlock.h>
 
 #define GICD_CTLR_WRITE_COMPLETE   (1UL << 31)
 #define GICD_CTLR_ARE_NS           (1U << 4)
@@ -58,6 +59,8 @@
 #define GICD_ICFGR_TRIG_LVL        (0 << 1)
 #define GICD_ICFGR_TRIG_EDGE       (1 << 1)
 #define GICD_ICFGR_TRIG_MASK       0x2
+#define GICD_TYPER_LPI_NUM_MASK    0x1f
+#define GICD_TYPER_IDBITS_MASK     0x1f
 
 #define GICD_IROUTER_BASE          (0x6000)
 #define MPIDR_AFF3_MASK	            0xff00000000
@@ -81,10 +84,13 @@
 	((((uint64_t)(aff) << 8) & MPIDR_AFF3_MASK) | ((aff) & 0xffffff) | \
 	 ((uint64_t)(mode) << 31))
 
+#define GIC_LPI_INTS_START         8192
+
 #define GICR_STRIDE                (0x20000)
 #define GICR_SGI_BASE              (0x10000)
 
 #define GICR_CTLR                  (0x0000)
+#define GICR_CTLR_EnableLPIs       (1U)
 #define GICR_IIDR                  (0x0004)
 #define GICR_TYPER                 (0x0008)
 #define GICR_STATUSR               (0x0010)
@@ -96,9 +102,12 @@
 #define GICR_INVLPIR               (0x00A0)
 #define GICR_INVALLR               (0x00B0)
 #define GICR_SYNCR                 (0x00C0)
+#define GICR_TYPER_LAST            (0b10000)
+#define GICR_TYPER_VLPIS           (0b10)
 
 #define GICR_WAKER_ProcessorSleep  (1U << 1)
 #define GICR_WAKER_ChildrenAsleep  (1U << 2)
+#define GICR_TYPER_PROC_NUM(type)  (((type) & 0xffff00) >> 8)
 
 #define GICR_IPRIORITYR4(n)        (GICR_SGI_BASE + 0x0400 + 4 * ((n) >> 2))
 
@@ -117,6 +126,11 @@
 #define GICR_IGRPMODR0             (GICR_SGI_BASE + 0x0D00)
 #define GICR_NSACR                 (GICR_SGI_BASE + 0x0E00)
 
+#define GICR_TYPER_AFF3(type)      (((type) & 0xff00000000000000) >> 56)
+#define GICR_TYPER_AFF2(type)      (((type) & 0x00ff000000000000) >> 48)
+#define GICR_TYPER_AFF1(type)      (((type) & 0x0000ff0000000000) >> 40)
+#define GICR_TYPER_AFF0(type)      (((type) & 0x000000ff00000000) >> 32)
+
 #define GICD_DEF_PPI_ICENABLERn	   0xffff0000
 #define GICD_DEF_SGI_ISENABLERn    0xffff
 
@@ -124,6 +138,8 @@
 
 #define GICR_I_PER_ICENABLERn      32
 #define GICR_I_PER_ISENABLERn      32
+
+#define GICR_PENDBASER_PTZ         (1UL << 62)
 
 /*
  * GIC System register assembly aliases
@@ -144,7 +160,7 @@ namespace gic {
 
 class gic_v3_dist : public gic_dist {
 public:
-    gic_v3_dist(mmu::phys b) : gic_dist(b) {}
+    gic_v3_dist(mmu::phys b, size_t l) : gic_dist(b, l) {}
 
     void enable();
     void disable();
@@ -155,29 +171,139 @@ public:
 //Redistributor interface
 class gic_v3_redist {
 public:
-    gic_v3_redist(mmu::phys b) : _base(b) {}
+    gic_v3_redist(mmu::phys b, size_t l);
+
+    void init_cpu_base(int smp_idx);
+    void init_lpis(int smp_idx, u64 prop_base, u64 pend_base);
 
     u32 read_at_offset(int smp_idx, u32 offset);
+    u64 read64_at_offset(int smp_idx, u32 offset);
     void write_at_offset(int smp_idx, u32 offset, u32 value);
+    void write64_at_offset(int smp_idx, u32 offset, u64 value);
+
+    void init_rdbase(int smp_idx, bool pta);
+    inline mmu::phys rdbase(int smp_idx) { return _rdbases[smp_idx]; }
 
     void wait_for_write_complete();
 private:
     mmu::phys _base;
+    mmu::phys *_cpu_bases;
+    mmu::phys *_rdbases;
+};
+
+//See https://developer.arm.com/documentation/ddi0601/2024-09/External-Registers/GITS-BASER-n---ITS-Table-Descriptors
+#define GITS_PAGE_SIZE(baser)      (((baser) & 0x300) >> 8) //Capture bits [9:8]
+#define GITS_ITT_entry_size(type)  (((type) & 0xf0) >> 4)
+
+#define ITS_MAPC_V                 (1ull << 63)
+#define ITS_MAPD_V                 (1ull << 63)
+
+#define GITS_TABLE_TYPE(baser)     (((baser) & 0x700000000000000ull) >> 56) //Capture bits [58:56]
+#define GITS_TABLE_DEVICES_TYPE     0b001
+#define GITS_TABLE_COLLECTIONS_TYPE 0b100
+
+#define GITS_TABLE_PAGE_SIZE_4K     0b00
+#define GITS_TABLE_PAGE_SIZE_16K    0b01
+#define GITS_TABLE_PAGE_SIZE_64K    0b10
+
+#define GITS_TABLE_BASE_PA_MASK     0xfffffffff000
+#define GITS_BASER_VALID            0x8000000000000000ull
+
+#define GITS_TABLE_NUM_MAX          8
+
+#define GITS_CBASER_VALID           0x8000000000000000ull
+
+#define GITS_CTLR_ENABLED           0x1
+#define GITS_TYPER_PTA              0x80000 //Bit 19 - see https://developer.arm.com/documentation/ddi0601/2024-09/External-Registers/GITS-TYPER--ITS-Type-Register
+
+enum class gic_its_reg : unsigned int {
+    GICITS_CTLR    = 0x0000, /* Reg */
+    GICITS_TYPER   = 0x0008, /* Reg */
+    GICITS_CBASER  = 0x0080, /* Reg */
+    GICITS_CWRITER = 0x0088, /* Reg */
+    GICITS_CREADR  = 0x0090, /* Reg */
+    GICITS_BASER   = 0x0100, /* The base address and size of the ITS tables reg*/
+};
+
+enum class gic_its_cmd : unsigned int {
+    ITS_CMD_CLEAR   = 0x04,
+    ITS_CMD_DISCARD = 0x0f,
+    ITS_CMD_INT     = 0x03,
+    ITS_CMD_INV     = 0x0c,
+    ITS_CMD_INVALL  = 0x0d,
+    ITS_CMD_MAPC    = 0x09,
+    ITS_CMD_MAPD    = 0x08,
+    ITS_CMD_MAPI    = 0x0b,
+    ITS_CMD_MAPTI   = 0x0a,
+    ITS_CMD_MOVALL  = 0x0e,
+    ITS_CMD_MOVI    = 0x01,
+    ITS_CMD_SYNC    = 0x05,
+};
+
+struct its_cmd {
+    u64 data[4];
+};
+
+//
+//Interrupt Translation Service interface
+class gic_v3_its {
+public:
+    gic_v3_its(mmu::phys b, size_t l);
+
+    u64 read_reg64(gic_its_reg r);
+    u64 read_reg64_at_offset(gic_its_reg r, u32 offset);
+    void write_reg(gic_its_reg r, u32 v);
+    void write_reg64(gic_its_reg r, u64 v);
+    void write_reg64_at_offset(gic_its_reg r, u32 offset, u64 v);
+
+    void read_type_register();
+    void initialize_cmd_queue();
+    void enqueue_cmd(its_cmd *cmd);
+
+    void cmd_mapd(u32 dev_id, u64 itt_pa, u64 itt_size);
+    void cmd_mapti(u32 dev_id, int vector, int smp_idx);
+    void cmd_movi(u32 dev_id, int vector, int smp_idx);
+    void cmd_inv(u32 dev_id, int vector);
+    void cmd_discard(u32 dev_id, int vector);
+    void cmd_sync(mmu::phys rdbase);
+    void cmd_mapc(int smp_idx, mmu::phys rdbase);
+
+    bool is_typer_pta() { return _typer & GITS_TYPER_PTA; }
+    u64 itt_entry_size() { return GITS_ITT_entry_size(_typer); }
+
+    mmu::phys base() { return _base; }
+
+private:
+    mmu::phys _base;
+    void *_cmd_queue;
+    u64 _typer;
 };
 
 constexpr int max_sgi_cpus = 16;
 
 class gic_v3_driver : public gic_driver {
 public:
-    gic_v3_driver(mmu::phys d, mmu::phys r) : _gicd(d), _gicr(r) {}
+    gic_v3_driver(mmu::phys d, size_t d_len,
+                  mmu::phys r, size_t r_len,
+                  mmu::phys i, size_t i_len) :
+        _gicd(d, d_len), _gicrd(r, r_len), _gits(i, i_len) {}
 
     virtual void init_on_primary_cpu()
     {
+        _gicrd.init_cpu_base(0);
+        init_lpis(0);
         init_dist();
         init_redist(0);
+        init_its(0);
     }
 
-    virtual void init_on_secondary_cpu(int smp_idx) { init_redist(smp_idx); }
+    virtual void init_on_secondary_cpu(int smp_idx)
+    {
+        _gicrd.init_cpu_base(smp_idx);
+        init_lpis(smp_idx);
+        init_redist(smp_idx);
+        init_its(smp_idx);
+    }
 
     virtual void mask_irq(unsigned int id);
     virtual void unmask_irq(unsigned int id);
@@ -188,13 +314,37 @@ public:
 
     virtual unsigned int ack_irq();
     virtual void end_irq(unsigned int iar);
+
+    virtual void allocate_msi_dev_mapping(pci::function* dev);
+
+    virtual void initialize_msi_vector(unsigned int vector) {}
+    virtual void map_msi_vector(unsigned int vector, pci::function* dev, u32 target_cpu);
+    virtual void unmap_msi_vector(unsigned int vector, pci::function* dev);
+    virtual void msi_format(u64 *address, u32 *data, int vector);
+
 private:
+    void init_lpis(int smp_idx);
     void init_dist();
     void init_redist(int smp_idx);
+    void init_its_device_or_collection_table(int idx);
+    void init_its(int smp_idx);
+
+    u32 pci_device_id(pci::function* dev);
 
     gic_v3_dist _gicd;
-    gic_v3_redist _gicr;
+    gic_v3_redist _gicrd;
+    gic_v3_its _gits;
     u64 _mpids_by_smpid[max_sgi_cpus];
+
+    u8 *_lpi_config_table;
+    u64 _lpi_prop_base;
+    u64 *_lpi_pend_bases;
+
+    u16 _msi_vector_num;
+
+    std::array<std::pair<u32, void*>, max_msi_handlers> _itt_by_device_id = {};
+    std::array<u32, max_msi_handlers> _cpu_by_vector = {};
+    np_spinlock _smp_init_its_lock;
 };
 
 }

--- a/conf/profiles/aarch64/all.mk
+++ b/conf/profiles/aarch64/all.mk
@@ -1,5 +1,6 @@
 include conf/profiles/$(arch)/virtio-mmio.mk
 include conf/profiles/$(arch)/virtio-pci.mk
 include conf/profiles/$(arch)/xen.mk
+include conf/profiles/$(arch)/nvme.mk
 
 conf_drivers_cadence?=1

--- a/conf/profiles/aarch64/base.mk
+++ b/conf/profiles/aarch64/base.mk
@@ -26,6 +26,11 @@ ifeq ($(conf_drivers_virtio_rng),1)
 export conf_drivers_virtio?=1
 endif
 
+export conf_drivers_nvme?=0
+ifeq ($(conf_drivers_nvme),1)
+export conf_drivers_pci?=1
+endif
+
 export conf_drivers_cadence?=0
 export conf_drivers_virtio?=0
 export conf_drivers_pci?=0

--- a/conf/profiles/aarch64/nvme.mk
+++ b/conf/profiles/aarch64/nvme.mk
@@ -1,0 +1,3 @@
+conf_drivers_pci?=1
+
+conf_drivers_nvme?=1

--- a/drivers/pci-function.cc
+++ b/drivers/pci-function.cc
@@ -623,9 +623,6 @@ namespace pci {
 
     void function::msix_enable()
     {
-#ifdef __aarch64__
-        return;
-#endif
         if (!is_msix() || _msix_enabled) {
             return;
         }

--- a/drivers/virtio-pci-device.cc
+++ b/drivers/virtio-pci-device.cc
@@ -45,17 +45,11 @@ void virtio_pci_device::init()
 
 void virtio_pci_device::register_interrupt(interrupt_factory irq_factory)
 {
-#ifdef AARCH64_PORT_STUB
-    // Currently MSI-X support for aach64 is stubbed (please see arch/aarch64/msi.cc)
-    // so until it becomes functional we register regular PCI interrupt
-    _irq.reset(irq_factory.create_pci_interrupt(*_dev));
-#else
     if (irq_factory.register_msi_bindings && _dev->is_msix()) {
         irq_factory.register_msi_bindings(_msi);
     } else {
         _irq.reset(irq_factory.create_pci_interrupt(*_dev));
     }
-#endif
 }
 
 virtio_legacy_pci_device::virtio_legacy_pci_device(pci::device *dev)
@@ -70,7 +64,6 @@ void virtio_legacy_pci_device::kick_queue(int queue)
 
 void virtio_legacy_pci_device::setup_queue(vring *queue)
 {
-#ifndef AARCH64_PORT_STUB
     if (_dev->is_msix()) {
         // Setup queue_id:entry_id 1:1 correlation...
         virtio_conf_writew(VIRTIO_MSI_QUEUE_VECTOR, queue->index());
@@ -79,7 +72,6 @@ void virtio_legacy_pci_device::setup_queue(vring *queue)
             return;
         }
     }
-#endif
     // Tell host about pfn
     // TODO: Yak, this is a bug in the design, on large memory we'll have PFNs > 32 bit
     // Dor to notify Rusty
@@ -182,7 +174,6 @@ void virtio_modern_pci_device::setup_queue(vring *queue)
 {
     auto queue_index = queue->index();
 
-#ifndef AARCH64_PORT_STUB
     if (_dev->is_msix()) {
         // Setup queue_id:entry_id 1:1 correlation...
         _common_cfg->virtio_conf_writew(COMMON_CFG_OFFSET_OF(queue_msix_vector), queue_index);
@@ -191,7 +182,6 @@ void virtio_modern_pci_device::setup_queue(vring *queue)
             return;
         }
     }
-#endif
 
     _queues_notify_offsets[queue_index] =
             _common_cfg->virtio_conf_readw(COMMON_CFG_OFFSET_OF(queue_notify_off));


### PR DESCRIPTION
The series of these 4 commits implements the MSI support on the aarch64 architecture:
- Implement GIC v3 ITS and GIC v2m to support MSI
- Implement aarch64-specific MSI methods
- Enable MSI/X for virtio PCI devices
- Enable NVME support

Compared to the original PR, GIC v3 code does not use `std::map` and consistently employs spinlock with interrupts disabled in all necessary places.

For more details, please look at the commit messages.