### PR TITLE
Running Rust/tokio applications on OSv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -458,9 +458,9 @@ kernel_base := 0x200000
 lzkernel_base := 0x100000
 kernel_vm_base := 0x40200000
 
-# the default of 64 bytes can be overridden by passing the app_local_exec_tls_size
+# the default of 512 bytes can be overridden by passing the app_local_exec_tls_size
 # environment variable to the make or scripts/build
-app_local_exec_tls_size := 0x40
+app_local_exec_tls_size := 0x200
 
 $(out)/arch/x64/boot16.o: $(out)/lzloader.elf
 $(out)/boot.bin: arch/x64/boot16.ld $(out)/arch/x64/boot16.o
@@ -528,7 +528,7 @@ endif # x64
 ifeq ($(arch),aarch64)
 
 kernel_vm_base := 0xfc0080000 #63GB
-app_local_exec_tls_size := 0x40
+app_local_exec_tls_size := 0x200
 
 include $(libfdt_base)/Makefile.libfdt
 libfdt-source := $(patsubst %.c, $(libfdt_base)/%.c, $(LIBFDT_SRCS))

--- a/libc/af_local.cc
+++ b/libc/af_local.cc
@@ -99,15 +99,26 @@ int af_local::close()
 
 int socketpair_af_local(int type, int proto, int sv[2])
 {
-    assert(type == SOCK_STREAM);
+    int flags = type & (SOCK_NONBLOCK | SOCK_CLOEXEC);
+    int base_type = type & ~(SOCK_NONBLOCK | SOCK_CLOEXEC);
+    assert(base_type == SOCK_STREAM);
     assert(proto == 0);
     pipe_buffer_ref b1{new pipe_buffer};
     pipe_buffer_ref b2{new pipe_buffer};
     try {
         fileref f1 = make_file<af_local>(b1, b2);
         fileref f2 = make_file<af_local>(std::move(b2), std::move(b1));
+        if (flags & SOCK_NONBLOCK) {
+            FD_LOCK(f1.get());
+            f1->f_flags |= FNONBLOCK;
+            FD_UNLOCK(f1.get());
+            FD_LOCK(f2.get());
+            f2->f_flags |= FNONBLOCK;
+            FD_UNLOCK(f2.get());
+        }
         fdesc fd1(f1);
         fdesc fd2(f2);
+        // SOCK_CLOEXEC is a no-op in OSv (no fork/exec)
         // all went well, user owns descriptors now
         sv[0] = fd1.release();
         sv[1] = fd2.release();


### PR DESCRIPTION
Two fixes:

1. socketpair: mask `SOCK_NONBLOCK|SOCK_CLOEXEC` flags before the type assertion, apply `FNONBLOCK` to both fds
2. TLS size: bump default from `64` → `512` bytes to prevent silent memory corruption of thread-locals for Rust/Go apps