### PR TITLE
support building ext images

### DIFF
--- a/bootfs_ext.manifest.skel
+++ b/bootfs_ext.manifest.skel
@@ -1,0 +1,3 @@
+[manifest]
+/usr/lib/fs/libext.so: modules/libext/libext.so
+/usr/lib/liblwext4.so: ../../modules/lwext4/upstream/lwext4/build_lib_only/src/liblwext4.so

--- a/modules/libext/Makefile
+++ b/modules/libext/Makefile
@@ -1,10 +1,9 @@
-arch=x64
 include ../common.gmk
 
 module_out := $(out)/modules/libext
 
 CXXFLAGS = -fPIC -std=gnu++11 $(INCLUDES) -I../lwext4/upstream/lwext4/include -I../lwext4/upstream/lwext4/build_lib_only/include \
-	 -D_KERNEL -D_GNU_SOURCE -Wall -fno-exceptions -fno-rtti
+	 -D_KERNEL -D_GNU_SOURCE -Wall -fno-exceptions -fno-rtti -O2
 
 # the build target executable:
 TARGET = libext
@@ -15,7 +14,7 @@ DEPS := $(OBJ_FILES:.o=.d)
 LIBS = -L../lwext4/upstream/lwext4/build_lib_only/src/ -llwext4
 
 $(module_out)/$(TARGET).so: $(OBJ_FILES)
-	$(call quiet, $(CXX) $(CXXFLAGS) $(LDFLAGS) -static-libstdc++ -shared -o $(module_out)/$(TARGET).so $^ $(LIBS), LINK $@)
+	$(call quiet, $(CXX) $(CXXFLAGS) $(LDFLAGS) -static-libstdc++ -nodefaultlibs -shared -o $(module_out)/$(TARGET).so $^ $(LIBS), LINK $@)
 
 $(module_out)/%.o: %.cc
 	$(call quiet, $(CXX) $(CXXFLAGS) -c -o $@ $<, CXX $@)
@@ -26,8 +25,7 @@ init:
 .PHONY: init
 
 module: init $(module_out)/$(TARGET).so
-	echo '/usr/lib/fs/libext.so: ./modules/libext/libext.so' > usr.manifest
 
 clean:
-	rm -f $(TARGET)*.so usr.manifest
+	rm -f $(TARGET)*.so
 	$(call very-quiet, $(RM) -rf $(module_out))

--- a/modules/libext/module.py
+++ b/modules/libext/module.py
@@ -1,3 +1,11 @@
+import os
 from osv.modules import api
+from osv.modules.filemap import FileMap
+
+build_dir = 'build/' + os.environ['mode'] + '.' + os.environ['ARCH']
+
+usr_files = FileMap()
+if os.environ.get("fs_type") != 'ext':
+    usr_files.add('${OSV_BASE}/' + build_dir + '/modules/libext/libext.so').to('/usr/lib/fs/libext.so')
 
 api.require('lwext4')

--- a/modules/lwext4/module.py
+++ b/modules/lwext4/module.py
@@ -1,0 +1,8 @@
+import os
+from osv.modules.filemap import FileMap
+
+_module = '${OSV_BASE}/modules/lwext4'
+
+usr_files = FileMap()
+if os.environ.get("fs_type") != 'ext':
+    usr_files.add(os.path.join(_module, 'upstream/lwext4/build_lib_only/src/liblwext4.so')).to('/usr/lib/liblwext4.so')

--- a/modules/lwext4/usr.manifest
+++ b/modules/lwext4/usr.manifest
@@ -1,9 +1,0 @@
-#
-# Copyright (C) 2024 Waldemar Kozaczuk
-#
-# This work is open source software, licensed under the terms of the
-# BSD license as described in the LICENSE file in the top-level directory.
-#
-
-[manifest]
-/usr/lib/liblwext4.so: ${MODULE_DIR}/upstream/lwext4/build_lib_only/src/liblwext4.so

--- a/scripts/build
+++ b/scripts/build
@@ -21,24 +21,24 @@ usage() {
 	  scripts/build clean
 
 	Options:
-	  --help|-h                     Print this help message
-	  arch=x64|aarch64              Specify the build architecture; default is the same as build host arch
-	  mode=release|debug            Specify the build mode; default is release
-	  export=none|selected|all      If 'selected' or 'all' export the app files to <export_dir>
-	  export_dir=<dir>              The directory to export the files to; default is build/export
-	  fs=zfs|rofs|rofs_with_zfs|    Specify the filesystem of the image partition
-	     ramfs|virtiofs
-	  fs_size=N                     Specify the size of the image in bytes
-	  fs_size_mb=N                  Specify the size of the image in MiB
-	  app_local_exec_tls_size=N     Specify the size of app local TLS in bytes; the default is 64
-	  usrskel=<*.skel>              Specify the base manifest for the image
-	  <module_makefile_arg>=<value> Pass value of module_makefile_arg to an app/module makefile
-	                                (can be used to customize specific app/module build process)
-	  -j<N>                         Set number of parallel jobs for make
-	  --append-manifest             Append build/<mode>/append.manifest to usr.manifest
-	  --create-disk                 Instead of usr.img create kernel-less disk.img
-	  --create-zfs-disk             Create extra empty disk with ZFS filesystem
-	  --use-openzfs                 Build and manipulate ZFS images using on host OpenZFS tools
+	  --help|-h                      Print this help message
+	  arch=x64|aarch64               Specify the build architecture; default is the same as build host arch
+	  mode=release|debug             Specify the build mode; default is release
+	  export=none|selected|all       If 'selected' or 'all' export the app files to <export_dir>
+	  export_dir=<dir>               The directory to export the files to; default is build/export
+	  fs=zfs|rofs|ext|ramfs|virtiofs Specify the filesystem of the image partition
+	    |rofs_with_zfs|rofs_with_ext
+	  fs_size=N                      Specify the size of the image in bytes
+	  fs_size_mb=N                   Specify the size of the image in MiB
+	  app_local_exec_tls_size=N      Specify the size of app local TLS in bytes; the default is 64
+	  usrskel=<*.skel>               Specify the base manifest for the image
+	  <module_makefile_arg>=<value>  Pass value of module_makefile_arg to an app/module makefile
+	                                 (can be used to customize specific app/module build process)
+	  -j<N>                          Set number of parallel jobs for make
+	  --append-manifest              Append build/<mode>/append.manifest to usr.manifest
+	  --create-disk                  Instead of usr.img create kernel-less disk.img
+	  --create-zfs-disk              Create extra empty disk with ZFS filesystem
+	  --use-openzfs                  Build and manipulate ZFS images using on host OpenZFS tools
 
 	Examples:
 	  ./scripts/build -j4 fs=rofs image=native-example   # Create image with native-example app
@@ -189,7 +189,7 @@ SRC=`pwd`
 arch=`expr $OUT : '.*\.\(.*\)'`
 mode=`expr $OUT : '.*/\(.*\)\..*'`
 
-# Set "modules" according to the image= or modules= paramters, or some
+# Set "modules" according to the image= or modules= parameters, or some
 # defaults (with same rules as in our old makefile)
 case $arch in
 aarch64) image=${vars[image]-uush};;
@@ -211,7 +211,11 @@ usrskel_arg=
 case $fs_type in
 zfs)
 	;; # Nothing to change here. This is our default behavior
-rofs|rofs_with_zfs|virtiofs)
+ext)
+	cp "$SRC"/static/etc/fstab_ext "$OUT"/fstab
+	manifest=bootfs_ext.manifest.skel
+	usrskel_arg="--usrskel usr_ext.manifest.skel";;
+rofs|rofs_with_zfs|rofs_with_ext|virtiofs)
 	# Both are read-only (in OSv) and require nothing extra on bootfs to work
 	manifest=bootfs_empty.manifest.skel
 	usrskel_arg="--usrskel usr_rofs.manifest.skel";;
@@ -242,6 +246,10 @@ fi
 
 if [[ ${vars[append_manifest]} == "true" && $modules == "!default" ]]; then
 	modules="empty"
+fi
+
+if [[ "$fs_type" == "ext" || "$fs_type" == "rofs_with_ext" ]]; then
+	modules="$modules,libext"
 fi
 
 CC=gcc
@@ -286,7 +294,7 @@ if [[ ${vars[append_manifest]} == "true" && -f "$OSV_BUILD_PATH/append.manifest"
 	fi
 fi
 
-bootfs_manifest=$manifest make "${args[@]}" | tee -a build.out
+fs=$fs_type bootfs_manifest=$manifest make "${args[@]}" | tee -a build.out
 # check exit status of make
 status=${PIPESTATUS[0]}
 if [ $status -ne 0 ]
@@ -342,6 +350,14 @@ create_zfs_disk() {
 	rm ${raw_disk}.raw
 }
 
+create_ext_disk() {
+	cp $bare $raw_disk.raw
+	"$SRC"/scripts/imgedit.py setpartition "-f raw ${raw_disk}.raw" 2 $partition_offset $partition_size
+	qemu-img resize ${raw_disk}.raw ${image_size}b >/dev/null 2>&1
+	dd if=disk.ext of=${raw_disk}.raw obs=$partition_offset seek=1 >/dev/null 2>&1
+	qemu-img convert -f raw -O qcow2 $raw_disk.raw $qcow2_disk.img
+}
+
 create_rofs_disk() {
 	cp $bare $raw_disk.raw
 	"$SRC"/scripts/imgedit.py setpartition "-f raw ${raw_disk}.raw" 2 $partition_offset $partition_size
@@ -382,6 +398,12 @@ zfs)
 	image_size=$fs_size
 	cp "$SRC"/static/etc/fstab fstab
 	create_zfs_disk ;;
+ext)
+	rm -rf disk.ext
+	"$SRC"/scripts/ext-disk-utils.sh create disk.ext $(((fs_size - partition_offset)/(1024*1024))) true
+	partition_size=`stat --printf %s disk.ext`
+	image_size=$fs_size
+	create_ext_disk ;;
 rofs)
 	rm -rf rofs.img
 	cp "$SRC"/static/etc/fstab_rofs fstab
@@ -392,22 +414,34 @@ rofs)
 	partition_size=`stat --printf %s rofs.img`
 	image_size=$fs_size
 	create_rofs_disk ;;
-rofs_with_zfs)
+rofs_with_zfs|rofs_with_ext)
 	# Create disk with rofs image on it 1st partition
 	rm -rf rofs.img
 	cp "$SRC"/static/etc/fstab_rofs fstab
-	echo "/dev/vblk0.2 /data      zfs       defaults 0 0" >> fstab
+	if [[ "$fs_type" == "rofs_with_zfs" ]]; then
+		echo "/dev/vblk0.2 /data      zfs       defaults 0 0" >> fstab
+	else
+		echo "/dev/vblk0.2 /data      ext       defaults 0 0" >> fstab
+	fi
 	"$SRC"/scripts/gen-rofs-img.py -o rofs.img -m usr.manifest -D libgcc_s_dir="$libgcc_s_dir"
 	partition_size=`stat --printf %s rofs.img`
 	image_size=$((fs_size+partition_size))
 	create_rofs_disk
-	# Resize the disk to fit ZFS on it after rofs
+	# Resize the disk to fit ext or zfs on it after rofs
 	qemu-img resize $qcow2_disk.img ${image_size}b >/dev/null 2>&1
-	# Create filesystem on ZFS partition
-	zfs_partition_offset=$((partition_offset + partition_size))
-	zfs_partition_size=$((image_size-zfs_partition_offset))
-	"$SRC"/scripts/imgedit.py setpartition "$qcow2_disk.img" 3 $zfs_partition_offset $zfs_partition_size
-	create_zfs_filesystem $qcow2_disk.img "/dev/vblk0.2" 2;;
+	snd_partition_offset=$((partition_offset + partition_size))
+	snd_partition_size=$((image_size-snd_partition_offset))
+	"$SRC"/scripts/imgedit.py setpartition "$qcow2_disk.img" 3 $snd_partition_offset $snd_partition_size
+	# Create filesystem on ZFS/EXT partition
+	if [[ "$fs_type" == "rofs_with_zfs" ]]; then
+		create_zfs_filesystem $qcow2_disk.img "/dev/vblk0.2" 2
+	else
+		rm -rf disk.ext
+		"$SRC"/scripts/ext-disk-utils.sh create disk.ext $((snd_partition_size/(1024*1024)))
+		qemu-img convert -f qcow2 -O raw $qcow2_disk.img $raw_disk.raw
+		dd if=disk.ext of=${raw_disk}.raw obs=$snd_partition_offset seek=1 >/dev/null 2>&1
+		qemu-img convert -f raw -O qcow2 $raw_disk.raw $qcow2_disk.img
+	fi ;;
 ramfs|virtiofs)
 	# No need to create extra fs like above: ramfs is already created (as the
 	# bootfs) and virtio-fs is specified with virtiofsd at run time

--- a/scripts/disk-utils-common.sh
+++ b/scripts/disk-utils-common.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+connect_image_to_nbd_device() {
+	# Check if we have something connected to nbd0
+	if [[ 0 != $(lsblk | grep nbd0 | wc -l) && "" == $(lsblk | grep nbd0 | grep " 0B") ]]; then
+		echo "The device /dev/nbd0 is busy. Please disconnect it or run $0 unmount"
+		return -1
+	fi
+	sudo -p "password for %p to activate qemu nbd kernel module:" modprobe nbd
+	local image_path="$1"
+	sudo qemu-nbd --connect /dev/nbd0 ${image_path} 1>/dev/null
+	echo "Connected device /dev/nbd0 to the image ${image_path}"
+
+	# Identify nbd device if it maps to a specific partition 
+	if [[ "$2" != "" ]]; then
+		local partition=$2
+		local nbd_device=$(lsblk | grep part | grep -o "nbd0\S*" | head -n $partition | tail -1)
+	else
+		local nbd_device=$(lsblk | grep part | grep -o "nbd0\S*" | tail -1)
+	fi
+	if [[ "" == "$nbd_device" ]]; then
+		nbd_device=nbd0
+		echo "Assuming /dev/nbd0 as a device to mount to"
+	fi
+	device=$nbd_device
+	device_path="/dev/$nbd_device"
+}
+
+connect_image_to_loop_device() {
+	local image_path="$1"
+	if [[ $(losetup | grep "$image_path" | wc -l) != 0 ]]; then
+		echo "The $image_path is already created and mounted. Please unmount and delete it first!"
+		exit 1
+	fi
+	local partition_offset=0
+	if [[ "$2" != "" ]]; then
+		local partition=$(($2+1))
+		partition_offset=$($OSV_ROOT/scripts/imgedit.py getpartition_offset "-f raw $image_path" $partition)
+	fi
+	device_path=$(sudo -p "password for %p to run losetup to create loop device:" losetup -o $partition_offset -f --show ${image_path})
+	device=${device_path:5}
+	echo "Connected device $device to the image ${image_path}"
+}
+
+connect_image() {
+	local image_path="$1"
+	local image_format=$(qemu-img info ${image_path} | grep "file format")
+
+	if [[ "$image_format" == *"qcow2"* ]]; then
+ 		connect_image_to_nbd_device $image_path $2
+	elif [[ "$image_format" == *"raw"* ]]; then
+ 		connect_image_to_loop_device $image_path $2
+	else
+		echo "The file $image_path does not seem to be a valid qcow2 nor raw image!"
+		return -1
+	fi
+}
+
+disconnect_image() {
+	local device=$1
+	# Try NBD sevice
+	if [[ "$device" != "" && "" != $(lsblk | grep nbd | grep $device) ]]; then
+		sudo qemu-nbd --disconnect /dev/$device 1>/dev/null
+		echo "Disconnected nbd device $device from the image"
+		return 0
+	elif [[ 0 != $(lsblk | grep nbd0 | wc -l) && "" == $(lsblk | grep nbd0 | grep " 0B") ]]; then
+		sudo qemu-nbd --disconnect /dev/nbd0 1>/dev/null
+		echo "Disconnected nbd device /dev/nbd0 from the image"
+		return 0
+	fi
+
+	# Try loopback device
+	if [[ "$device" != "" && "" != $(lsblk | grep loop | grep $device) ]]; then
+		sudo losetup -d /dev/$device 1>/dev/null
+		echo "Disconnected loop device $device from the image"
+	elif [[ "" != $(lsblk | grep loop) ]]; then
+		local device_path=$(losetup -ln | cut -d ' ' -f 1)
+		sudo losetup -d $device_path 1>/dev/null
+		echo "Disconnected loop device $device_path from the image"
+	fi
+}

--- a/scripts/ext-disk-utils.sh
+++ b/scripts/ext-disk-utils.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+
+argv0=${0##*/}
+usage() {
+	cat <<-EOF
+	Manipulate ext4 disk - create and optionally populate it, mount and unmount.
+
+	Usage: ${argv0} create <disk_path> <disk_size> (<populate_bool>) |
+	                            mount <disk_path> |
+	                            unmount <disk_path> <device>
+
+	Where:
+	  disk_path       path to a new or existing ext4 disk file
+	  disk_size_in_mb size of the disk when creating
+	  device          name of the device the disk is mounted to (for example loop1 or nbd0)
+
+	Examples:
+	  ${argv0} create build/last/disk.ext $((256*1024*1024)) true   # Create disk at build/last/disk.ext and populate it with the files from usr.manifest
+	  ${argv0} mount build/last/disk.ext                   # Mount OSv image from build/last/disk.ext
+	  ${argv0} unmount build/last/disk.ext loop1           # Unmount OSv image mounted as /dev/loop1 device
+	EOF
+	exit ${1:-0}
+}
+
+source $(dirname $0)/disk-utils-common.sh
+
+create_disk() {
+	if [[ "$DISK_PATH" == "" ]]; then
+		echo "The disk_path has not been specified!"
+		exit 1
+	fi
+	if [[ "$DISK_SIZE_IN_MB" == "" ]]; then
+		echo "The disk_size_in_mb has not been specified!"
+		exit 1
+	fi
+	#Create empty file and ext filesystem on it
+	if [[ -f $DISK_PATH ]]; then
+		echo "There is already file at $DISK_PATH. Please delete it first!"
+		exit 1
+	fi
+	dd if=/dev/zero of=$DISK_PATH bs=1M count=$DISK_SIZE_IN_MB 2>1 1>/dev/null
+	sudo -p "password for %p to run mkfs.ext4:" mkfs.ext4 $DISK_PATH 1>/dev/null
+	echo "Created empty ext4 disk at $DISK_PATH of the size $DISK_SIZE_IN_MB mb"
+}
+
+populate_disk() {
+	#Copy files in the manifest
+	OSV_ROOT=$(dirname $(readlink -f $0))/..
+	EXPORT_DIR=$(readlink -f $DISK_PATH.image)
+	pushd "$OSV_ROOT/build/last" 1>/dev/null
+	sudo "$OSV_ROOT/scripts/export_manifest.py" -m usr.manifest -e $EXPORT_DIR -D libgcc_s_dir="$libgcc_s_dir"
+	popd 1>/dev/null
+	echo "Populated ext4 disk $DISK_PATH"
+}
+
+mount_disk() {
+	if [[ "$DISK_PATH" == "" ]]; then
+		echo "The disk_path has not been specified!"
+		exit 1
+	fi
+	#Mounting disk as a loop device
+	if [[ -f "$DISK_PATH.image" ]]; then
+		echo "There is already file at $DISK_PATH.image - disk is potentially mounted. Please delete it first!"
+		exit 1
+	fi
+	connect_image "$DISK_PATH"
+
+	mkdir $DISK_PATH.image
+	sudo mount $device_path $DISK_PATH.image
+	echo "Mounted the ext4 disk at $DISK_PATH.image under the device $device_path"
+}
+
+unmount_disk() {
+	if [[ "$DISK_PATH" == "" ]]; then
+		echo "The disk_path has not been specified!"
+		exit 1
+	fi
+	if [[ "$device" == "" ]]; then
+		echo "The device has not been specified!"
+		exit 1
+	fi
+	sudo -p "password for %p to unmount disk:" umount $DISK_PATH.image
+	rmdir $DISK_PATH.image
+	echo "Unmounted the ext4 disk at $DISK_PATH.image"
+	disconnect_image $device
+}
+
+command=$1
+shift
+case $command in
+	create)
+		DISK_PATH=${1}
+		DISK_SIZE_IN_MB=${2:-256}
+		POPULATE=${3:-false}
+		create_disk
+		if [[ "$POPULATE" == "true" ]]; then
+			mount_disk
+			populate_disk
+			unmount_disk
+		fi
+		;;
+	mount)
+		DISK_PATH=${1}
+		mount_disk
+		;;
+	unmount)
+		DISK_PATH=${1}
+		device=${2}
+		unmount_disk
+		;;
+	*)
+		usage
+		;;
+esac

--- a/static/etc/fstab_ext
+++ b/static/etc/fstab_ext
@@ -1,0 +1,4 @@
+/dev/vblk0.1 /          ext       defaults 0 0
+none         /dev       devfs     defaults 0 0
+none         /proc      procfs    defaults 0 0
+none         /sys       sysfs     defaults 0 0

--- a/usr_ext.manifest.skel
+++ b/usr_ext.manifest.skel
@@ -8,4 +8,3 @@
 /proc: ../../static
 /sys: ../../static
 /tmp: ../../static
-/data: ../../static


### PR DESCRIPTION
This patch updates existing scripts and adds new `ext-disk-utils.sh` to support building OSv images with ext root filesystem.

More specifically, we update `scripts/build` to support new values of the parameter `fs`:
- `ext` - to build an image with the `ext` filesystem mounted at root (`/`)
- `rofs_with_ext` - to build an image with the `rofs` at `/` and `ext` in the 2nd disk partition mounted at `/data`

In addition, we add a new script `ext-disk-utils.sh`, called by `scripts/build`. The `ext-disk-utils.sh` utilizes the standard `mkfs.ext` utility from the Linux host to create an empty ext disk file, which is then set up as a loop device and mounted to populate its content using the `export_manifest.py`.

The `ext` filesystem is implemented as a library, similarly to the ZFZ. Just like `libsolaris.so` of ZFS, the ext library object files - `libext.so` and its dependent `liblwext4.so` - are placed on the bootfs filesystem, which is part of the kernel loader - `loader.elf`, if the root filesystem is ext. If ext is on the 2nd partition - `fs=rofs_with_ext`, then `libext.so` and `liblwext4.so` are loaded from the root rofs partition just like other binaries would.

The `libext.so` comes from the `libext` module and the `liblwext4.so` from the `lwext4` one. These two modules get added implicitly by `scripts/build` is `fs=ext` or `fs=rofs_with_ext`.

Finally, this patch modifies the main makefile, to handle passed-in `fs` parameter to drive what files need to be put into the `bootfs.bin`. It is worth noting that as a side effect, the `libsolaris.so` is only built if `fs=zfs`, which stays as a default in `scripts/build`.

For more information, please read this Wiki page -
https://github.com/cloudius-systems/osv/wiki/Filesystems#ext.