### PR TITLE
tests: Fix bashism in java-tests Makefile

### DIFF
--- a/modules/java-tests/Makefile
+++ b/modules/java-tests/Makefile
@@ -83,7 +83,7 @@ java_perms_cmd := 'java-perms: /usr/lib/jvm/java/bin/java -cp /tests/java/tests.
 ifeq ($(arch),$(host_arch))
 test_commands:
 	$(call very-quiet, rm -f test_commands)
-	$(call very-quiet, if [[ "$(javac_version)" == "javac 1.8" && "$(conf_hide_symbols)" != "1" ]]; then \
+	$(call very-quiet, if [ "$(javac_version)" = "javac 1.8" -a "$(conf_hide_symbols)" != "1" ]; then \
 		echo $(java_isolated_cmd) >> test_commands && \
 		echo $(java_non_isolated_cmd) >> test_commands; fi )
 	$(call very-quiet, echo $(java_no_wrapper_cmd) >> test_commands)


### PR DESCRIPTION
For Makefiles, we cannot assume that $SHELL is bash. Therefore, unless we set $SHELL explicitly, we must not use any non-POSIX bash language extensions. The `[[` operator is such a bash extension and causes the following output on Debian-derivates where /bin/sh is dash:

	/bin/sh: 1: [: javac 1.8: unexpected operator

This commit fixes this by using POSIX's `[` operator.