### PR TITLE
synch: fix wakeup_one to honor empty equal_range result

### DIFF
--- a/bsd/porting/synch.cc
+++ b/bsd/porting/synch.cc
@@ -120,8 +120,6 @@ int synch_port::_msleep(void *chan, struct mtx *mtx,
         if (chan) {
             // A pointer to the local "wait" may still be on the list -
             // need to remove it before we can return:
-            // A pointer to the local "wait" may still be on the list -
-            // need to remove it before we can return:
             mutex_lock(&_lock);
             auto ppp = _evlist.equal_range(chan);
             for (auto it=ppp.first; it!=ppp.second; ++it) {
@@ -160,8 +158,8 @@ void synch_port::wakeup_one(void* chan)
 
     mutex_lock(&_lock);
     auto ppp = _evlist.equal_range(chan);
-    auto it = ppp.first;
-    if (it != _evlist.end()) {
+    if (ppp.first != ppp.second) {
+        auto it = ppp.first;
         synch_thread* wait = (*it).second;
         _evlist.erase(it);
         trace_synch_wakeup_one_waking(chan, wait->_thread);


### PR DESCRIPTION
Split out of #1399 per review (one PR per subsystem).

`equal_range` returns `[first, second)`. An empty result has
`first == second`, but `first` is not necessarily `end()` — it points at the
first element greater than `chan`. The old `if (it != _evlist.end())` could
therefore dereference a non-matching element.

The fix tests `ppp.first != ppp.second`, matching how the range is correctly
consumed elsewhere in the file. A duplicated comment block in `_msleep` is also
removed.

Build-qualified (kernel compile+link, `image=empty`) on a binutils 2.44 /
g++ 14.3.0 host.