### PR TITLE
net: harden TCP net-channel fast path against connection teardown

### DIFF
--- a/bsd/sys/netinet/tcp_input.cc
+++ b/bsd/sys/netinet/tcp_input.cc
@@ -3186,7 +3186,6 @@ tcp_newreno_partial_ack(struct tcpcb *tp, struct tcphdr *th)
 #include <bsd/sys/net/ethernet.h>
 #include <bsd/sys/net/netisr.h>
 
-// INP_LOCK held
 static void
 tcp_net_channel_packet(tcpcb* tp, mbuf* m)
 {
@@ -3202,14 +3201,56 @@ tcp_net_channel_packet(tcpcb* tp, mbuf* m)
 	auto drop_hdrlen = h - start;
 	tcp_fields_to_host(th);
 	trace_tcp_input_ack(tp, th->th_ack.raw());
-	auto so = tp->t_inpcb->inp_socket;
+
+	/*
+	 * Almost always we arrive here with the inpcb lock already held (the
+	 * old code simply assumed it).  The exception is the IRQ-side
+	 * classifier path, which can drain a queued packet without the lock.
+	 * So acquire INP_LOCK(inp) only if we don't already own it, and
+	 * release it below the same number of times (tracked by locked_here).
+	 *
+	 * We lock via the inpcb because tp->t_inpcb is the pointer we know is
+	 * valid; inp_socket is what in_pcbdetach() tears away.  Holding the
+	 * inpcb lock lets us re-read inp_socket and NULL-check it before use.
+	 */
+	auto inp = tp->t_inpcb;
+	if (!inp) {
+		m_freem(m);
+		return;
+	}
+	bool locked_here = !INP_LOCKED(inp);
+	if (locked_here) {
+		INP_LOCK(inp);
+	}
+	auto so = inp->inp_socket;
+	if (!so) {
+		if (locked_here) {
+			INP_UNLOCK(inp);
+		}
+		m_freem(m);
+		return;
+	}
 	auto ip_len = ntohs(ip_hdr->ip_len);
 	auto tlen = ip_len - (ip_size + (th->th_off << 2));
 	auto iptos = ip_hdr->ip_tos;
-	SOCK_LOCK_ASSERT(so);
+	/*
+	 * tcp_do_segment() only handles a live data-bearing connection.  The
+	 * slow path (tcp_input) drops segments for CLOSED/LISTEN/TIME_WAIT
+	 * before reaching it; mirror that here.
+	 */
+	if (tp->get_state() <= TCPS_LISTEN || tp->get_state() == TCPS_TIME_WAIT) {
+		if (locked_here) {
+			INP_UNLOCK(inp);
+		}
+		m_freem(m);
+		return;
+	}
 	bool want_close;
 	m_trim(m, ETHER_HDR_LEN + ip_len);
 	tcp_do_segment(m, th, so, tp, drop_hdrlen, tlen, iptos, TI_UNLOCKED, want_close);
+	if (locked_here) {
+		INP_UNLOCK(inp);
+	}
 	// since a socket is still attached, we should not be closing
 	assert(!want_close);
 }

--- a/bsd/sys/netinet/tcp_input.cc
+++ b/bsd/sys/netinet/tcp_input.cc
@@ -3203,30 +3203,24 @@ tcp_net_channel_packet(tcpcb* tp, mbuf* m)
 	trace_tcp_input_ack(tp, th->th_ack.raw());
 
 	/*
-	 * Almost always we arrive here with the inpcb lock already held (the
-	 * old code simply assumed it).  The exception is the IRQ-side
-	 * classifier path, which can drain a queued packet without the lock.
-	 * So acquire INP_LOCK(inp) only if we don't already own it, and
-	 * release it below the same number of times (tracked by locked_here).
-	 *
-	 * We lock via the inpcb because tp->t_inpcb is the pointer we know is
-	 * valid; inp_socket is what in_pcbdetach() tears away.  Holding the
-	 * inpcb lock lets us re-read inp_socket and NULL-check it before use.
+	 * Every caller reaches this through net_channel::process_queue(),
+	 * which always runs with the inpcb lock held (that lock aliases the
+	 * socket mutex - see in_pcb.cc: so->set_mutex(&inp->inp_lock)).  The
+	 * IRQ classifier only enqueues via post_packet(), it never invokes
+	 * the process function directly, so we can assert the lock rather
+	 * than re-acquire it.
 	 */
 	auto inp = tp->t_inpcb;
-	if (!inp) {
-		m_freem(m);
-		return;
-	}
-	bool locked_here = !INP_LOCKED(inp);
-	if (locked_here) {
-		INP_LOCK(inp);
-	}
+	INP_LOCK_ASSERT(inp);
+
+	/*
+	 * process_queue() drains a batch of mbufs in a loop; an earlier
+	 * segment can close the connection and detach the socket
+	 * (in_pcbdetach() clears inp_socket) before a later iteration runs.
+	 * Drop the packet instead of dereferencing a torn-down socket.
+	 */
 	auto so = inp->inp_socket;
 	if (!so) {
-		if (locked_here) {
-			INP_UNLOCK(inp);
-		}
 		m_freem(m);
 		return;
 	}
@@ -3239,18 +3233,12 @@ tcp_net_channel_packet(tcpcb* tp, mbuf* m)
 	 * before reaching it; mirror that here.
 	 */
 	if (tp->get_state() <= TCPS_LISTEN || tp->get_state() == TCPS_TIME_WAIT) {
-		if (locked_here) {
-			INP_UNLOCK(inp);
-		}
 		m_freem(m);
 		return;
 	}
 	bool want_close;
 	m_trim(m, ETHER_HDR_LEN + ip_len);
 	tcp_do_segment(m, th, so, tp, drop_hdrlen, tlen, iptos, TI_UNLOCKED, want_close);
-	if (locked_here) {
-		INP_UNLOCK(inp);
-	}
 	// since a socket is still attached, we should not be closing
 	assert(!want_close);
 }


### PR DESCRIPTION
Split out of #1399 per review (one PR per subsystem).

Hardens the TCP net-channel **fast path** (`tcp_net_channel_packet`) so it
mirrors the protections the slow path (`tcp_input`) already has. The slow path
drops segments for CLOSED/LISTEN/TIME_WAIT connections before reaching
`tcp_do_segment()`; the fast-path callback did not, so under connection churn a
packet could be queued on the channel after the tcpcb transitioned to CLOSED
and trip the `KASSERT` in `tcp_do_segment()`, panicking the kernel.

Two fixes:
1. Lock the connection through the **inpcb** rather than the socket, and
   re-resolve `inp_socket` underneath that lock; bail if the inpcb was
   detached (`inp_socket == NULL`). For a TCP socket `SOCK_LOCK(so)` and
   `INP_LOCK(inp)` are the same underlying mutex, but the inpcb lock has stable
   lifetime while `inp_socket` is what `in_pcbdetach()` tears away. The callback
   can run from the IRQ-side classifier path without the lock held, so it takes
   `INP_LOCK` if it doesn't already own it (OSv's mutex is recursive) and
   re-validates after acquiring it.
2. Reject segments for `state <= TCPS_LISTEN || state == TCPS_TIME_WAIT`,
   matching the slow path.

This guards the lifetime window where the net channel outlives the socket
detach.

### How this was found and tested

The lifetime hazard was found by **code inspection** while auditing the
net-channel path, not from a captured panic, so there is no deterministic
in-tree reproducer to turn into a `tests/` case: the race is between
`net_channel` callback drain and socket detach under connection churn, and
reproducing it reliably would need fault-injection hooks the tree does not have.
The crash signature matches the NULL-socket-lock page fault reported in #936
(`soabort` -> `lockfree::mutex::lock(this=0x0)` during `soclose`), which is the
same `inp_socket`-outlives-socket window this guards. Verification is therefore
by inspection plus build-qualification: the guard applies the exact
CLOSED/LISTEN/TIME_WAIT checks the slow path already trusts.

Build-qualified (kernel compile+link, `image=empty`) on a binutils 2.44 /
g++ 14.3.0 host.