### PR TITLE
More scalable rwlock implementation

### DIFF
--- a/core/lfmutex.cc
+++ b/core/lfmutex.cc
@@ -270,6 +270,10 @@ bool mutex::owned() const
     return owner.load(std::memory_order_relaxed) == sched::thread::current();
 }
 
+sched::thread *mutex::get_owner()
+{
+    return owner.load(std::memory_order_relaxed);
+}
 }
 
 // For use in C, which can't access namespaces or methods. Note that for

--- a/core/rwlock.cc
+++ b/core/rwlock.cc
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2013 Cloudius Systems, Ltd.
+ * Copyright (C) 2025 Waldemar Kozaczuk
  *
  * This work is open source software, licensed under the terms of the
  * BSD license as described in the LICENSE file in the top-level directory.
@@ -10,175 +11,326 @@
 #include <osv/rwlock.h>
 #include <osv/export.h>
 
+using namespace sched;
+
+//This read-write lock implementation is a 2nd version and aims to improve
+//performance especially for read heavy workflows.
+//
+//It is based on similar ideas used in the read-write lock implementation in Golang
+//and described in this article by Eli Bendersky - "A more efficient writer-preferring RW lock"
+//in https://eli.thegreenplace.net/2019/implementing-reader-writer-locks/. However, it uses
+//OSv primitives - wait()/wake() - to facilitate synchronization between writer and readers.
+//Also, I believe, it uses a novel idea of using single field - `_readers` - to count
+//both owning readers and pending readers at the same time (it could be that I re-invented
+//what somebody else already invented before me). Last but not least, I was inspired
+//by another implementation using atomics only and thread::yield() by Christian Dietrich
+//(see https://gitlab.ibr.cs.tu-bs.de/kanoun/osv/-/blob/dbdb91c1c7d1a16c7ad2093c0f61fe5914656f2d/core/rwlock.cc)
+//
+//In essence, this implementation uses a mutex to synchronize access between writers
+//and atomics to synchronize access between readers and writers.
+//
+//The fields:
+// _wmtx - writers' mutex to enforce only single writer can acquire the lock
+//
+// _writer_wait - boolean field used to synchronize between last reader runlock()
+//                and a pending writer in wlock()
+//
+// _readers -  multi-purpose 32-bit field manipulated atomically and used to:
+//             - indicate if the lock is owned by a writer (31st bit, see LOCK_INDICATOR)
+//             - indicate if there is a pending writer (30th bit, see WRITE_INDICATOR);
+//               it is set by a pending writer in wlock() before entering a wait to block
+//               any new readers from acquiring the lock
+//             - count readers that own the lock (bits 29-16, see READER_MASKS); max of 16383
+//               we actually add 0x10000 for each rlock()
+//             - count pending readers (bits 15-0); max of 65535
+//
+// _read_waiters - lock-less multiple-producer single-consumer queue used to register
+//                 pending readers; pending reader pushes its thread after all unsuccessful
+//                 attempts to acquire a read lock in rlock(), the owning writer pops waiting
+//                 readers of the queue and wakes them up before releasing the lock in
+//                 wunlock() and downgrade()
+//
+//The atomic operations manipulating _readers and _writer_wait use the "acquire/release"
+//memory ordering to make sure the changes are visible across the CPUs with weak-memory model
+//(for example ARM). The "acquire/release" does not have any effect on x86_64. Please
+//read https://davekilian.com/acquire-release.html, if you want to better understand
+//the "acquire/release" memory order.
+//
+//This RW lock should be fair for both writers and readers. Even though pending writer sets
+//WRITE_INDICATOR bit to block new readers, the owning writer in wunlock() wakes pending readers
+//to acquire the lock for reading. Therefore, neither readers nor writers should starve.
+
+static constexpr unsigned LOCK_INDICATOR       = 0x80000000;
+static constexpr unsigned WRITE_INDICATOR      = 0x40000000;
+static constexpr unsigned READER_MASKS         = 0x3fff0000;
+static constexpr unsigned IND_READ_MASK        = 0xffff0000;
+static constexpr unsigned WAITING_READERS_MASK = 0x0000ffff;
+static constexpr unsigned READER_LOCK_INC      = 0x00010000;
+
 rwlock::rwlock()
-    : _readers(0),
-      _wowner(nullptr),
-      _wrecurse(0)
-{ }
+    : _readers(0)
+{}
 
 rwlock::~rwlock()
 {
-    assert(_wowner == nullptr);
     assert(_readers == 0);
     assert(_read_waiters.empty());
-    assert(_write_waiters.empty());
-}
-
-void rwlock::rlock()
-{
-    std::lock_guard<mutex> guard(_mtx);
-    reader_wait_lockable();
-
-    _readers++;
 }
 
 bool rwlock::try_rlock()
 {
-    std::lock_guard<mutex> guard(_mtx);
-    if (!read_lockable()) {
-        return false;
+    //If there is no owning or pending writer, try to acquire the lock for reading
+    //by adding READER_LOCK_INC to the _readers atomically
+    if (_readers < WRITE_INDICATOR) {
+        std::atomic<unsigned> *readers = reinterpret_cast<std::atomic<unsigned>*>(&_readers);
+        unsigned prev_readers = readers->load(std::memory_order_acquire);
+        if (readers->compare_exchange_strong(prev_readers, prev_readers + READER_LOCK_INC, std::memory_order_acq_rel)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void rwlock::rlock()
+{
+    std::atomic<unsigned> *readers = reinterpret_cast<std::atomic<unsigned>*>(&_readers);
+
+    //Try to acquire a lock for reading by adding READER_LOCK_INC to the _readers atomically
+    //The loop will stop once a new writer enters wlock() past the _wmtx.lock()
+    //and sets WRITE_INDICATOR, or writer has already locked it before, so
+    //the WRITE_INDICATOR is already set.
+    //It may race with wunlock() which removes WRITE_INDICATOR
+    //The loop may also race with other threads calling rlock() or runlock()
+    unsigned prev_readers = readers->load(std::memory_order_acquire);
+    while (prev_readers < WRITE_INDICATOR) {
+        if (readers->compare_exchange_weak(prev_readers, prev_readers + READER_LOCK_INC, std::memory_order_acq_rel)) {
+            return;
+        }
     }
 
-    _readers++;
-    return true;
+    //We stopped because the WRITE_INDICATOR was set so let us add ourselves to
+    //the pending readers
+    //This may race with wunlock() which removes WRITE_INDICATOR
+    //1) if we win (1st) - wunlock() will see the latest number of pending readers including us
+    //2) if we lose (2nd) - we will see WRITE_INDICATOR off (the while condition true)
+    prev_readers = readers->fetch_add(1, std::memory_order_acq_rel) + 1;
+    //We add 1 above, because this is the value we expect to modify below
+    //Let us try in a loop again because maybe the 2nd scenario above is true
+    while (prev_readers < WRITE_INDICATOR) {
+        if (readers->compare_exchange_weak(prev_readers, prev_readers + READER_LOCK_INC - 1, std::memory_order_acq_rel)) {
+            return;
+        }
+    }
+
+    //We have failed to acquire the lock for reading and bumped the pending readers count
+    //Let us wait until wunlock() or downgrade() wakes us and bumps the _readers
+    //by (READER_LOCK_INC - 1) on our behalf
+    lockfree::linked_item<thread*> read_waiter(thread::current());
+    _read_waiters.push(&read_waiter);
+    std::atomic<thread*> *value = reinterpret_cast<std::atomic<thread*>*>(&read_waiter.value);
+    thread::wait_until( [value] {
+        return value->load(std::memory_order_acquire) == nullptr;
+    });
 }
 
 void rwlock::runlock()
 {
-    WITH_LOCK(_mtx) {
-        assert(_wowner == nullptr);
-        assert(_readers > 0);
+    //Release the lock for reading by subtracting READER_LOCK_INC atomically
+    std::atomic<unsigned> *readers = reinterpret_cast<std::atomic<unsigned>*>(&_readers);
 
-        // If we are the last reader and we have a write waiter,
-        // then wake up one writer
-        if (--_readers == 0) {
-            _write_waiters.wake_one(_mtx);
+    unsigned prev_readers = readers->fetch_add(-READER_LOCK_INC, std::memory_order_acq_rel);
+
+    assert(prev_readers > 0);
+    assert(prev_readers < LOCK_INDICATOR);
+
+    //Wake potential pending writer if any, if we are the last owning reader
+    if ((prev_readers & READER_MASKS) == READER_LOCK_INC && (prev_readers & WRITE_INDICATOR) && (prev_readers & LOCK_INDICATOR) == 0) {
+        //Wake the _wmtx owner - pending writer - if not null
+        auto pending_writer = _wmtx.get_owner();
+        if (pending_writer) {
+            //Synchronize with pending writer by setting _writer_wait to false
+            std::atomic<bool> *writer_wait = reinterpret_cast<std::atomic<bool>*>(&_writer_wait);
+            writer_wait->store(false, std::memory_order_release);
+            pending_writer->wake();
         }
     }
 }
 
 bool rwlock::try_upgrade()
 {
-    std::lock_guard<mutex> guard(_mtx);
+    //First we need to acquire the writers' mutex
+    if (!_wmtx.try_lock()) {
+        return false;
+    }
 
-    // if we don't have any write waiters and we are the only reader
-    if ((_readers == 1) && (_write_waiters.empty())) {
-        assert(_wowner == nullptr);
-        _readers = 0;
-        _wowner = sched::thread::current();
+    std::atomic<unsigned> *readers = reinterpret_cast<std::atomic<unsigned>*>(&_readers);
+
+    unsigned prev_readers = readers->load(std::memory_order_acquire);
+    //We have to be the only owning reader and there are no other pending writers
+    if ((prev_readers & IND_READ_MASK) == READER_LOCK_INC) { // LOCK_INDICATOR and WRITE_INDICATOR are off
+        if (readers->compare_exchange_strong(prev_readers, WRITE_INDICATOR | LOCK_INDICATOR | (prev_readers & WAITING_READERS_MASK), std::memory_order_acq_rel)) {
+            // we've won the race
+            return true;
+        }
+    }
+
+    //We either were not the only reader or have lost the race with a new reader or writer
+    _wmtx.unlock();
+    return false;
+}
+
+bool rwlock::try_wlock()
+{
+    //First we need to acquire the writers' mutex
+    if (!_wmtx.try_lock()) {
+        return false;
+    }
+
+    std::atomic<unsigned> *readers = reinterpret_cast<std::atomic<unsigned>*>(&_readers);
+    unsigned prev_readers = readers->load(std::memory_order_acquire);
+    if ((prev_readers & READER_MASKS) == 0 && (prev_readers & LOCK_INDICATOR) == 0) { //No owning readers and writer
+        if (readers->compare_exchange_strong(prev_readers, WRITE_INDICATOR | LOCK_INDICATOR | (prev_readers & WAITING_READERS_MASK), std::memory_order_acq_rel)) {
+            // we've won the race
+            return true;
+        }
+    } else if (prev_readers & LOCK_INDICATOR && _wmtx.owned()) { //Lock is acuired for writing and it is us
         return true;
     }
 
+    //We have lost the race with a new reader or writer
+    _wmtx.unlock();
     return false;
 }
 
 void rwlock::wlock()
 {
-    std::lock_guard<mutex> guard(_mtx);
-    writer_wait_lockable();
+    //Lock the writer mutex which may go to sleep
+    _wmtx.lock();
 
-    // recursive write lock
-    if (_wowner == sched::thread::current()) {
-        _wrecurse++;
+    //At this point we are still a pending writer and the 1st from all the pending ones if any
+    _writer_wait = true;
+
+    //Lets set the write indicator in order to phase out the current readers and block new ones
+    //from acquiring the lock for reading
+    //This may race with the runlock() of the last reader
+    std::atomic<unsigned> *readers = reinterpret_cast<std::atomic<unsigned>*>(&_readers);
+    unsigned prev_readers = readers->fetch_or(WRITE_INDICATOR, std::memory_order_acq_rel);
+    //1) If we lost (the fetch above was 2nd), then the count of owning readers per
+    //   prev_readers should be 0, and runlock() will not see WRITE_INDICATOR, and
+    //   therefore the last reader will not try to wake us and change _writer_wait.
+    //   The compare_exchange_weak() down below will acquire the lock for writing if
+    //   successful.
+    //2) If we won, then the count of owning readers per prev_readers will be equal to
+    //   READER_LOCK_INC and runlock() will see WRITE_INDICATOR and should wake us
+    //   and set _writer_wait to false.
+    //   The while loop down below will not enter and proceed to wait_until()
+
+    //Check recursive
+    if (prev_readers & LOCK_INDICATOR && _wmtx.owned()) {
+        return;
     }
 
-    _wowner = sched::thread::current();
+    //Try to set LOCK_INDICATOR if no active readers and no LOCK_INDICATOR set already (is LOCK_INDICATOR necessary here?)
+    prev_readers = prev_readers | WRITE_INDICATOR;
+    //Stop looping if the lock owner by a reader
+    while ((prev_readers & READER_MASKS) == 0 && (prev_readers & LOCK_INDICATOR) == 0) {
+        if (readers->compare_exchange_weak(prev_readers, WRITE_INDICATOR | LOCK_INDICATOR | (prev_readers & WAITING_READERS_MASK), std::memory_order_acq_rel)) {
+            // we've won the race
+            _writer_wait = false; //I do not think it is necessary
+            return;
+        }
+    }
+
+    //There were some active readers
+    //Wait for last active reader to wake us
+    std::atomic<bool> *writer_wait = reinterpret_cast<std::atomic<bool>*>(&_writer_wait);
+    thread::wait_until( [writer_wait] {
+        return !writer_wait->load(std::memory_order_acquire);
+    });
+
+    //Acquire the lock for writing by setting the LOCK_INDICATOR and WRITE_INDICATOR bits
+    readers->fetch_or(LOCK_INDICATOR | WRITE_INDICATOR, std::memory_order_acq_rel);
 }
 
-bool rwlock::try_wlock()
+void rwlock::wake_waiting_readers(std::atomic<unsigned> *readers, unsigned waiting_readers)
 {
-    std::lock_guard<mutex> guard(_mtx);
-    if (!write_lockable()) {
-        return false;
+    //TODO:In order to minimize triggering 100s of IPI wakeups to other CPUs we may
+    //use a new thread::wake_many() method that would do similar logic to what
+    //wake_impl() does for single thread - set status to waking for each thread, but
+    //set need_reschedule or send IPI wake up once only for each relevant target CPU
+    //
+    //Wake pending readers one by one - stop when the count of the pending readers is 0
+    //per the 16 least significant bits of _readers
+    while (waiting_readers) {
+        lockfree::linked_item<thread*> *read_waiter = _read_waiters.pop();
+        if (!read_waiter) {
+            //Even though the _read_waiters is empty, re-read the count of pending readers
+            //and keep trying until it reaches 0
+            waiting_readers = readers->load(std::memory_order_acquire) & WAITING_READERS_MASK;
+            continue;
+        }
+        //Acquire the lock for reading on behalf of this pending reader by adding (READER_LOCK_INC - 1)
+        //and wake its thread
+        waiting_readers = readers->fetch_add(READER_LOCK_INC - 1, std::memory_order_acq_rel) & WAITING_READERS_MASK; //lock - pending
+        thread *t = read_waiter->value;
+        std::atomic<thread*> *rt = reinterpret_cast<std::atomic<thread*>*>(&read_waiter->value);
+        rt->store(nullptr, std::memory_order_release);
+        t->wake();
     }
-
-    // recursive write lock
-    if (_wowner == sched::thread::current()) {
-        _wrecurse++;
-    }
-
-    _wowner = sched::thread::current();
-    return true;
 }
 
 void rwlock::wunlock()
 {
-    WITH_LOCK(_mtx) {
-        assert(_wowner == sched::thread::current());
+    assert(_readers & (LOCK_INDICATOR | WRITE_INDICATOR));
 
-        if (_wrecurse > 0) {
-            _wrecurse--;
-        } else {
-            _wowner = nullptr;
-        }
-
-        if (!_write_waiters.empty()) {
-            _write_waiters.wake_one(_mtx);
-        } else {
-            _read_waiters.wake_all(_mtx);
-        }
+    //If we are recursed then simply unlock and return
+    if (_wmtx.getdepth() > 1) {
+        return _wmtx.unlock();
     }
+
+    //Allow waiting readers to acquire a lock before new writer comes in
+    //or the 1st from the pending one wakes from the the sleep
+    std::atomic<unsigned> *readers = reinterpret_cast<std::atomic<unsigned>*>(&_readers);
+    unsigned waiting_readers = readers->fetch_and(~(LOCK_INDICATOR | WRITE_INDICATOR), std::memory_order_acq_rel) & WAITING_READERS_MASK;
+
+    //Wake the waiting readers and acquire the lock for reading on their behalf
+    wake_waiting_readers(readers, waiting_readers);
+
+    _wmtx.unlock();
 }
 
 void rwlock::downgrade()
 {
-    WITH_LOCK(_mtx) {
-        assert(_wowner == sched::thread::current());
+    assert(_readers & (LOCK_INDICATOR | WRITE_INDICATOR));
 
-        // I'm aware this implementation is ugly but it does the trick for the
-        // time being.
-        while (_wrecurse) this->wunlock();
-        this->wunlock();
+    std::atomic<unsigned> *readers = reinterpret_cast<std::atomic<unsigned>*>(&_readers);
+
+    //Remove LOCK and WRITE indicators but increment readers
+    unsigned prev_readers = readers->load(std::memory_order_acquire);
+    while(true) {
+        unsigned next_readers = (prev_readers & ~(LOCK_INDICATOR | WRITE_INDICATOR)) + READER_LOCK_INC;
+        if (readers->compare_exchange_weak(prev_readers, next_readers, std::memory_order_acq_rel)) {
+            break;
+        }
     }
+    //
+    //Wake the waiting readers and acquire the lock for reading on their behalf
+    wake_waiting_readers(readers, readers->load(std::memory_order_acquire) & WAITING_READERS_MASK);
 
-    // FIXME: Writers that already wait get precedence, so this function can
-    // block, there's only one user in sys/netinet/if_ether.c
-    // and we need to make sure that it's ok to block here.
-
-    this->rlock();
+    //Unlock all the way down
+    for (int depth = _wmtx.getdepth(); depth > 0; depth--) {
+        _wmtx.unlock();
+    }
 }
 
 bool rwlock::wowned()
 {
-    return (sched::thread::current() == _wowner);
-}
-
-bool rwlock::read_lockable()
-{
-    return ((!_wowner) && (_write_waiters.empty()));
-}
-
-bool rwlock::write_lockable()
-{
-    return ((_wowner == sched::thread::current()) ||
-            ((!_readers) && (!_wowner)));
-}
-
-void rwlock::writer_wait_lockable()
-{
-    while (true) {
-        if (write_lockable()) {
-            return;
-        }
-
-        _write_waiters.wait(_mtx);
-    }
-}
-
-void rwlock::reader_wait_lockable()
-{
-    while (true) {
-        if (read_lockable()) {
-            return;
-        }
-
-        _read_waiters.wait(_mtx);
-    }
+    return _wmtx.owned();
 }
 
 bool rwlock::has_readers()
 {
-    return _readers;
+    return _readers & READER_MASKS;
 }
 
 OSV_LIBSOLARIS_API

--- a/include/lockfree/mutex.hh
+++ b/include/lockfree/mutex.hh
@@ -87,6 +87,7 @@ public:
     void unlock();
 
     bool owned() const;
+    sched::thread *get_owner();
     // getdepth() should only be used by the thread holding the lock
     inline unsigned int getdepth() const { return depth; }
 

--- a/include/osv/rwlock.h
+++ b/include/osv/rwlock.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2013 Cloudius Systems, Ltd.
+ * Copyright (C) 2025 Waldemar Kozaczuk
  *
  * This work is open source software, licensed under the terms of the
  * BSD license as described in the LICENSE file in the top-level directory.
@@ -9,13 +10,25 @@
 #define __OSV_RWLOCK_H__
 
 #include <osv/mutex.h>
-#include <osv/condvar.h>
 #include <sys/cdefs.h>
 #include <osv/waitqueue.hh>
 
 #define RWLOCK_INITIALIZER {}
 
+#define LOCKFREE_QUEUE_MPSC_ALIGN void*
+#define LOCKFREE_QUEUE_MPSC_SIZE  16
+
 #ifdef __cplusplus
+#include <lockfree/queue-mpsc.hh>
+
+namespace sched {
+    class thread;
+}
+
+static_assert(sizeof(lockfree::queue_mpsc<lockfree::linked_item<sched::thread*>>) == LOCKFREE_QUEUE_MPSC_SIZE,
+         "LOCKFREE_QUEUE_MPSC_SIZE should match size of lockfree::queue_mpsc");
+static_assert(alignof(lockfree::queue_mpsc<lockfree::linked_item<sched::thread*>>) == alignof(LOCKFREE_QUEUE_MPSC_ALIGN),
+         "LOCKFREE_QUEUE_MPSC_ALIGN should match alignment of lockfree::queue_mpsc");
 
 class rwlock;
 
@@ -82,26 +95,25 @@ public:
     bool has_readers();
 
 private:
-
-    void writer_wait_lockable();
-    void reader_wait_lockable();
-
-    bool read_lockable();
-    bool write_lockable();
-
     friend class rwlock_for_read;
     friend class rwlock_for_write;
 
+    void wake_waiting_readers(std::atomic<unsigned> *readers, unsigned waiting_readers);
+
+    //TODO: Consider replacing with lockfree::unordered_queue_mpsc which is
+    //supposedly faster but uses more memory (has to be CACHELINE_ALIGNED)
+    lockfree::queue_mpsc<lockfree::linked_item<sched::thread*>> _read_waiters;
+#else
+    //For C
+    union {
+        char forsize[LOCKFREE_QUEUE_MPSC_SIZE];
+        LOCKFREE_QUEUE_MPSC_ALIGN foralignment;
+    };
 #endif // __cplusplus
 
-    mutex_t _mtx;
-    unsigned _readers;
-    waitqueue _read_waiters;
-    waitqueue _write_waiters;
-
-    void* _wowner;
-    unsigned _wrecurse;
-
+    mutex_t _wmtx;
+    unsigned _readers; //TODO: Consider expanding to a 64-bit long type to increase maximum number of owning readers and pending readers
+    bool _writer_wait;
 };
 
 typedef struct rwlock rwlock_t;


### PR DESCRIPTION
This patch implements more scalable version of the reader-writer lock. It should specifically improve performance of read-heavy workflows.

The implementation is based on similar ideas used in the reader-writer lock implementation in Golang and described in this article by Eli Bendersky - "A more efficient writer-preferring RW lock" in https://eli.thegreenplace.net/2019/implementing-reader-writer-locks/. However, it uses OSv primitives - wait()/wake() - to facilitate synchronization between writer and readers. Also, I believe, it uses a novel idea of using single field - `_readers` - to count both owning readers and pending readers at the same time (it could be that I re-invented what somebody else already invented before me). Last but not least, I was inspired by another implementation using atomics only and thread::yield() by Christian Dietrich (see https://gitlab.ibr.cs.tu-bs.de/kanoun/osv/-/blob/dbdb91c1c7d1a16c7ad2093c0f61fe5914656f2d/core/rwlock.cc)

In essence, this implementation uses a mutex to synchronize access between writers and atomics to synchronize access between readers and writers.

This RW lock should be fair for both writers and readers. Even though the pending writer sets WRITE_INDICATOR bit to block new readers, the owning writer in wunlock() wakes pending readers to acquire the lock for reading. Therefore, neither readers nor writers should starve.

Here are some tests results that compare various metrics of this new implementation with the original one:

```
=== misc-mutex ===
=== Uncontended single-thread lock/unlock cycle
=================
Original
--------
Measuring uncontended lockfree::mutex lock/unlock: 16 ns
Measuring uncontended handoff_stressing_mutex lock/unlock: 34 ns
Measuring uncontended spinlock lock/unlock: 8 ns
Measuring uncontended rwlock_read_lock lock/unlock: 36 ns
Measuring uncontended rwlock_write_lock lock/unlock: 39 ns ----
New
----
Measuring uncontended lockfree::mutex lock/unlock: 16 ns
Measuring uncontended handoff_stressing_mutex lock/unlock: 36 ns
Measuring uncontended spinlock lock/unlock: 8 ns
Measuring uncontended rwlock_read_lock lock/unlock: 16 ns
Measuring uncontended rwlock_write_lock lock/unlock: 40 ns
```

The reader path or rwlock in the uncontended cases is at least twice cheaper.

```
=== Contended lock/unlock scenarios
========
Original
--------
Contended mutex test, rwlock_write_lock, 2 pinned threads ABBABABABABABABABABA
1712 ns
Contended mutex test, rwlock_write_lock, 4 pinned threads ADBCADBCADCBADCBADCBADCBABDCADBCADBCABDC
1988 ns
Contended mutex test, rwlock_write_lock, 20 non-pinned threads 1272 ns
Contended mutex test, rwlock_read_lock, 2 pinned threads ABBABAABBABABAABBABA
1193 ns
Contended mutex test, rwlock_read_lock, 4 pinned threads ABCDABCDABCDABCDABCDABCDABCDABCDABCDABCD
1229 ns
Contended mutex test, rwlock_read_lock, 20 non-pinned threads 895 ns
---
New
---
Contended mutex test, rwlock_write_lock, 2 pinned threads ABBAABBABAABBABAABBA
603 ns
Contended mutex test, rwlock_write_lock, 4 pinned threads ABDCABCDABCDABCDABCDABCDABCDACBDABCDABCD
609 ns
Contended mutex test, rwlock_write_lock, 20 non-pinned threads 470 ns
Contended mutex test, rwlock_read_lock, 2 pinned threads ABBAABABABABABABABAB
86 ns
Contended mutex test, rwlock_read_lock, 4 pinned threads ABCDDDDDDDDDDBCACABCABCABCACBACBACACBABB
112 ns
Contended mutex test, rwlock_read_lock, 20 non-pinned threads 46 ns
```
As one can see the reader path in the contended case is dramatically faster.

```
Other misc-mutex test
--
Original
---
Mutual exclusion test using checker_thread with rwlock_write_lock:
Contended mutex test, rwlock_write_lock, 2 pinned threads 1547 ns

Contended mutex test, rwlock_write_lock, 4 pinned threads 1625 ns

Contended mutex test, rwlock_write_lock, 20 non-pinned threads 2092 ns

--
New
---
Mutual exclusion test using checker_thread with rwlock_write_lock:
Contended mutex test, rwlock_write_lock, 2 pinned threads 1223 ns

Contended mutex test, rwlock_write_lock, 4 pinned threads 1274 ns

Contended mutex test, rwlock_write_lock, 20 non-pinned threads 1138 ns
```
```
====
New reader-writer test with both readers and writers:
-- Original
Cmdline: /tests/tst-rwlock.so
Running contended read-write lock tests

Test with 10 writers and 1000 readers, 100 iterations, 1 writer inner loops, data len=1000, non-pinned threads
Reader lock/unlock count = 100000, lock wait: total = 1121640.17 ms, avg = 11216401.68 ns, unlock wait: total = 131800.30 ms, avg = 1318003.05 ns
Writer lock/unlock count = 1000, lock wait: total = 7136.79 ms, avg = 7136788.35 ns, unlock wait: total = 1159.55 ms, avg = 1159546.43 ns Total runtime 1603.18 ms

Test with 10 writers and 1000 readers, 100 iterations, 1 writer inner loops, data len=1000, pinned threads
Reader lock/unlock count = 100000, lock wait: total = 2197968.93 ms, avg = 21979689.31 ns, unlock wait: total = 158759.70 ms, avg = 1587597.02 ns
Writer lock/unlock count = 1000, lock wait: total = 16269.13 ms, avg = 16269125.97 ns, unlock wait: total = 2007.15 ms, avg = 2007152.40 ns Total runtime 2407.85 ms

-- New
Cmdline: /tests/tst-rwlock.so
Running contended read-write lock tests

Test with 10 writers and 1000 readers, 100 iterations, 1 writer inner loops, data len=1000, non-pinned threads
Reader lock/unlock count = 100000, lock wait: total = 137.68 ms, avg = 1376.83 ns, unlock wait: total = 8.65 ms, avg = 86.47 ns
Writer lock/unlock count = 1000, lock wait: total = 4.58 ms, avg = 4582.71 ns, unlock wait: total = 0.32 ms, avg = 319.08 ns Total runtime 524.06 ms

Test with 10 writers and 1000 readers, 100 iterations, 1 writer inner loops, data len=1000, pinned threads
Reader lock/unlock count = 100000, lock wait: total = 17.04 ms, avg = 170.40 ns, unlock wait: total = 7.52 ms, avg = 75.19 ns
Writer lock/unlock count = 1000, lock wait: total = 2.17 ms, avg = 2173.15 ns, unlock wait: total = 0.75 ms, avg = 745.52 ns Total runtime 390.06 ms
```
MySQL tests:
```
==
Original
----
Threads started!

[ 10s ] thds: 12 tps: 382.03 qps: 7653.88 (r/w/o: 5359.68/1528.94/765.27) lat (ms,95%): 44.98 err/s: 0.00 reconn/s: 0.00 [ 20s ] thds: 12 tps: 404.20 qps: 8083.40 (r/w/o: 5658.47/1616.52/808.41) lat (ms,95%): 40.37 err/s: 0.00 reconn/s: 0.00 [ 30s ] thds: 12 tps: 407.50 qps: 8153.40 (r/w/o: 5708.30/1630.10/815.00) lat (ms,95%): 40.37 err/s: 0.00 reconn/s: 0.00 [ 40s ] thds: 12 tps: 392.80 qps: 7852.54 (r/w/o: 5495.76/1571.19/785.59) lat (ms,95%): 41.85 err/s: 0.00 reconn/s: 0.00 [ 50s ] thds: 12 tps: 360.50 qps: 7210.39 (r/w/o: 5047.49/1441.90/721.00) lat (ms,95%): 44.17 err/s: 0.00 reconn/s: 0.00 [ 60s ] thds: 12 tps: 364.70 qps: 7292.50 (r/w/o: 5104.77/1458.32/729.41) lat (ms,95%): 44.98 err/s: 0.00 reconn/s: 0.00 SQL statistics:
    queries performed:
        read:                            323820
        write:                           92520
        other:                           46260
        total:                           462600
    transactions:                        23130  (385.37 per sec.)
    queries:                             462600 (7707.31 per sec.)
    ignored errors:                      0      (0.00 per sec.)
    reconnects:                          0      (0.00 per sec.)

General statistics:
    total time:                          60.0195s
    total number of events:              23130

Latency (ms):
         min:                                    5.75
         avg:                                   31.13
         max:                                  116.35
         95th percentile:                       42.61
         sum:                               720082.28

Threads fairness:
    events (avg/stddev):           1927.5000/17.10
    execution time (avg/stddev):   60.0069/0.00

New
----
Threads started!

[ 10s ] thds: 12 tps: 427.02 qps: 8553.25 (r/w/o: 5989.65/1708.37/855.24) lat (ms,95%): 41.10 err/s: 0.00 reconn/s: 0.00 [ 20s ] thds: 12 tps: 417.81 qps: 8354.94 (r/w/o: 5847.77/1671.65/835.52) lat (ms,95%): 38.94 err/s: 0.00 reconn/s: 0.00 [ 30s ] thds: 12 tps: 408.70 qps: 8171.71 (r/w/o: 5719.84/1634.48/817.39) lat (ms,95%): 39.65 err/s: 0.00 reconn/s: 0.00 [ 40s ] thds: 12 tps: 412.99 qps: 8261.22 (r/w/o: 5782.87/1652.26/826.08) lat (ms,95%): 38.94 err/s: 0.00 reconn/s: 0.00 [ 50s ] thds: 12 tps: 413.81 qps: 8282.45 (r/w/o: 5799.51/1655.33/827.62) lat (ms,95%): 40.37 err/s: 0.00 reconn/s: 0.00 [ 60s ] thds: 12 tps: 415.70 qps: 8313.94 (r/w/o: 5819.73/1662.81/831.40) lat (ms,95%): 39.65 err/s: 0.00 reconn/s: 0.00 SQL statistics:
    queries performed:
        read:                            349622
        write:                           99892
        other:                           49946
        total:                           499460
    transactions:                        24973  (416.10 per sec.)
    queries:                             499460 (8321.99 per sec.)
    ignored errors:                      0      (0.00 per sec.)
    reconnects:                          0      (0.00 per sec.)

General statistics:
    total time:                          60.0155s
    total number of events:              24973

Latency (ms):
         min:                                    5.34
         avg:                                   28.83
         max:                                  106.06
         95th percentile:                       39.65
         sum:                               720051.48

Threads fairness:
    events (avg/stddev):           2081.0833/22.89
    execution time (avg/stddev):   60.0043/0.00
```

The MySQL test using new rwlock is 8-10 % faster.