### PR TITLE
ext: support building and running unit tests on an ext image

### DIFF
--- a/modules/tests/Makefile
+++ b/modules/tests/Makefile
@@ -111,6 +111,8 @@ rofs-only-tests := rofs/tst-chdir.so rofs/tst-symlink.so rofs/tst-readdir.so \
 zfs-only-tests := tst-readdir.so tst-fallocate.so tst-fs-link.so \
 	tst-concurrent-read.so tst-solaris-taskq.so
 
+ext-only-tests := tst-readdir.so tst-concurrent-read.so tst-fs-link.so
+
 specific-fs-tests := $($(fs_type)-only-tests)
 
 tests := tst-pthread.so misc-ramdisk.so tst-vblk.so tst-bsd-evh.so \
@@ -275,6 +277,8 @@ boost-tests := $(common-boost-tests)
 rofs-only-boost-tests := rofs/tst-stdio.so
 
 zfs-only-boost-tests := tst-rename.so tst-stdio.so
+
+ext-only-boost-tests := tst-rename.so tst-stdio.so
 
 boost-tests += $($(fs_type)-only-boost-tests)
 

--- a/tests/tst-symlink.cc
+++ b/tests/tst-symlink.cc
@@ -301,6 +301,9 @@ int main(int argc, char **argv)
 
     rc = open(N2, O_RDONLY | O_NOFOLLOW);
     report(rc < 0 && errno == ELOOP, "open(symlink, O_NOFOLLOW) must fail");
+
+    //See issue #1373
+    close(fd);
     report(unlink(N2) == 0, "unlink");
     report(unlink(N1) == 0, "unlink");
 


### PR DESCRIPTION
This patch mainly modifies the tests module makefile to support building an ext image with the unit tests on it so that it can be run with the `scripts/test.py`.

It also fixes a subtle bug in the `tst-symlink.cc` that closes an open file descriptor before removing directory entries. This fix is actually a good practice type one and has helped discover more important bug in the ext implementation described by the issue #1373. So once issue #1373 is fixed, we can uncomment the line with `close()` and see if the test passes on ext.