### PR TITLE
elf: include path and sizes in "executable too short" error

### DIFF
--- a/core/elf.cc
+++ b/core/elf.cc
@@ -327,8 +327,14 @@ void file::read(Elf64_Off offset, void* data, size_t size)
 {
     // read(fileref, ...) is void, and crashes with assertion failure if the
     // file is not long enough. So we need to check first.
-    if (::size(_f) < offset + size) {
-        throw osv::invalid_elf_error("executable too short");
+    auto fsize = ::size(_f);
+    if (fsize < offset + size) {
+        char buf[256];
+        snprintf(buf, sizeof(buf),
+                 "executable too short %s: file_size=%lu need=%lu",
+                 _pathname.c_str(), (unsigned long)fsize,
+                 (unsigned long)(offset + size));
+        throw osv::invalid_elf_error(buf);
     }
     ::read(_f, data, offset, size);
 }


### PR DESCRIPTION
Split out of #1399 per review (one PR per subsystem).

Adds the file path and the actual vs. expected sizes to the "executable too
short" error so a truncated or malformed object is diagnosable from the message
alone instead of just reporting that something was too short.

Build-qualified (kernel compile+link, `image=empty`) on a binutils 2.44 /
g++ 14.3.0 host.