### PR TITLE
lzloader: give .rodata its own output section

### DIFF
--- a/arch/x64/lzloader.ld
+++ b/arch/x64/lzloader.ld
@@ -10,7 +10,7 @@ SECTIONS
 {
     . = OSV_LZKERNEL_BASE + 0x1000;
     .text : { *(.text) }
-    . = OSV_LZKERNEL_BASE + 0x3000;
+    .rodata : { *(.rodata .rodata.*) }
     .data : { *(.data) }
     .bss : { *(.bss) }
     .edata = .;


### PR DESCRIPTION
Split out of #1399 per review.

This was the unrelated linker-script change flagged in review on the io_uring
commit (`arch/x64/lzloader.ld:13`). It gives `.rodata` its own output section in
the lzloader (kernel decompressor) link and is not part of the io_uring change,
so it is submitted on its own here.

Build-qualified (kernel compile+link, `image=empty`) on a binutils 2.44 /
g++ 14.3.0 host.