### PR TITLE
libext: count references when opening and closing i-nodes

### DIFF
--- a/modules/libext/ext_vfsops.cc
+++ b/modules/libext/ext_vfsops.cc
@@ -66,7 +66,7 @@ static int blockdev_bread_or_write(struct ext4_blockdev *bdev, void *buf, uint64
     bio->bio_dev->driver->devops->strategy(bio);
     int error = bio_wait(bio);
 
-    ext_debug("%s %ld bytes at offset %ld to %p with error:%d\n", read ? "Read" : "Wrote",
+    ext_debug("blockdev %s %ld bytes at offset %ld to %p with error:%d\n", read ? "read" : "wrote",
         bio->bio_bcount, bio->bio_offset, bio->bio_data, error);
 
     if (!is_linear_mapped(buf)) {
@@ -217,9 +217,13 @@ ext_mount(struct mount *mp, const char *dev, int flags, const void *data)
     return r;
 }
 
+extern void ext_delete_outstanding_inodes(struct ext4_fs *fs);
+
 static int
 ext_unmount(struct mount *mp, int flags)
 {
+    ext_delete_outstanding_inodes(&ext_fs);
+
     int r = ext4_fs_fini(&ext_fs);
     if (r == EOK) {
         ext4_bcache_cleanup(&ext_block_cache);


### PR DESCRIPTION
As issue #1373 explains, the current libext implementation does not prevent a file from being deleted when it is still open for reading or writing. To fix this deficiency, this patch implements necessary reference counting in `ext_open()` and `ext_close()` so that when `ext_dir_remove_entry()` is called, it will only delete i-node if the `ref_count == 0`. Otherwise, it will set the flag `delete_on_last_close`, so that when `ext_close()` executes later, it will delete the inode if the flag is true and `ref_count == 0`.

There may be cases, such as the one caught in the **tst-symlink** unit test, where the application fails to close the file descriptor after removing a file. For that reason, we store ids of the i-nodes to be deleted when the `delete_on_last_close` is set, and we delete those that have never been closed when unmounting the filesystem in `ext_unmount()` - see the `ext_delete_outstanding_inodes()` function.

This patch also cleans some of the `ext_debug()` calls to make them a little more consistent.

Fixes #1373