### PR TITLE
Makefile: suppress ld RWX LOAD segment warning for loader.elf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,12 @@ CROSS_PREFIX ?= $(if $(filter-out $(arch),$(host_arch)),$(arch)-linux-gnu-)
 CXX=$(CROSS_PREFIX)g++
 CC=$(CROSS_PREFIX)gcc
 LD=$(CROSS_PREFIX)ld.bfd
+# binutils >= 2.39 warns about LOAD segments with RWX permissions. OSv intentionally
+# uses a single RWX LOAD segment in loader.ld, so suppress the warning if supported.
+ld_no_warn_rwx := $(shell $(LD) --no-warn-rwx-segments 2>&1 | grep -c "unrecognized option")
+ifeq ($(ld_no_warn_rwx),0)
+conf_linker_extra_options += --no-warn-rwx-segments
+endif
 export STRIP=$(CROSS_PREFIX)strip
 OBJCOPY=$(CROSS_PREFIX)objcopy
 


### PR DESCRIPTION
When building loader.elf, ld.bfd now emits:

  ld.bfd: warning: build/release.x64/loader.elf has a LOAD segment
          with RWX permissions

This warning was introduced in binutils 2.39 (August 2022) as a security-hardening measure to encourage W^X (Write XOR Execute) policies in userspace binaries.  Many distros have shipped binutils 2.39 or later since 2023, so the warning now appears for most users.

The warning is a false positive for OSv.  Our linker script (arch/x64/loader.ld) deliberately places all sections -- .text, .data, .bss, and friends -- into a single PT_LOAD segment.  This is an intentional kernel design: the loader bootstraps the MMU and enforces its own page-level permissions after it is running; the ELF segment permissions are irrelevant at that point.

The "correct" fix would be to split loader.ld into two PT_LOAD segments -- one RX for code and one RW for data -- as W^X would require.  However, that change is harder to reason about: OSv's loader relies on the precise VA/PA layout expressed via AT(ADDR(s) - OSV_KERNEL_VM_SHIFT) throughout the linker script, and splitting the single contiguous segment could affect relocation handling, the ELF header placement, and early-boot assumptions that have never been tested with a multi-segment layout.  Proper W^X support for the kernel image is tracked in issue #651; we defer it to that effort.

For now, detect whether ld.bfd supports --no-warn-rwx-segments (added in the same binutils 2.39 release that introduced the warning) and, if so, pass it when linking loader.elf and zfs_builder.elf.  On older toolchains the flag is absent and the build is unaffected.