### PR TITLE
tests: fix compilation with `mode=debug`.

### DIFF
--- a/tests/tst-bsd-tcp1.cc
+++ b/tests/tst-bsd-tcp1.cc
@@ -21,9 +21,9 @@
 #include <boost/asio.hpp>
 
 #if CONF_logger_debug
-    #define dbg_d(tag, ...) printf(__VA_ARGS__)
+    #define dbg_d(...) printf(__VA_ARGS__)
 #else
-    #define dbg_d(tag, ...) do{}while(0)
+    #define dbg_d(...) do{}while(0)
 #endif
 
 #define LISTEN_PORT (5555)


### PR DESCRIPTION
Without this change, building the tests in `mode=debug` (where `CONF_logger_debug` is set) fails with the following error with GCC >= 11:

	error: too few arguments to function ‘int printf(const char*, ...)’
		#define dbg_d(tag, ...) printf(__VA_ARGS__)

This commit fixes that by removing the tag argument as the macro is only used with a single argument in the code.