### PR TITLE
build: decouple nvme driver from virtio gating

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -929,10 +929,6 @@ drivers += drivers/virtio-vring.o
 ifeq ($(conf_drivers_mmio),1)
 drivers += drivers/virtio-mmio.o
 endif
-ifeq ($(conf_drivers_nvme),1)
-drivers += drivers/nvme.o
-drivers += drivers/nvme-queue.o
-endif
 ifeq ($(conf_networking_stack),1)
 drivers += drivers/virtio-net.o
 endif
@@ -940,6 +936,11 @@ drivers += drivers/virtio-blk.o
 drivers += drivers/virtio-scsi.o
 drivers += drivers/virtio-rng.o
 drivers += drivers/virtio-fs.o
+endif
+
+ifeq ($(conf_drivers_nvme),1)
+drivers += drivers/nvme.o
+drivers += drivers/nvme-queue.o
 endif
 
 ifeq ($(conf_networking_stack),1)
@@ -1006,16 +1007,16 @@ endif
 ifeq ($(conf_drivers_mmio),1)
 drivers += drivers/virtio-mmio.o
 endif
-ifeq ($(conf_drivers_nvme),1)
-drivers += drivers/nvme.o
-drivers += drivers/nvme-queue.o
-endif
 drivers += drivers/virtio-vring.o
 drivers += drivers/virtio-rng.o
 drivers += drivers/virtio-blk.o
 drivers += drivers/virtio-scsi.o
 drivers += drivers/virtio-net.o
 drivers += drivers/virtio-fs.o
+endif
+ifeq ($(conf_drivers_nvme),1)
+drivers += drivers/nvme.o
+drivers += drivers/nvme-queue.o
 endif
 ifeq ($(conf_drivers_scsi),1)
 drivers += drivers/scsi-common.o


### PR DESCRIPTION
## Summary

The `nvme.o`/`nvme-queue.o` objects were nested inside the `ifeq ($(conf_drivers_virtio),1)` guard in both the x64 and aarch64 driver sections of the Makefile. NVMe has no dependency on virtio, so any driver profile that enables nvme while disabling virtio failed to compile the nvme driver and errored at link with an undefined reference to `nvme::driver::probe`.

This affects the `aws` profile in particular: AWS Nitro instances expose EBS volumes as NVMe devices, but the aws profile disables virtio. Before this change, `conf_drivers_profile=aws conf_drivers_nvme=1` produced a kernel with no NVMe driver.

This moves the nvme block outside the virtio guard in both the x64 and aarch64 sections so `conf_drivers_nvme=1` compiles the driver regardless of virtio state.

## Test plan

- [x] `make conf_drivers_profile=aws conf_drivers_nvme=1` — a `make -n` of the loader link line shows `drivers/nvme.o` and `drivers/nvme-queue.o` present and `drivers/virtio-blk.o` absent, confirming nvme links in with virtio disabled.
- [x] nvme + virtio objects compile cleanly under the aws profile.