### PR TITLE
init: fix boot when using DT_GNU_HASH

### DIFF
--- a/include/osv/elf.hh
+++ b/include/osv/elf.hh
@@ -440,10 +440,12 @@ protected:
     bool has_non_writable_text_relocations();
     unsigned get_segment_mmap_permissions(const Elf64_Phdr& phdr);
 private:
-    Elf64_Sym* lookup_symbol_old(const char* name);
-    Elf64_Sym* lookup_symbol_gnu(const char* name, bool self_lookup);
     template <typename T>
     T* dynamic_ptr(unsigned tag);
+    // opt_dynamic_ptr() is the same as dynamic_ptr() but returns nullptr
+    // instead of throwing when the given tag is missing.
+    template <typename T>
+    T* opt_dynamic_ptr(unsigned tag);
     Elf64_Xword dynamic_val(unsigned tag);
     const char* dynamic_str(unsigned tag);
     bool dynamic_exists(unsigned tag);
@@ -726,8 +728,9 @@ program* get_program();
 
 /* tables needed for initial dynamic segment relocations */
 struct init_dyn_tabs {
-    const Elf64_Sym *symtab;
-    const Elf64_Word *hashtab;
+    Elf64_Sym *symtab;
+    const Elf64_Word *dt_hash;
+    const Elf64_Word *dt_gnu_hash;
     const char *strtab;
     const Elf64_Sym *lookup(u32 sym);
 };


### PR DESCRIPTION
Before this series, OSv fails to boot if built on Fedora 42 with Gcc 15.1.1.

It turns out the problem is symbol resolution during relocation of kernel symbols (specifically, TLS names like sched::s_current). Unfortunately we had two different copies of symbol resultion functions:

1. init_dyn_tabs::lookup() used for the initialization-time relocations.
2. object::lookup_symbol() used for any other lookups.

The latter is the complete implementation of symbol lookup, supporting both the traditional ELF "DT_HASH" hash table format, and the newer (2006) "DT_GNU_HASH" format. But the former implementation was incomplete, and was missing the DT_GNU_HASH support - so failed to do relocations (and boot...) on systems where DT_HASH was no longer output to the executable.

The first patch unifies both lookup functions into one function elf::lookup_symbol called by both paths. The new function's code is based on the more complete object::lookup_symbol().

After that patch, OSv can be built and run on Fedora 42 (and also continues to work on Fedora 41).

The second patch in the series also fixes a test that started to fail on Fedora 42 because of a new optimization that optimized away what the test was trying to do :-)

Fixes #1369.