### PR TITLE
io_uring: add opcodes, CQ backlog, cancellable poll, timer-based timeout

### DIFF
--- a/core/io_uring.cc
+++ b/core/io_uring.cc
@@ -36,6 +36,7 @@
 #include <osv/mempool.hh>
 #include <osv/sched.hh>
 #include <osv/clock.hh>
+#include <osv/condvar.h>
 #include "fs/vfs/vfs.h"
 
 #include <sys/mman.h>
@@ -55,9 +56,34 @@
 #include <deque>
 #include <unordered_map>
 #include <atomic>
+#include <algorithm>
 
 /* Forward declaration */
 class io_uring_file;
+struct cancel_token;
+struct io_uring_work;
+
+/*
+ * Return the io_uring_ctx backing a file, or nullptr if `fp` is not an
+ * io_uring fd.  Defined after io_uring_file (below) because the RTTI check
+ * needs the complete type; forward-declared here so exec_single_sqe (which
+ * runs MSG_RING against a *target* ring fd) can use it.
+ */
+static struct io_uring_ctx *io_uring_ctx_from_file(struct file *fp);
+
+/*
+ * OSv's futex() (defined in linux.cc, C++ linkage, global namespace).  Only
+ * FUTEX_WAIT / FUTEX_WAKE / FUTEX_WAIT_BITSET(match-any) are implemented; used
+ * by IORING_OP_FUTEX_WAIT / IORING_OP_FUTEX_WAKE.
+ */
+#ifndef FUTEX_WAIT
+#define FUTEX_WAIT 0
+#endif
+#ifndef FUTEX_WAKE
+#define FUTEX_WAKE 1
+#endif
+int futex(int *uaddr, int op, int val, const struct timespec *timeout,
+          int *uaddr2, uint32_t val3);
 
 /* Round up to the next power of two, leaving 0 and 1 unchanged.  A plain
  * clz-based round-up turns 1 into 2 (it feeds 1 into __builtin_clz), which
@@ -74,6 +100,20 @@ struct provided_buf {
     void    *addr;
     uint32_t len;
     uint16_t bid;
+};
+
+/*
+ * A registered provided-buffer ring (IORING_REGISTER_PBUF_RING).  Unlike the
+ * classic PROVIDE_BUFFERS deque, this is a LIVE shared ring: the application
+ * writes io_uring_buf entries and advances ring->tail; the kernel side picks
+ * bufs[head & mask] and advances its own head.  We store the ring pointer and
+ * mask and read ring->tail on every pick so newly-added buffers are seen
+ * without re-registration.  Protected by ctx->mtx.
+ */
+struct buf_ring {
+    struct io_uring_buf_ring *ring = nullptr;
+    uint32_t mask   = 0;   /* ring_entries - 1 */
+    uint16_t head   = 0;   /* kernel-side consumed counter */
 };
 
 /*
@@ -113,13 +153,24 @@ struct io_uring_ctx {
 
     /* Fixed resources */
     void          **registered_buffers;
+    size_t         *registered_buffer_lens;
     unsigned        nr_registered_buffers;
     struct file   **registered_files;
     unsigned        nr_registered_files;
 
+    /* Setup-time flags (IORING_SETUP_*) persisted from io_uring_params.flags */
+    uint32_t setup_flags;
+
+    /*
+     * IORING_SETUP_R_DISABLED: the ring starts disabled and rejects
+     * submissions until IORING_REGISTER_ENABLE_RINGS clears this.
+     */
+    bool disabled;
+
     /* SQPOLL */
     sched::thread *sq_poll_thread;
     uint32_t       sq_idle_ms;
+    uint32_t       sq_thread_cpu;   /* IORING_SETUP_SQ_AFF target CPU */
 
     /* Eventfd for completion notification */
     int eventfd_fd;
@@ -129,7 +180,7 @@ struct io_uring_ctx {
      * Each entry is an atomic<bool> shared with the work thread.
      * Protected by mtx.
      */
-    std::unordered_multimap<uint64_t, std::atomic<bool>*> cancellable;
+    std::unordered_multimap<uint64_t, cancel_token*> cancellable;
 
     /*
      * Provided buffer groups: buf_group_id -> deque of available buffers.
@@ -137,13 +188,77 @@ struct io_uring_ctx {
      */
     std::unordered_map<uint16_t, std::deque<provided_buf>> buf_groups;
 
+    /*
+     * Registered live buffer rings (IORING_REGISTER_PBUF_RING):
+     * buf_group_id -> live ring.  Takes precedence over buf_groups for a
+     * given bgid.  Protected by mtx.
+     */
+    std::unordered_map<uint16_t, buf_ring> buf_rings;
+
+    /*
+     * CQ overflow backlog.  When the visible CQ ring is full, completions are
+     * queued here instead of being dropped (IORING_FEAT_NODROP honesty) and
+     * flushed into the ring as the application consumes CQEs.  Protected by
+     * mtx.
+     */
+    std::deque<struct io_uring_cqe> cq_overflow;
+
+    /*
+     * io-wq worker pool.  Replaces the former detached-thread-per-chain model
+     * (which created one sched::thread per submitted SQE chain -- a thread-
+     * creation amplifier under PostgreSQL-style batch submit).  Persistent
+     * workers pull chains from per-class queues and are reused across
+     * submissions, so thread creation is bounded to wq_max_workers per class
+     * for the whole lifetime of the ring rather than growing with load.
+     *
+     * Two classes mirror Linux io-wq and IORING_REGISTER_IOWQ_MAX_WORKERS,
+     * which takes a [bounded, unbounded] pair:
+     *   index 0 = WQ_BOUNDED   -- file/disk ops that complete promptly.
+     *   index 1 = WQ_UNBOUNDED -- net/poll/timeout ops that may block
+     *                             indefinitely; kept in a separate pool so a
+     *                             burst of blocking waits cannot starve disk
+     *                             I/O of workers.
+     * All fields protected by mtx.
+     */
+    std::deque<std::shared_ptr<std::vector<io_uring_work>>> wq_queue[2];
+    waitqueue   wq_wait[2];
+    uint32_t    wq_nr_workers[2];   /* threads created per class */
+    uint32_t    wq_idle[2];         /* workers currently blocked on wq_wait */
+    uint32_t    wq_max_workers[2];  /* cap per class (IOWQ_MAX_WORKERS) */
+    std::vector<sched::thread*> wq_threads;  /* all workers, joined at teardown */
+
     io_uring_ctx()
         : pending_ops(0), shutdown(false),
-          registered_buffers(nullptr), nr_registered_buffers(0),
+          registered_buffers(nullptr), registered_buffer_lens(nullptr),
+          nr_registered_buffers(0),
           registered_files(nullptr), nr_registered_files(0),
-          sq_poll_thread(nullptr), sq_idle_ms(0),
+          setup_flags(0), disabled(false),
+          sq_poll_thread(nullptr), sq_idle_ms(0), sq_thread_cpu(0),
           eventfd_fd(-1)
-    {}
+    {
+        unsigned ncpu = (unsigned)sched::cpus.size();
+        if (ncpu == 0) ncpu = 1;
+        wq_max_workers[0] = std::max(4u, ncpu);       /* bounded (disk) */
+        wq_max_workers[1] = std::max(16u, ncpu * 4);  /* unbounded (net) */
+        wq_nr_workers[0] = wq_nr_workers[1] = 0;
+        wq_idle[0] = wq_idle[1] = 0;
+    }
+};
+
+/*
+ * Cancellation token for one work item.  Shared (by pointer) between the
+ * work item and the ctx->cancellable map so that a cancel request can reach
+ * an operation whether it is still queued or already in flight.
+ *
+ *   cancelled  - set by a cancel request; checked before the op starts.
+ *   worker     - the thread running this op once it is in flight, else null.
+ *                A cancel request that finds a non-null worker interrupts it,
+ *                unblocking an interruptible wait (socket recv/accept/etc.)
+ *                with EINTR so the op returns instead of hanging forever.
+ */
+struct cancel_token {
+    std::atomic<bool>           cancelled{false};
+    std::atomic<sched::thread*> worker{nullptr};
 };
 
 /*
@@ -153,12 +268,18 @@ struct io_uring_ctx {
 struct io_uring_work {
     struct io_uring_ctx *ctx;
     struct io_uring_sqe  sqe;
-    std::atomic<bool>    cancelled{false};
+    cancel_token         cancel;
 
     io_uring_work() = default;
-    /* std::atomic is non-movable; define a move ctor that copies the value */
+    /* cancel_token is non-movable; define a move ctor that copies its state */
     io_uring_work(io_uring_work&& o) noexcept
-        : ctx(o.ctx), sqe(o.sqe), cancelled(o.cancelled.load(std::memory_order_relaxed)) {}
+        : ctx(o.ctx), sqe(o.sqe)
+    {
+        cancel.cancelled.store(o.cancel.cancelled.load(std::memory_order_relaxed),
+                               std::memory_order_relaxed);
+        cancel.worker.store(o.cancel.worker.load(std::memory_order_relaxed),
+                            std::memory_order_relaxed);
+    }
     io_uring_work& operator=(io_uring_work&&) = delete;
 };
 
@@ -174,14 +295,35 @@ static constexpr off_t IORING_OFF_SQES    = 0x10000000ULL;
  * CQE posting
  * ---------------------------------------------------------------------- */
 
-static void io_uring_complete_op(struct io_uring_ctx *ctx,
-                                 uint64_t user_data,
-                                 int32_t  res,
-                                 uint32_t cqe_flags)
+/*
+ * Raise or clear IORING_SQ_CQ_OVERFLOW in the SQ ring flags so the
+ * application can observe that a backlog exists (and must drain the CQ /
+ * re-enter to flush it).  ctx->mtx must be held.
+ */
+static void set_cq_overflow_flag_locked(struct io_uring_ctx *ctx, bool on)
 {
-    WITH_LOCK(ctx->mtx) {
-        uint32_t head, tail, next;
+    if (!ctx->sq_ring)
+        return;
+    auto *sq = static_cast<struct io_uring_sq_ring *>(ctx->sq_ring);
+    if (on)
+        sq->flags.fetch_or(IORING_SQ_CQ_OVERFLOW, std::memory_order_release);
+    else
+        sq->flags.fetch_and(~IORING_SQ_CQ_OVERFLOW, std::memory_order_release);
+}
 
+/*
+ * Move backlogged completions into the visible CQ ring while free slots
+ * exist, preserving FIFO order.  Clears the overflow flag once drained.
+ * ctx->mtx must be held.  Does not touch pending_ops (those were already
+ * accounted when the completion was first produced).
+ */
+static void flush_cq_overflow_locked(struct io_uring_ctx *ctx)
+{
+    if (ctx->cq_overflow.empty())
+        return;
+
+    while (!ctx->cq_overflow.empty()) {
+        uint32_t head, tail;
         if (ctx->cq_ring) {
             auto *cq = static_cast<struct io_uring_cq_ring *>(ctx->cq_ring);
             head = cq->head.load(std::memory_order_acquire);
@@ -191,18 +333,70 @@ static void io_uring_complete_op(struct io_uring_ctx *ctx,
             tail = ctx->cq.tail;
         }
 
-        next = tail + 1;
-        if ((next - head) > ctx->cq.entries) {
-            /* CQ overflow: increment the overflow counter */
-            if (ctx->cq_ring) {
-                auto *cq = static_cast<struct io_uring_cq_ring *>(ctx->cq_ring);
-                cq->overflow.fetch_add(1, std::memory_order_relaxed);
-            }
-            ctx->pending_ops--;
-            ctx->wait_cq.wake_all(ctx->mtx);
-            return;
-        }
+        uint32_t next = tail + 1;
+        if ((next - head) > ctx->cq.entries)
+            break;      /* ring still full; leave the rest backlogged */
 
+        const struct io_uring_cqe &c = ctx->cq_overflow.front();
+        struct io_uring_cqe *slot = &ctx->cqes[tail & ctx->cq.mask];
+        slot->user_data = c.user_data;
+        slot->res       = c.res;
+        slot->flags     = c.flags;
+        ctx->cq_overflow.pop_front();
+
+        std::atomic_thread_fence(std::memory_order_release);
+
+        if (ctx->cq_ring) {
+            auto *cq = static_cast<struct io_uring_cq_ring *>(ctx->cq_ring);
+            cq->tail.store(next, std::memory_order_release);
+        }
+        ctx->cq.tail = next;
+    }
+
+    if (ctx->cq_overflow.empty())
+        set_cq_overflow_flag_locked(ctx, false);
+}
+
+/*
+ * Post a single CQE to the ring (or the overflow backlog).  ctx->mtx must be
+ * held.  Does NOT touch pending_ops or wake waiters -- the caller decides
+ * whether this completion retires an op.  Shared by io_uring_complete_op()
+ * (terminal completions) and the multishot intermediate poster.
+ */
+static void io_uring_post_cqe_locked(struct io_uring_ctx *ctx,
+                                     uint64_t user_data,
+                                     int32_t  res,
+                                     uint32_t cqe_flags)
+{
+    /* Drain any backlogged CQEs into slots the app has freed. */
+    flush_cq_overflow_locked(ctx);
+
+    uint32_t head, tail, next;
+
+    if (ctx->cq_ring) {
+        auto *cq = static_cast<struct io_uring_cq_ring *>(ctx->cq_ring);
+        head = cq->head.load(std::memory_order_acquire);
+        tail = cq->tail.load(std::memory_order_acquire);
+    } else {
+        head = ctx->cq.head;
+        tail = ctx->cq.tail;
+    }
+
+    next = tail + 1;
+    if (!ctx->cq_overflow.empty() || (next - head) > ctx->cq.entries) {
+        /*
+         * CQ ring is full (or a backlog already exists and ordering must
+         * be preserved): enqueue to the overflow backlog instead of
+         * dropping, and raise the overflow flag.  IORING_FEAT_NODROP
+         * guarantees no completion is lost.
+         */
+        struct io_uring_cqe c;
+        c.user_data = user_data;
+        c.res       = res;
+        c.flags     = cqe_flags;
+        ctx->cq_overflow.push_back(c);
+        set_cq_overflow_flag_locked(ctx, true);
+    } else {
         struct io_uring_cqe *cqe = &ctx->cqes[tail & ctx->cq.mask];
         cqe->user_data = user_data;
         cqe->res       = res;
@@ -215,8 +409,17 @@ static void io_uring_complete_op(struct io_uring_ctx *ctx,
             cq->tail.store(next, std::memory_order_release);
         }
         ctx->cq.tail = next;
-        ctx->pending_ops--;
+    }
+}
 
+static void io_uring_complete_op(struct io_uring_ctx *ctx,
+                                 uint64_t user_data,
+                                 int32_t  res,
+                                 uint32_t cqe_flags)
+{
+    WITH_LOCK(ctx->mtx) {
+        io_uring_post_cqe_locked(ctx, user_data, res, cqe_flags);
+        ctx->pending_ops--;
         ctx->wait_cq.wake_all(ctx->mtx);
     }
 
@@ -227,6 +430,111 @@ static void io_uring_complete_op(struct io_uring_ctx *ctx,
         (void)::write(ctx->eventfd_fd, &val, sizeof(val));
     }
 }
+
+/*
+ * Post a multishot intermediate CQE with IORING_CQE_F_MORE set.  The op stays
+ * armed (pending_ops is NOT decremented), so only the terminal CQE -- posted
+ * later via io_uring_complete_op() without F_MORE -- retires it.
+ */
+static void io_uring_post_multishot_cqe(struct io_uring_ctx *ctx,
+                                        uint64_t user_data,
+                                        int32_t  res,
+                                        uint32_t cqe_flags)
+{
+    WITH_LOCK(ctx->mtx) {
+        io_uring_post_cqe_locked(ctx, user_data, res,
+                                 cqe_flags | IORING_CQE_F_MORE);
+        ctx->wait_cq.wake_all(ctx->mtx);
+    }
+
+    if (ctx->eventfd_fd >= 0) {
+        uint64_t val = 1;
+        (void)::write(ctx->eventfd_fd, &val, sizeof(val));
+    }
+}
+
+/* -------------------------------------------------------------------------
+ * Cancel a single tracked op by its cancel_token.  Must be called with
+ * ctx->mtx held.  Sets the cancelled flag (so a not-yet-started op will be
+ * short-circuited) and, if the op is already in flight on a worker thread,
+ * interrupts that thread so an interruptible blocking wait returns EINTR.
+ * ---------------------------------------------------------------------- */
+
+static void cancel_token_fire(cancel_token *tok)
+{
+    tok->cancelled.store(true, std::memory_order_relaxed);
+    sched::thread *w = tok->worker.load(std::memory_order_acquire);
+    if (w)
+        w->interrupted(true);
+}
+
+/* -------------------------------------------------------------------------
+ * Convert an io_uring timeout spec (__kernel_timespec + timeout_flags) into
+ * an absolute monotonic (uptime) deadline suitable for condvar/timer waits.
+ *
+ * Honors IORING_TIMEOUT_ABS and the clock-selection flags:
+ *   - relative (default): now() + (sec, nsec)
+ *   - ABS + BOOTTIME:      absolute uptime nanoseconds
+ *   - ABS + REALTIME/def:  absolute wall-clock ns since epoch, mapped to
+ *                          uptime by subtracting the current boot_time().
+ * ---------------------------------------------------------------------- */
+
+static osv::clock::uptime::time_point
+io_uring_deadline(const struct __kernel_timespec *ts, uint32_t flags)
+{
+    using namespace std::chrono;
+    auto dur = duration_cast<osv::clock::uptime::duration>(
+                   seconds(ts->tv_sec) + nanoseconds(ts->tv_nsec));
+
+    if (flags & IORING_TIMEOUT_ABS) {
+        if (flags & IORING_TIMEOUT_BOOTTIME) {
+            return osv::clock::uptime::time_point(dur);
+        }
+        /* Absolute wall-clock target -> uptime via boot_time offset. */
+        auto wall_target = osv::clock::wall::time_point(
+            duration_cast<osv::clock::wall::duration>(dur));
+        auto rel = wall_target - osv::clock::wall::boot_time();
+        return osv::clock::uptime::time_point(
+            duration_cast<osv::clock::uptime::duration>(rel));
+    }
+    return osv::clock::uptime::now() + dur;
+}
+
+
+/* -------------------------------------------------------------------------
+ * Pick a provided buffer for buffer-select (IOSQE_BUFFER_SELECT).  Tries the
+ * live registered buffer ring (IORING_REGISTER_PBUF_RING) first, reading its
+ * tail fresh so buffers the app added since registration are visible; falls
+ * back to the classic PROVIDE_BUFFERS deque.  ctx->mtx MUST be held.
+ * Returns true and fills *out on success; false if no buffer is available.
+ * ---------------------------------------------------------------------- */
+static bool io_uring_pick_buffer(struct io_uring_ctx *ctx, uint16_t bgid,
+                                 provided_buf *out)
+{
+    auto rit = ctx->buf_rings.find(bgid);
+    if (rit != ctx->buf_rings.end() && rit->second.ring) {
+        buf_ring &br = rit->second;
+        uint16_t tail = __atomic_load_n(&br.ring->tail, __ATOMIC_ACQUIRE);
+        if ((uint16_t)(tail - br.head) != 0) {
+            struct io_uring_buf &b = br.ring->bufs[br.head & br.mask];
+            out->addr = reinterpret_cast<void *>(b.addr);
+            out->len  = b.len;
+            out->bid  = b.bid;
+            br.head++;
+            return true;
+        }
+        return false;   /* live ring registered but empty: do not fall back */
+    }
+
+    auto git = ctx->buf_groups.find(bgid);
+    if (git != ctx->buf_groups.end() && !git->second.empty()) {
+        *out = git->second.front();
+        git->second.pop_front();
+        return true;
+    }
+    return false;
+}
+
 
 /* -------------------------------------------------------------------------
  * Resolve fd: if IOSQE_FIXED_FILE is set, look up the registered file slot;
@@ -296,7 +604,16 @@ static int32_t exec_single_sqe(struct io_uring_ctx *ctx,
                 res = -EFAULT;
                 break;
             }
-            iov_local.iov_base = ctx->registered_buffers[idx];
+            uintptr_t base = reinterpret_cast<uintptr_t>(ctx->registered_buffers[idx]);
+            size_t    blen = ctx->registered_buffer_lens[idx];
+            uintptr_t want = sqe->addr;
+            if (want < base || sqe->len > blen ||
+                want + sqe->len > base + blen) {
+                if (!fixed) fdrop(fp);
+                res = -EFAULT;
+                break;
+            }
+            iov_local.iov_base = reinterpret_cast<void *>(want);
             iov_local.iov_len  = sqe->len;
             iovp   = &iov_local;
             iovcnt = 1;
@@ -336,7 +653,16 @@ static int32_t exec_single_sqe(struct io_uring_ctx *ctx,
                 res = -EFAULT;
                 break;
             }
-            iov_local.iov_base = ctx->registered_buffers[idx];
+            uintptr_t base = reinterpret_cast<uintptr_t>(ctx->registered_buffers[idx]);
+            size_t    blen = ctx->registered_buffer_lens[idx];
+            uintptr_t want = sqe->addr;
+            if (want < base || sqe->len > blen ||
+                want + sqe->len > base + blen) {
+                if (!fixed) fdrop(fp);
+                res = -EFAULT;
+                break;
+            }
+            iov_local.iov_base = reinterpret_cast<void *>(want);
             iov_local.iov_len  = sqe->len;
             iovp   = &iov_local;
             iovcnt = 1;
@@ -365,7 +691,30 @@ static int32_t exec_single_sqe(struct io_uring_ctx *ctx,
 
     /* --- SYNC_FILE_RANGE --- */
     case IORING_OP_SYNC_FILE_RANGE: {
-        /* OSv has no sync_file_range(2); fall back to fsync */
+        /*
+         * Linux sync_file_range(2) semantics on the SQE:
+         *   off  = starting offset, len = nbytes (0 nbytes = "to EOF"),
+         *   sync_range_flags = SYNC_FILE_RANGE_{WAIT_BEFORE,WRITE,WAIT_AFTER}.
+         * It validates its arguments strictly, rejecting a negative offset,
+         * negative/overflowing length, or unknown flag bits with -EINVAL.
+         *
+         * OSv has no ranged writeback primitive, so once the arguments are
+         * validated we issue a full fsync(): flushing the whole file is a
+         * correct superset of flushing a byte range, so the durability the
+         * caller asked for is honored (never under-synced).  We validate
+         * first rather than silently ignoring bad input.
+         */
+        int64_t off   = (int64_t)sqe->off;
+        int64_t nbytes = (int64_t)sqe->len;
+        uint32_t sflags = sqe->sync_range_flags;
+        const uint32_t valid = SYNC_FILE_RANGE_WAIT_BEFORE |
+                               SYNC_FILE_RANGE_WRITE |
+                               SYNC_FILE_RANGE_WAIT_AFTER;
+        if ((sflags & ~valid) || off < 0 || nbytes < 0 ||
+            (nbytes && off > INT64_MAX - nbytes)) {
+            res = -EINVAL;
+            break;
+        }
         bool fixed;
         struct file *fp = resolve_fd(ctx, sqe->fd, sqe->flags, fixed);
         if (!fp) { res = -EBADF; break; }
@@ -383,31 +732,46 @@ static int32_t exec_single_sqe(struct io_uring_ctx *ctx,
                                                   : sqe->poll_events);
         pfd.revents = 0;
         /*
-         * io_uring POLL_ADD has no implicit timeout -- it completes only when
-         * an event fires or an error occurs.  poll() with a finite timeout is
-         * used so the worker stays responsive, but a plain timeout (r == 0) is
-         * not a completion: retry until we get events or a hard error.
+         * OSv's ::poll() (core/poll.cc poll_many) blocks in a
+         * non-interruptible wait_until, so a single long poll cannot be
+         * broken by a cancel.  Instead poll in short slices and check this
+         * worker's interrupt flag between slices: a POLL_REMOVE / ASYNC_CANCEL
+         * fires cancel_token_fire() which sets interrupted(true), so we notice
+         * within one slice and return -ECANCELED.  The wait is otherwise
+         * indefinite (one-shot readiness), matching Linux POLL_ADD: a plain
+         * poll() timeout (r == 0) is not a completion.
          */
-        int r;
-        do {
-            pfd.revents = 0;
-            r = ::poll(&pfd, 1, 30000);
-        } while (r == 0);
-        if (r < 0)  res = -errno;
-        else        res = pfd.revents;
+        res = -ECANCELED;
+        while (!sched::thread::current()->interrupted() && !ctx->shutdown) {
+            int r = ::poll(&pfd, 1, 100 /* ms slice */);
+            if (r < 0)      { res = -errno; break; }
+            if (r > 0)      { res = pfd.revents; break; }
+            /* r == 0: slice timed out with no events -- loop and re-check */
+        }
         break;
     }
 
     /* --- POLL_REMOVE --- */
-    case IORING_OP_POLL_REMOVE:
+    case IORING_OP_POLL_REMOVE: {
         /*
-         * OSv POLL_ADD dispatches a thread that calls poll() synchronously.
-         * We cannot interrupt it mid-call, so POLL_REMOVE returns ENOENT
-         * (no matching operation found) -- the same error Linux returns when
-         * the poll op already completed.
+         * Cancel a pending POLL_ADD identified by sqe->addr == original
+         * user_data.  Fire its cancel token; the sliced-poll loop notices the
+         * interrupt flag and returns -ECANCELED.  Mirrors TIMEOUT_REMOVE /
+         * ASYNC_CANCEL.  Returns 0 if a match was found, else -ENOENT.
          */
-        res = -ENOENT;
+        uint64_t target = sqe->addr;
+        bool found = false;
+        WITH_LOCK(ctx->mtx) {
+            auto range = ctx->cancellable.equal_range(target);
+            for (auto it = range.first; it != range.second; ++it) {
+                cancel_token_fire(it->second);
+                found = true;
+                break;
+            }
+        }
+        res = found ? 0 : -ENOENT;
         break;
+    }
 
     /* --- TIMEOUT --- */
     case IORING_OP_TIMEOUT: {
@@ -428,53 +792,49 @@ static int32_t exec_single_sqe(struct io_uring_ctx *ctx,
             res = -EINVAL;
             break;
         }
-        auto ns  = std::chrono::seconds(ts->tv_sec) +
-                   std::chrono::nanoseconds(ts->tv_nsec);
+        auto deadline = io_uring_deadline(ts, sqe->timeout_flags);
 
         uint32_t count = sqe->len;      /* completion-count trigger */
 
-        if (count == 0) {
-            /* Pure timer: sleep for the specified duration */
-            sched::thread::sleep(ns);
-            res = -ETIME;
-        } else {
-            /*
-             * Wait until 'count' completions arrive OR the timer expires.
-             * We busy-wait by checking CQ tail periodically.
-             */
-            auto deadline = osv::clock::uptime::now() + ns;
-            uint32_t start_tail;
-            {
-                WITH_LOCK(ctx->mtx) {
-                    if (ctx->cq_ring) {
-                        auto *cq = static_cast<struct io_uring_cq_ring *>(ctx->cq_ring);
-                        start_tail = cq->tail.load(std::memory_order_acquire);
-                    } else {
-                        start_tail = ctx->cq.tail;
+        /*
+         * Arm a real timer to the (possibly absolute) deadline and block on
+         * the CQ waitqueue, which is woken by every completion.  This replaces
+         * the former 1 ms busy-poll: we sleep until either the timer fires or
+         * enough completions have arrived.  IORING_TIMEOUT_ABS and the clock
+         * flags are honored by io_uring_deadline().
+         */
+        sched::timer tmr(*sched::thread::current());
+        tmr.set(deadline);
+
+        bool timed_out;
+        WITH_LOCK(ctx->mtx) {
+            uint32_t start_tail = ctx->cq_ring
+                ? static_cast<struct io_uring_cq_ring *>(ctx->cq_ring)
+                      ->tail.load(std::memory_order_acquire)
+                : ctx->cq.tail;
+
+            for (;;) {
+                if (count > 0) {
+                    uint32_t cur_tail = ctx->cq_ring
+                        ? static_cast<struct io_uring_cq_ring *>(ctx->cq_ring)
+                              ->tail.load(std::memory_order_acquire)
+                        : ctx->cq.tail;
+                    if ((cur_tail - start_tail) >= count) {
+                        timed_out = false;
+                        break;
                     }
                 }
-            }
-            bool timed_out = true;
-            while (osv::clock::uptime::now() < deadline) {
-                uint32_t cur_tail;
-                {
-                    WITH_LOCK(ctx->mtx) {
-                        if (ctx->cq_ring) {
-                            auto *cq = static_cast<struct io_uring_cq_ring *>(ctx->cq_ring);
-                            cur_tail = cq->tail.load(std::memory_order_acquire);
-                        } else {
-                            cur_tail = ctx->cq.tail;
-                        }
-                    }
-                }
-                if ((cur_tail - start_tail) >= count) {
-                    timed_out = false;
+                if (tmr.expired()) {
+                    timed_out = true;
                     break;
                 }
-                sched::thread::sleep(std::chrono::milliseconds(1));
+                /* Blocks until a completion wakes wait_cq or the timer fires. */
+                sched::thread::wait_for(ctx->mtx, ctx->wait_cq, tmr);
             }
-            res = timed_out ? -ETIME : 0;
         }
+        tmr.cancel();
+
+        res = timed_out ? -ETIME : 0;
         if (sqe->timeout_flags & IORING_TIMEOUT_ETIME_SUCCESS)
             if (res == -ETIME) res = 0;
         break;
@@ -493,7 +853,7 @@ static int32_t exec_single_sqe(struct io_uring_ctx *ctx,
         WITH_LOCK(ctx->mtx) {
             auto it = ctx->cancellable.find(target);
             if (it != ctx->cancellable.end()) {
-                it->second->store(true, std::memory_order_relaxed);
+                cancel_token_fire(it->second);
                 found = true;
             }
         }
@@ -517,7 +877,7 @@ static int32_t exec_single_sqe(struct io_uring_ctx *ctx,
         WITH_LOCK(ctx->mtx) {
             auto range = ctx->cancellable.equal_range(target);
             for (auto it = range.first; it != range.second; ++it) {
-                it->second->store(true, std::memory_order_relaxed);
+                cancel_token_fire(it->second);
                 found = true;
                 break; /* cancel the first match, per Linux semantics */
             }
@@ -642,12 +1002,7 @@ static int32_t exec_single_sqe(struct io_uring_ctx *ctx,
             provided_buf pb{};
             bool found = false;
             WITH_LOCK(ctx->mtx) {
-                auto git = ctx->buf_groups.find(bgid);
-                if (git != ctx->buf_groups.end() && !git->second.empty()) {
-                    pb    = git->second.front();
-                    git->second.pop_front();
-                    found = true;
-                }
+                found = io_uring_pick_buffer(ctx, bgid, &pb);
             }
             if (!found) { res = -ENOBUFS; break; }
             buf = pb.addr;
@@ -705,92 +1060,155 @@ static int32_t exec_single_sqe(struct io_uring_ctx *ctx,
     /* --- SPLICE --- */
     case IORING_OP_SPLICE: {
         /*
-         * OSv has no zero-copy splice.  Implement as read-into-buffer +
-         * write-from-buffer.  Allocate a temporary bounce buffer of up to
-         * 64 KB per call.
+         * OSv has no pipes and no zero-copy splice, so this is an honest
+         * bounce-buffer copy through the VFS file layer (sys_read/sys_write),
+         * not the raw ::read/::pread of unresolved integer fds.
+         *
+         * SQE layout (Linux):
+         *   splice_fd_in    = source fd (registered-file index if
+         *                     splice_flags & SPLICE_F_FD_IN_FIXED)
+         *   splice_off_in   = source offset, or (uint64_t)-1 for "current pos"
+         *   fd              = destination fd (registered if IOSQE_FIXED_FILE)
+         *   off             = destination offset, or (uint64_t)-1 for cur pos
+         *   len             = bytes to move
+         *
+         * NOTE: SPLICE_F_FD_IN_FIXED selects a REGISTERED source file; it does
+         * NOT mean "use current position" (the previous implementation had this
+         * backwards and drove ::pread on a raw fd).
          */
-        size_t   total     = sqe->len;
-        int      fd_in     = sqe->splice_fd_in;
-        off_t    off_in    = (sqe->splice_flags & SPLICE_F_FD_IN_FIXED) ? -1
-                             : (off_t)sqe->splice_off_in;
-        int      fd_out    = sqe->fd;
-        off_t    off_out   = (sqe->off == (uint64_t)-1) ? -1 : (off_t)sqe->off;
-        size_t   chunk     = (total < 65536) ? total : 65536;
-        char    *bounce    = new char[chunk];
-        size_t   copied    = 0;
-        int      saved_err = 0;
+        size_t total = sqe->len;
+
+        bool in_fixed = (sqe->splice_flags & SPLICE_F_FD_IN_FIXED) != 0;
+        struct file *fin = in_fixed
+            ? (((unsigned)sqe->splice_fd_in < ctx->nr_registered_files)
+                   ? ctx->registered_files[sqe->splice_fd_in] : nullptr)
+            : nullptr;
+        if (!in_fixed && fget(sqe->splice_fd_in, &fin) != 0)
+            fin = nullptr;
+        if (!fin) { res = -EBADF; break; }
+
+        bool out_fixed;
+        struct file *fout = resolve_fd(ctx, sqe->fd, sqe->flags, out_fixed);
+        if (!fout) {
+            if (!in_fixed) fdrop(fin);
+            res = -EBADF;
+            break;
+        }
+
+        off_t off_in  = (sqe->splice_off_in == (uint64_t)-1) ? -1
+                        : (off_t)sqe->splice_off_in;
+        off_t off_out = (sqe->off == (uint64_t)-1) ? -1 : (off_t)sqe->off;
+
+        size_t chunk  = (total < 65536) ? total : 65536;
+        char  *bounce = new char[chunk];
+        size_t copied = 0;
+        int    err    = 0;
 
         while (copied < total) {
             size_t want = total - copied;
             if (want > chunk) want = chunk;
-            ssize_t nr;
-            if (off_in >= 0) {
-                nr = ::pread(fd_in, bounce, want, off_in);
-                if (nr > 0) off_in += nr;
-            } else {
-                nr = ::read(fd_in, bounce, want);
-            }
-            if (nr <= 0) { saved_err = (nr < 0) ? errno : 0; break; }
 
-            char *p = bounce;
-            ssize_t remain = nr;
-            while (remain > 0) {
-                ssize_t nw;
-                if (off_out >= 0) {
-                    nw = ::pwrite(fd_out, p, (size_t)remain, off_out);
-                    if (nw > 0) off_out += nw;
-                } else {
-                    nw = ::write(fd_out, p, (size_t)remain);
-                }
-                if (nw <= 0) { saved_err = (nw < 0) ? errno : 0; remain = 0; break; }
-                p      += nw;
-                remain -= nw;
-                copied += (size_t)nw;
+            struct iovec riov = { bounce, want };
+            size_t got = 0;
+            int r = sys_read(fin, &riov, 1, off_in, &got);
+            if (r != 0) { err = r; break; }
+            if (got == 0) break;          /* EOF */
+            if (off_in >= 0) off_in += (off_t)got;
+
+            size_t wr = 0;
+            while (wr < got) {
+                struct iovec wiov = { bounce + wr, got - wr };
+                size_t put = 0;
+                int w = sys_write(fout, &wiov, 1, off_out, &put);
+                if (w != 0) { err = w; break; }
+                if (put == 0) { err = EIO; break; }
+                if (off_out >= 0) off_out += (off_t)put;
+                wr     += put;
+                copied += put;
             }
-            if (saved_err) break;
+            if (err) break;
         }
         delete[] bounce;
-        res = saved_err ? -(int)saved_err : (int32_t)copied;
+        if (!in_fixed)  fdrop(fin);
+        if (!out_fixed) fdrop(fout);
+        res = err ? -err : (int32_t)copied;
         break;
     }
 
     /* --- TEE --- */
     case IORING_OP_TEE: {
         /*
-         * OSv has no pipes or zero-copy tee.  Implement as a read-then-write
-         * that does NOT advance the source (by re-seeking after read, if the
-         * source fd supports seeking).  For non-seekable sources (e.g. sockets)
-         * tee is semantically impossible without O_PEEK; return ESPIPE.
+         * tee(2) duplicates data between two pipes WITHOUT consuming the
+         * source.  OSv has no pipes, so a faithful tee is impossible.  We
+         * emulate it for seekable source files only: read a chunk, restore the
+         * source position with sys_lseek, then write to the destination.  A
+         * non-seekable source (socket/eventfd/tty) makes non-consuming reads
+         * impossible, so we honestly return -ESPIPE.
+         *
+         * fd_in is registered iff SPLICE_F_FD_IN_FIXED; fd_out iff
+         * IOSQE_FIXED_FILE.  No explicit offsets (tee has none) — always
+         * current position, restored on the source after each read.
          */
-        size_t   total  = sqe->len;
-        int      fd_in  = sqe->splice_fd_in;
-        int      fd_out = sqe->fd;
-        off_t    pos    = ::lseek(fd_in, 0, SEEK_CUR);
-        if (pos == (off_t)-1) { res = -ESPIPE; break; }
+        size_t total = sqe->len;
 
-        size_t  chunk   = (total < 65536) ? total : 65536;
-        char   *bounce  = new char[chunk];
-        size_t  copied  = 0;
-        int     err     = 0;
+        bool in_fixed = (sqe->splice_flags & SPLICE_F_FD_IN_FIXED) != 0;
+        struct file *fin = in_fixed
+            ? (((unsigned)sqe->splice_fd_in < ctx->nr_registered_files)
+                   ? ctx->registered_files[sqe->splice_fd_in] : nullptr)
+            : nullptr;
+        if (!in_fixed && fget(sqe->splice_fd_in, &fin) != 0)
+            fin = nullptr;
+        if (!fin) { res = -EBADF; break; }
+
+        bool out_fixed;
+        struct file *fout = resolve_fd(ctx, sqe->fd, sqe->flags, out_fixed);
+        if (!fout) {
+            if (!in_fixed) fdrop(fin);
+            res = -EBADF;
+            break;
+        }
+
+        /* Source must be seekable for non-consuming reads. */
+        off_t pos = 0;
+        if (sys_lseek(fin, 0, SEEK_CUR, &pos) != 0) {
+            if (!in_fixed)  fdrop(fin);
+            if (!out_fixed) fdrop(fout);
+            res = -ESPIPE;
+            break;
+        }
+
+        size_t chunk  = (total < 65536) ? total : 65536;
+        char  *bounce = new char[chunk];
+        size_t copied = 0;
+        int    err    = 0;
 
         while (copied < total) {
             size_t want = total - copied;
             if (want > chunk) want = chunk;
-            ssize_t nr = ::read(fd_in, bounce, want);
-            if (nr <= 0) { err = (nr < 0) ? errno : 0; break; }
 
-            /* Re-seek source back by nr bytes */
-            ::lseek(fd_in, -(off_t)nr, SEEK_CUR);
+            struct iovec riov = { bounce, want };
+            size_t got = 0;
+            int r = sys_read(fin, &riov, 1, pos, &got);
+            if (r != 0) { err = r; break; }
+            if (got == 0) break;          /* EOF — source not advanced */
 
-            ssize_t nw = ::write(fd_out, bounce, (size_t)nr);
-            if (nw < 0) { err = errno; break; }
-
-            /* Advance source by actual bytes written */
-            ::lseek(fd_in, (off_t)nw, SEEK_CUR);
-            copied += (size_t)nw;
+            size_t wr = 0;
+            while (wr < got) {
+                struct iovec wiov = { bounce + wr, got - wr };
+                size_t put = 0;
+                int w = sys_write(fout, &wiov, 1, -1, &put);
+                if (w != 0) { err = w; break; }
+                if (put == 0) { err = EIO; break; }
+                wr     += put;
+                copied += put;
+            }
+            if (err) break;
+            /* tee does not consume the source: leave pos where it was. */
         }
         delete[] bounce;
-        res = err ? -(int)err : (int32_t)copied;
+        if (!in_fixed)  fdrop(fin);
+        if (!out_fixed) fdrop(fout);
+        res = err ? -err : (int32_t)copied;
         break;
     }
 
@@ -898,6 +1316,237 @@ static int32_t exec_single_sqe(struct io_uring_ctx *ctx,
         break;
     }
 
+    /* --- SOCKET --- */
+    case IORING_OP_SOCKET: {
+        /* fd=domain, off=type, len=protocol, splice_fd_in=file_index.
+         * OSv has no "install into registered-file slot" path for a freshly
+         * created fd, so the fixed-file variant is rejected honestly. */
+        if (sqe->splice_fd_in != 0) { res = -EINVAL; break; }
+        int domain   = sqe->fd;
+        int type     = (int)sqe->off;
+        int protocol = (int)sqe->len;
+        int r = ::socket(domain, type, protocol);
+        res = (r < 0) ? -errno : r;
+        break;
+    }
+
+    /* --- BIND --- */
+    case IORING_OP_BIND: {
+        /* fd=sockfd, addr=sockaddr ptr, addr2=addr_len */
+        auto *addr = reinterpret_cast<const struct sockaddr *>(sqe->addr);
+        socklen_t len = (socklen_t)sqe->addr2;
+        int r = ::bind(sqe->fd, addr, len);
+        res = (r < 0) ? -errno : 0;
+        break;
+    }
+
+    /* --- LISTEN --- */
+    case IORING_OP_LISTEN: {
+        /* fd=sockfd, len=backlog */
+        int r = ::listen(sqe->fd, (int)sqe->len);
+        res = (r < 0) ? -errno : 0;
+        break;
+    }
+
+    /* --- FTRUNCATE --- */
+    case IORING_OP_FTRUNCATE: {
+        /* fd=fd, off=length */
+        int r = ::ftruncate(sqe->fd, (off_t)sqe->off);
+        res = (r < 0) ? -errno : 0;
+        break;
+    }
+
+    /* --- READ_MULTISHOT: read into a provided buffer, re-armed by the
+     * multishot loop.  Always buffer-select: each event consumes one buffer
+     * from the group named by sqe->buf_group and reports it via F_BUFFER. --- */
+    case IORING_OP_READ_MULTISHOT: {
+        bool fixed;
+        struct file *fp = resolve_fd(ctx, sqe->fd, sqe->flags, fixed);
+        if (!fp) { res = -EBADF; break; }
+
+        uint16_t bgid = sqe->buf_group;
+        provided_buf pb{};
+        bool found = false;
+        WITH_LOCK(ctx->mtx) {
+            found = io_uring_pick_buffer(ctx, bgid, &pb);
+        }
+        if (!found) { if (!fixed) fdrop(fp); res = -ENOBUFS; break; }
+
+        struct iovec iov;
+        iov.iov_base = pb.addr;
+        iov.iov_len  = pb.len;
+        size_t done = 0;
+        int rc = sys_read(fp, &iov, 1, sqe->off, &done);
+        if (!fixed) fdrop(fp);
+        if (rc != 0) {
+            res = -rc;
+        } else {
+            res = (int32_t)done;
+            *out_cqe_flags = IORING_CQE_F_BUFFER | ((uint32_t)pb.bid << 16);
+        }
+        break;
+    }
+
+    /* --- FUTEX_WAIT: block until *uaddr != val or woken.
+     * ABI: uaddr=sqe->addr, val=sqe->addr2, mask=sqe->addr3 (unused: OSv
+     * futex has no bitset-any-value path here), futex flags in sqe->fd. --- */
+    case IORING_OP_FUTEX_WAIT: {
+        int *uaddr = reinterpret_cast<int *>(sqe->addr);
+        int  val   = (int)sqe->addr2;
+        int r = futex(uaddr, FUTEX_WAIT, val, nullptr, nullptr, 0);
+        res = (r < 0) ? -errno : 0;
+        break;
+    }
+
+    /* --- FUTEX_WAKE: wake up to `val` waiters on *uaddr. --- */
+    case IORING_OP_FUTEX_WAKE: {
+        int *uaddr = reinterpret_cast<int *>(sqe->addr);
+        int  nwake = (int)sqe->addr2;
+        int r = futex(uaddr, FUTEX_WAKE, nwake, nullptr, nullptr, 0);
+        res = (r < 0) ? -errno : r;
+        break;
+    }
+
+    /* --- MSG_RING: post a message to another io_uring's completion queue.
+     * ABI: sqe->addr = command (IORING_MSG_DATA / IORING_MSG_SEND_FD),
+     * sqe->fd = target ring fd, sqe->len = data (posted as target CQE res),
+     * sqe->off = target CQE user_data.  Only IORING_MSG_DATA is supported;
+     * SEND_FD has no OSv fixed-file-install-into-another-ring path. --- */
+    case IORING_OP_MSG_RING: {
+        if (sqe->addr != IORING_MSG_DATA) { res = -EINVAL; break; }
+        struct file *tfp = nullptr;
+        if (fget(sqe->fd, &tfp) != 0) { res = -EBADF; break; }
+        auto *tctx = io_uring_ctx_from_file(tfp);
+        if (!tctx) { fdrop(tfp); res = -EBADF; break; }
+        WITH_LOCK(tctx->mtx) {
+            io_uring_post_cqe_locked(tctx, sqe->off, (int32_t)sqe->len, 0);
+            tctx->wait_cq.wake_all(tctx->mtx);
+        }
+        if (tctx->eventfd_fd >= 0) {
+            uint64_t v = 1;
+            (void)::write(tctx->eventfd_fd, &v, sizeof(v));
+        }
+        fdrop(tfp);
+        res = 0;
+        break;
+    }
+
+    /* --- SEND_ZC / SENDMSG_ZC: OSv has no zero-copy net path, so this is a
+     * synchronous copying ::send / ::sendmsg.  To stay ABI-faithful we emit
+     * the two-CQE sequence a real zero-copy send produces: a data CQE (bytes
+     * sent, F_MORE) posted here, then the terminal notification CQE (res 0,
+     * F_NOTIF) posted by io_uring_complete_op via *out_cqe_flags.  Because the
+     * send already completed synchronously, the buffer is free immediately. --- */
+    case IORING_OP_SEND_ZC: {
+        void *buf = reinterpret_cast<void *>(sqe->addr);
+        ssize_t r = ::send(sqe->fd, buf, sqe->len, (int)sqe->msg_flags);
+        if (r < 0) { res = -(int)errno; break; }
+        io_uring_post_multishot_cqe(ctx, sqe->user_data, (int32_t)r, 0);
+        res = 0;
+        *out_cqe_flags = IORING_CQE_F_NOTIF;
+        break;
+    }
+    case IORING_OP_SENDMSG_ZC: {
+        struct msghdr *msg = reinterpret_cast<struct msghdr *>(sqe->addr);
+        ssize_t r = ::sendmsg(sqe->fd, msg, (int)sqe->msg_flags);
+        if (r < 0) { res = -(int)errno; break; }
+        io_uring_post_multishot_cqe(ctx, sqe->user_data, (int32_t)r, 0);
+        res = 0;
+        *out_cqe_flags = IORING_CQE_F_NOTIF;
+        break;
+    }
+
+    /* --- READV_FIXED / WRITEV_FIXED: vectored r/w whose iovecs point into a
+     * single registered buffer.  ABI: sqe->addr = iovec array, sqe->len =
+     * iovcnt, sqe->buf_index = registered buffer.  Each iovec is bounds-checked
+     * against the registered region before the syscall. --- */
+    case IORING_OP_READV_FIXED:
+    case IORING_OP_WRITEV_FIXED: {
+        bool fixed;
+        struct file *fp = resolve_fd(ctx, sqe->fd, sqe->flags, fixed);
+        if (!fp) { res = -EBADF; break; }
+        unsigned idx = sqe->buf_index;
+        if (idx >= ctx->nr_registered_buffers) {
+            if (!fixed) fdrop(fp);
+            res = -EFAULT;
+            break;
+        }
+        uintptr_t base = reinterpret_cast<uintptr_t>(ctx->registered_buffers[idx]);
+        size_t    blen = ctx->registered_buffer_lens[idx];
+        auto *iovp = reinterpret_cast<struct iovec *>(sqe->addr);
+        size_t iovcnt = sqe->len;
+        bool ok = true;
+        for (size_t i = 0; i < iovcnt; i++) {
+            uintptr_t p = reinterpret_cast<uintptr_t>(iovp[i].iov_base);
+            size_t    l = iovp[i].iov_len;
+            if (p < base || l > blen || p + l > base + blen) { ok = false; break; }
+        }
+        if (!ok) { if (!fixed) fdrop(fp); res = -EFAULT; break; }
+        size_t done = 0;
+        int rc = (sqe->opcode == IORING_OP_READV_FIXED)
+                     ? sys_read(fp, iovp, iovcnt, sqe->off, &done)
+                     : sys_write(fp, iovp, iovcnt, sqe->off, &done);
+        if (!fixed) fdrop(fp);
+        res = rc ? -rc : (int32_t)done;
+        break;
+    }
+
+    /* --- FIXED_FD_INSTALL: turn a registered file slot into a real fd.
+     * ABI: sqe->fd = registered slot index. --- */
+    case IORING_OP_FIXED_FD_INSTALL: {
+        unsigned slot = (unsigned)sqe->fd;
+        if (slot >= ctx->nr_registered_files ||
+            !ctx->registered_files[slot]) { res = -EBADF; break; }
+        struct file *rf = ctx->registered_files[slot];
+        fhold(rf);
+        int newfd = -1;
+        int rc = fdalloc(rf, &newfd);
+        if (rc != 0) { fdrop(rf); res = -rc; break; }
+        res = newfd;
+        break;
+    }
+
+    /* --- EPOLL_WAIT: blocking wait on an epoll fd.
+     * ABI: sqe->fd = epfd, sqe->addr = epoll_event array, sqe->len = maxevents.
+     * Blocks indefinitely (the io-wq worker thread absorbs the block). --- */
+    case IORING_OP_EPOLL_WAIT: {
+        auto *evs = reinterpret_cast<struct epoll_event *>(sqe->addr);
+        int r = ::epoll_wait(sqe->fd, evs, (int)sqe->len, -1);
+        res = (r < 0) ? -errno : r;
+        break;
+    }
+
+    /* --- Opcodes with no faithful OSv implementation: honest -ENOSYS rather
+     * than a lying success.  WAITID (no waitid syscall), FUTEX_WAITV (OSv
+     * futex has no vectored wait), RECV_ZC (no zero-copy rx), URING_CMD /
+     * URING_CMD128 (no NVMe passthrough / SQE128 geometry yet). --- */
+    case IORING_OP_WAITID:
+    case IORING_OP_FUTEX_WAITV:
+    case IORING_OP_RECV_ZC:
+    case IORING_OP_URING_CMD:
+    case IORING_OP_URING_CMD128:
+        res = -ENOSYS;
+        break;
+
+    /* --- NOP128: SQE128 NOP.  SQE128 ring geometry is not implemented
+     * (deferred to A3-4), so reject rather than silently treat as NOP. --- */
+    case IORING_OP_NOP128:
+        res = -EINVAL;
+        break;
+
+    /* --- xattr family: OSv has no extended-attribute syscalls --- */
+    case IORING_OP_SETXATTR:
+    case IORING_OP_FSETXATTR:
+    case IORING_OP_GETXATTR:
+    case IORING_OP_FGETXATTR:
+        res = -ENOSYS;
+        break;
+
+    /* --- PIPE: OSv has no pipes --- */
+    case IORING_OP_PIPE:
+        res = -ENOSYS;
+        break;
+
     default:
         res = -EINVAL;
         break;
@@ -915,33 +1564,155 @@ static int32_t exec_single_sqe(struct io_uring_ctx *ctx,
  *     SQEs get -ECANCELED.
  *   - HARDLINK SQEs always execute regardless of prior failures.
  *
- * LINK_TIMEOUT (opcode 15) may appear as the second element of a two-element
- * chain [linked_op, LINK_TIMEOUT].  We execute the linked op and the timeout
- * races: whichever fires first wins.  Since OSv is single-address-space we
- * implement this by running the op synchronously and then cancelling the
- * timeout (or vice-versa) -- effectively LINK_TIMEOUT is checked only after
- * the linked op completes.  If the op completes first and succeeds the
- * timeout CQE is -ECANCELED; if the op fails the timeout CQE is -ECANCELED.
- * This is equivalent to the Linux fast-path (op completes before timeout).
+ * LINK_TIMEOUT (opcode 15) appears as the element immediately following the
+ * op it guards in a linked chain: [linked_op, LINK_TIMEOUT].  We implement a
+ * REAL race: the linked op runs (blocking) on this worker thread while a
+ * helper thread waits until the timeout deadline.  Whichever finishes first
+ * wins, decided exactly once under ctx->mtx:
+ *   - op completes first  -> op posts its real result; LINK_TIMEOUT -> -ECANCELED
+ *   - timer expires first -> helper fires the op's cancel token (interrupting
+ *                            the blocked worker via A2-8); op -> -ECANCELED,
+ *                            LINK_TIMEOUT -> -ETIME (or 0 if ETIME_SUCCESS).
+ * IORING_TIMEOUT_ABS and the clock-selection flags are honored via
+ * io_uring_deadline().  Note: an op blocked in a NON-interruptible wait (e.g.
+ * disk I/O) cannot be broken mid-flight; if the timer wins in that case the
+ * op still runs to completion but its CQE is reported as -ECANCELED, matching
+ * the "timer fired first" outcome.
+ *
+ * A LINK_TIMEOUT that reaches the top-of-loop branch below (rather than being
+ * consumed inline) is one whose guarded op was short-circuited (cancelled or
+ * chain-failure propagated); Linux completes it with -ECANCELED.
  * ---------------------------------------------------------------------- */
+
+/* Shared race state between a linked op's worker and its timeout helper. */
+struct link_timeout_state {
+    mutex   m;          /* guards op_done + the condvar */
+    condvar cv;
+    bool    op_done   = false;  /* set by worker when the op returns (m held) */
+    bool    decided   = false;  /* winner chosen (ctx->mtx held) */
+    bool    timer_won = false;  /* the winner (ctx->mtx held) */
+};
+
+/*
+ * Is this SQE a multishot request?  Multishot re-arms and posts one CQE
+ * (with IORING_CQE_F_MORE) per event until it errors or is cancelled.  The
+ * flag lives in a different field per opcode:
+ *   POLL_ADD -> sqe->len       (IORING_POLL_ADD_MULTI)
+ *   ACCEPT   -> sqe->ioprio    (IORING_ACCEPT_MULTISHOT)
+ *   RECV     -> sqe->ioprio    (IORING_RECV_MULTISHOT)
+ *   READ_MULTISHOT -> opcode is itself multishot (opcode 49)
+ */
+static bool io_uring_is_multishot(const struct io_uring_sqe *sqe)
+{
+    switch (sqe->opcode) {
+    case IORING_OP_POLL_ADD:
+        return (sqe->len & IORING_POLL_ADD_MULTI) != 0;
+    case IORING_OP_ACCEPT:
+        return (sqe->ioprio & IORING_ACCEPT_MULTISHOT) != 0;
+    case IORING_OP_RECV:
+        return (sqe->ioprio & IORING_RECV_MULTISHOT) != 0;
+    case IORING_OP_READ_MULTISHOT:
+        return true;
+    default:
+        return false;
+    }
+}
+
+/*
+ * Run a multishot op to completion.  Repeatedly executes the op and posts an
+ * intermediate CQE (F_MORE set) per event, re-arming until the op errors, is
+ * cancelled, or the ring shuts down -- then posts a terminal CQE without
+ * F_MORE.  Runs on the calling io-wq worker; blocking waits between events are
+ * interruptible by a cancel (same worker-publish mechanism as single ops).
+ *
+ * ctx->mtx must NOT be held on entry.  The op has already been published as
+ * cancellable and this worker set as its cancel.worker by the caller.
+ */
+static void exec_multishot(struct io_uring_ctx *ctx, io_uring_work &w)
+{
+    /* Retire the op: clear worker, unregister, post terminal (non-F_MORE) CQE. */
+    auto retire = [&](int32_t res, uint32_t cqe_flags) {
+        WITH_LOCK(ctx->mtx) {
+            w.cancel.worker.store(nullptr, std::memory_order_release);
+            auto range = ctx->cancellable.equal_range(w.sqe.user_data);
+            for (auto it = range.first; it != range.second; ++it) {
+                if (it->second == &w.cancel) { ctx->cancellable.erase(it); break; }
+            }
+        }
+        io_uring_complete_op(ctx, w.sqe.user_data, res, cqe_flags);
+    };
+
+    for (;;) {
+        if (w.cancel.cancelled.load(std::memory_order_relaxed) ||
+            sched::thread::current()->interrupted() || ctx->shutdown) {
+            retire(-ECANCELED, 0);
+            return;
+        }
+
+        uint32_t cqe_flags = 0;
+        int32_t  res = exec_single_sqe(ctx, &w.sqe, &cqe_flags);
+
+        bool cancelled = w.cancel.cancelled.load(std::memory_order_relaxed);
+        if (cancelled && (res == -EINTR || res == -ERESTART))
+            res = -ECANCELED;
+
+        /*
+         * An error (including cancellation) terminates the multishot with a
+         * final CQE that has no F_MORE.  A successful event posts an
+         * intermediate CQE with F_MORE and re-arms.  RECV/ACCEPT/READ block
+         * until a genuinely new event on the next iteration.
+         */
+        if (res < 0 || cancelled) {
+            retire(res, cqe_flags);
+            return;
+        }
+
+        io_uring_post_multishot_cqe(ctx, w.sqe.user_data, res, cqe_flags);
+
+        /*
+         * POLL_ADD multishot: OSv's ::poll is level-triggered and offers no
+         * edge subscription, so a re-arm would immediately re-fire the same
+         * readiness and spin.  Post one intermediate CQE then a terminal CQE
+         * (res 0, no F_MORE) so the app re-arms explicitly -- honest
+         * degradation.  RECV/ACCEPT/READ loop because they block per event.
+         */
+        if (w.sqe.opcode == IORING_OP_POLL_ADD) {
+            retire(0, 0);
+            return;
+        }
+    }
+}
 
 static void exec_sqe_chain(struct io_uring_ctx *ctx,
                             std::vector<io_uring_work> chain)
 {
     bool chain_failed = false;
 
+    /* Remove a work item from the cancellable map (ctx->mtx must be held). */
+    auto unregister = [&](io_uring_work &w) {
+        auto range = ctx->cancellable.equal_range(w.sqe.user_data);
+        for (auto it = range.first; it != range.second; ++it) {
+            if (it->second == &w.cancel) {
+                ctx->cancellable.erase(it);
+                break;
+            }
+        }
+    };
+
     for (size_t i = 0; i < chain.size(); i++) {
         io_uring_work &w = chain[i];
 
-        /* If this SQE is a LINK_TIMEOUT, it is handled by the previous op's
-         * completion.  Just post -ECANCELED (op already done). */
+        /* An orphaned/short-circuited LINK_TIMEOUT: its guarded op did not run
+         * (it was cancelled or chain-failure propagated).  Post -ECANCELED. */
         if (w.sqe.opcode == IORING_OP_LINK_TIMEOUT) {
+            WITH_LOCK(ctx->mtx) { unregister(w); }
             io_uring_complete_op(ctx, w.sqe.user_data, -ECANCELED, 0);
             continue;
         }
 
-        /* Check for async-cancel of this work item */
-        if (w.cancelled.load(std::memory_order_relaxed)) {
+        /* Check for async-cancel of this work item (before it starts) */
+        if (w.cancel.cancelled.load(std::memory_order_relaxed)) {
+            WITH_LOCK(ctx->mtx) { unregister(w); }
             io_uring_complete_op(ctx, w.sqe.user_data, -ECANCELED, 0);
             chain_failed = true;
             continue;
@@ -949,23 +1720,131 @@ static void exec_sqe_chain(struct io_uring_ctx *ctx,
 
         /* Propagate chain failure to non-hardlinked SQEs */
         if (chain_failed && !(w.sqe.flags & IOSQE_IO_HARDLINK)) {
+            WITH_LOCK(ctx->mtx) { unregister(w); }
             io_uring_complete_op(ctx, w.sqe.user_data, -ECANCELED, 0);
             continue;
+        }
+
+        /* Does a LINK_TIMEOUT guard this op?  (It is the next chain element.) */
+        bool has_lt = (i + 1 < chain.size()) &&
+                      (chain[i + 1].sqe.opcode == IORING_OP_LINK_TIMEOUT);
+
+        /*
+         * Publish this thread as the op's worker so an in-flight cancel can
+         * interrupt a blocking wait.  Re-check the cancelled flag under the
+         * lock to close the race with a cancel that arrives right here, and
+         * clear any stale interrupt before we begin.
+         */
+        bool pre_cancelled = false;
+        WITH_LOCK(ctx->mtx) {
+            if (w.cancel.cancelled.load(std::memory_order_relaxed)) {
+                pre_cancelled = true;
+                unregister(w);
+            } else {
+                sched::thread::current()->interrupted(false);
+                w.cancel.worker.store(sched::thread::current(),
+                                      std::memory_order_release);
+            }
+        }
+        if (pre_cancelled) {
+            io_uring_complete_op(ctx, w.sqe.user_data, -ECANCELED, 0);
+            chain_failed = true;
+            continue;
+        }
+
+        /*
+         * Multishot ops re-arm and post one F_MORE CQE per event until they
+         * error or are cancelled.  Linux never links a multishot op, so it is
+         * handled standalone here: exec_multishot() runs the re-arm loop and
+         * performs its own retire (clears worker, unregisters, posts terminal
+         * CQE).  No LINK_TIMEOUT can guard it.
+         */
+        if (io_uring_is_multishot(&w.sqe)) {
+            exec_multishot(ctx, w);
+            continue;
+        }
+
+        /*
+         * Arm the racing timeout helper, if a LINK_TIMEOUT guards this op.
+         * The helper waits on st.cv until the op signals done or the deadline
+         * passes; on deadline it wins the race (under ctx->mtx) and fires the
+         * op's cancel token to break an interruptible blocking wait.
+         */
+        link_timeout_state st;
+        sched::thread *lt_helper = nullptr;
+        if (has_lt) {
+            struct io_uring_sqe *lt_sqe = &chain[i + 1].sqe;
+            auto *ts = reinterpret_cast<const struct __kernel_timespec *>(
+                           lt_sqe->addr);
+            auto deadline = io_uring_deadline(ts, lt_sqe->timeout_flags);
+            cancel_token *tok = &w.cancel;
+            lt_helper = sched::thread::make([ctx, &st, deadline, tok]() {
+                bool timed_out = false;
+                WITH_LOCK(st.m) {
+                    while (!st.op_done) {
+                        if (st.cv.wait(&st.m, deadline) == ETIMEDOUT) {
+                            timed_out = !st.op_done;
+                            break;
+                        }
+                    }
+                }
+                if (timed_out) {
+                    WITH_LOCK(ctx->mtx) {
+                        if (!st.decided) {
+                            st.decided   = true;
+                            st.timer_won = true;
+                        }
+                        if (st.timer_won)
+                            cancel_token_fire(tok);
+                    }
+                }
+            });
+            lt_helper->start();
         }
 
         uint32_t cqe_flags = 0;
         int32_t  res       = exec_single_sqe(ctx, &w.sqe, &cqe_flags);
 
-        /* Remove from cancellable map */
-        WITH_LOCK(ctx->mtx) {
-            auto range = ctx->cancellable.equal_range(w.sqe.user_data);
-            for (auto it = range.first; it != range.second; ++it) {
-                if (it->second == &w.cancelled) {
-                    ctx->cancellable.erase(it);
-                    break;
-                }
+        /* Signal the helper (if any) that the op has completed. */
+        if (has_lt) {
+            WITH_LOCK(st.m) {
+                st.op_done = true;
+                st.cv.wake_all();
             }
         }
+
+        /*
+         * Retire the op: clear the worker pointer and unregister from the
+         * cancellable map under the lock.  After this a late cancel only sets
+         * the (now-ignored) flag and cannot interrupt an unrelated op.  If a
+         * LINK_TIMEOUT is racing, decide the winner here (op side) too.
+         */
+        bool was_cancelled;
+        WITH_LOCK(ctx->mtx) {
+            w.cancel.worker.store(nullptr, std::memory_order_release);
+            was_cancelled = w.cancel.cancelled.load(std::memory_order_relaxed);
+            if (has_lt && !st.decided) {
+                st.decided   = true;
+                st.timer_won = false;
+            }
+            unregister(w);
+        }
+
+        if (has_lt) {
+            lt_helper->join();
+            delete lt_helper;
+        }
+
+        /*
+         * Determine the op's CQE result.  If the timer won, the op is
+         * cancelled regardless of what exec returned.  Otherwise, if the op
+         * was cancelled while in flight and bailed with an interruption error,
+         * normalize to -ECANCELED.
+         */
+        if (has_lt && st.timer_won)
+            res = -ECANCELED;
+        else if (was_cancelled && (res == -EINTR || res == -ERESTART))
+            res = -ECANCELED;
 
         bool suppress = (w.sqe.flags & IOSQE_CQE_SKIP_SUCCESS) && (res >= 0);
         if (!suppress)
@@ -979,11 +1858,131 @@ static void exec_sqe_chain(struct io_uring_ctx *ctx,
         }
 
         if (res < 0) chain_failed = true;
+
+        /*
+         * Consume the guarding LINK_TIMEOUT inline: post its CQE reflecting the
+         * race outcome and advance past it so the top-of-loop branch does not
+         * also complete it.
+         */
+        if (has_lt) {
+            io_uring_work &lt = chain[i + 1];
+            WITH_LOCK(ctx->mtx) { unregister(lt); }
+            int32_t lt_res;
+            if (st.timer_won)
+                lt_res = (lt.sqe.timeout_flags & IORING_TIMEOUT_ETIME_SUCCESS)
+                             ? 0 : -ETIME;
+            else
+                lt_res = -ECANCELED;
+            io_uring_complete_op(ctx, lt.sqe.user_data, lt_res, 0);
+            i++;   /* skip the consumed LINK_TIMEOUT */
+        }
     }
 }
 
 /* -------------------------------------------------------------------------
- * Read SQEs from the ring and dispatch chains as detached threads.
+ * io-wq worker pool.
+ *
+ * A chain is classified as bounded (disk/file, WQ_BOUNDED, index 0) or
+ * unbounded (net/poll/timeout, WQ_UNBOUNDED, index 1) by the opcode of its
+ * first non-LINK_TIMEOUT entry.  Unbounded ops may block for an unbounded
+ * time (recv/accept/poll/timeout), so they run in a separate worker pool to
+ * keep prompt disk I/O from being starved of workers.
+ *
+ * Workers are persistent: each blocks on wq_wait[cls] for work, executes one
+ * chain via exec_sqe_chain(), then loops.  A new worker is created lazily on
+ * enqueue only when no worker is idle and the per-class cap wq_max_workers[cls]
+ * has not been reached.  This bounds thread creation to the cap for the ring's
+ * whole lifetime instead of one thread per submission.
+ * ---------------------------------------------------------------------- */
+
+static int io_uring_work_class(uint8_t opcode)
+{
+    switch (opcode) {
+    case IORING_OP_POLL_ADD:
+    case IORING_OP_POLL_REMOVE:
+    case IORING_OP_SYNC_FILE_RANGE:  /* fsync can block on the backing dev */
+    case IORING_OP_SENDMSG:
+    case IORING_OP_RECVMSG:
+    case IORING_OP_TIMEOUT:
+    case IORING_OP_TIMEOUT_REMOVE:
+    case IORING_OP_ACCEPT:
+    case IORING_OP_ASYNC_CANCEL:
+    case IORING_OP_LINK_TIMEOUT:
+    case IORING_OP_CONNECT:
+    case IORING_OP_SEND:
+    case IORING_OP_RECV:
+    case IORING_OP_EPOLL_CTL:
+    case IORING_OP_SHUTDOWN:
+    case IORING_OP_SOCKET:
+    case IORING_OP_BIND:
+    case IORING_OP_LISTEN:
+    case IORING_OP_SEND_ZC:      /* copying ::send, may block on socket buffer */
+    case IORING_OP_SENDMSG_ZC:
+    case IORING_OP_EPOLL_WAIT:   /* blocks until an epoll event is ready */
+    case IORING_OP_FUTEX_WAIT:   /* blocks until woken */
+        return 1;   /* WQ_UNBOUNDED */
+    default:
+        return 0;   /* WQ_BOUNDED */
+    }
+}
+
+static uint8_t chain_lead_opcode(const std::vector<io_uring_work> &chain)
+{
+    for (const auto &w : chain)
+        if (w.sqe.opcode != IORING_OP_LINK_TIMEOUT)
+            return w.sqe.opcode;
+    return chain.empty() ? (uint8_t)IORING_OP_NOP : chain.front().sqe.opcode;
+}
+
+/* Persistent worker loop for pool class `cls`.  ctx->mtx must NOT be held. */
+static void io_uring_wq_worker(struct io_uring_ctx *ctx, int cls)
+{
+    WITH_LOCK(ctx->mtx) {
+        for (;;) {
+            while (ctx->wq_queue[cls].empty() && !ctx->shutdown) {
+                ctx->wq_idle[cls]++;
+                ctx->wq_wait[cls].wait(ctx->mtx);
+                ctx->wq_idle[cls]--;
+            }
+            if (ctx->shutdown && ctx->wq_queue[cls].empty())
+                return;
+
+            auto cp = std::move(ctx->wq_queue[cls].front());
+            ctx->wq_queue[cls].pop_front();
+
+            DROP_LOCK(ctx->mtx) {
+                exec_sqe_chain(ctx, std::move(*cp));
+            }
+        }
+    }
+}
+
+/*
+ * Hand a chain to the worker pool.  ctx->mtx must be held.  The chain has
+ * already been registered in ctx->cancellable and counted in pending_ops by
+ * the caller.  Spawns a new worker only when none is idle and the class cap
+ * is not yet reached.
+ */
+static void io_uring_wq_enqueue(struct io_uring_ctx *ctx,
+                                std::shared_ptr<std::vector<io_uring_work>> cp)
+{
+    int cls = io_uring_work_class(chain_lead_opcode(*cp));
+    ctx->wq_queue[cls].push_back(std::move(cp));
+
+    if (ctx->wq_idle[cls] == 0 &&
+        ctx->wq_nr_workers[cls] < ctx->wq_max_workers[cls]) {
+        ctx->wq_nr_workers[cls]++;
+        auto *t = sched::thread::make(
+            [ctx, cls]() { io_uring_wq_worker(ctx, cls); });
+        ctx->wq_threads.push_back(t);
+        t->start();
+    } else {
+        ctx->wq_wait[cls].wake_one(ctx->mtx);
+    }
+}
+
+/* -------------------------------------------------------------------------
+ * Read SQEs from the ring and dispatch chains to the io-wq worker pool.
  *
  * Handles IOSQE_IO_DRAIN by waiting for pending_ops to reach zero before
  * dispatching the drain-marked SQE (and its chain).
@@ -997,6 +1996,12 @@ static int io_uring_submit_sqes(struct io_uring_ctx *ctx, unsigned count)
     WITH_LOCK(ctx->mtx) {
         if (ctx->shutdown)
             return -EINVAL;
+        /*
+         * IORING_SETUP_R_DISABLED: reject submissions until the app issues
+         * IORING_REGISTER_ENABLE_RINGS.  Matches the kernel gating semantics.
+         */
+        if (ctx->disabled)
+            return -EBADFD;
 
         uint32_t head, tail;
         if (ctx->sq_ring) {
@@ -1013,15 +2018,13 @@ static int io_uring_submit_sqes(struct io_uring_ctx *ctx, unsigned count)
 
             /* Register all items in the chain as cancellable */
             for (auto &w : chain) {
-                ctx->cancellable.emplace(w.sqe.user_data, &w.cancelled);
+                ctx->cancellable.emplace(w.sqe.user_data, &w.cancel);
             }
 
-            /* shared_ptr makes the lambda copyable for std::function */
+            /* shared_ptr makes the work item copyable into the queue */
             auto cp = std::make_shared<std::vector<io_uring_work>>(
                 std::move(chain));
-            sched::thread::make(
-                [ctx, cp]() { exec_sqe_chain(ctx, std::move(*cp)); },
-                sched::thread::attr().detached())->start();
+            io_uring_wq_enqueue(ctx, std::move(cp));
         };
 
         while (submitted < count && head != tail) {
@@ -1089,14 +2092,29 @@ static int io_uring_submit_sqes(struct io_uring_ctx *ctx, unsigned count)
 
 /* -------------------------------------------------------------------------
  * Wait for at least min_complete CQEs to be available.
+ *
+ * If deadline_valid is true, the wait is bounded by deadline (an absolute
+ * osv::clock::uptime point); on expiry we return -ETIME if fewer than
+ * min_complete CQEs are ready.  This backs the io_uring_enter() EXT_ARG
+ * timeout (A2-12).  A min_wait floor is applied via min_deadline: the wait is
+ * not cut short before that point even when the main deadline is sooner.
  * ---------------------------------------------------------------------- */
 
-static int io_uring_wait_cqe(struct io_uring_ctx *ctx, unsigned min_complete)
+static int io_uring_wait_cqe(struct io_uring_ctx *ctx, unsigned min_complete,
+                             bool deadline_valid,
+                             osv::clock::uptime::time_point deadline)
 {
+    sched::timer tmr(*sched::thread::current());
+    if (deadline_valid)
+        tmr.set(deadline);
+
     WITH_LOCK(ctx->mtx) {
         while (true) {
             if (ctx->shutdown)
                 return -EINVAL;
+
+            /* Pull any backlogged CQEs into slots the app just freed. */
+            flush_cq_overflow_locked(ctx);
 
             uint32_t head, tail;
             if (ctx->cq_ring) {
@@ -1114,7 +2132,13 @@ static int io_uring_wait_cqe(struct io_uring_ctx *ctx, unsigned min_complete)
             if (ctx->pending_ops == 0 && (tail - head) > 0)
                 return 0;
 
-            ctx->wait_cq.wait(ctx->mtx);
+            if (deadline_valid && tmr.expired())
+                return (tail - head) >= min_complete ? 0 : -ETIME;
+
+            if (deadline_valid)
+                sched::thread::wait_for(ctx->mtx, ctx->wait_cq, tmr);
+            else
+                ctx->wait_cq.wait(ctx->mtx);
         }
     }
     return 0;
@@ -1223,6 +2247,14 @@ io_uring_file::io_uring_file(unsigned flags, struct io_uring_ctx *ctx)
     : file(FREAD | FWRITE | flags, DTYPE_UNSPEC), _ctx(ctx)
 {
     f_data = ctx;
+}
+
+/* See forward declaration near the top of the file. */
+static struct io_uring_ctx *io_uring_ctx_from_file(struct file *fp)
+{
+    if (!dynamic_cast<io_uring_file *>(fp))
+        return nullptr;
+    return static_cast<struct io_uring_ctx *>(fp->f_data);
 }
 
 void *io_uring_file::region_base(struct io_uring_ctx *ctx, off_t offset)
@@ -1348,6 +2380,8 @@ int io_uring_file::close()
         _ctx->shutdown = true;
         _ctx->wait_sq.wake_all(_ctx->mtx);
         _ctx->wait_cq.wake_all(_ctx->mtx);
+        _ctx->wq_wait[0].wake_all(_ctx->mtx);
+        _ctx->wq_wait[1].wake_all(_ctx->mtx);
     }
 
     if (_ctx->sq_poll_thread) {
@@ -1355,6 +2389,20 @@ int io_uring_file::close()
         delete _ctx->sq_poll_thread;
         _ctx->sq_poll_thread = nullptr;
     }
+
+    /*
+     * Join every io-wq worker.  A worker either exits promptly (idle, woken by
+     * the wake_all above) or after finishing its current chain: exec_sqe_chain
+     * observes ctx->shutdown (POLL_ADD bails, in-flight interruptible ops keep
+     * running to completion) and returns, then the worker sees an empty queue
+     * with shutdown set and exits.  Joining here guarantees no worker touches
+     * the ctx after we start freeing it below.
+     */
+    for (auto *t : _ctx->wq_threads) {
+        t->join();
+        delete t;
+    }
+    _ctx->wq_threads.clear();
 
     WITH_LOCK(_ctx->mtx) {
         while (_ctx->pending_ops > 0)
@@ -1381,6 +2429,10 @@ int io_uring_file::close()
     if (_ctx->registered_buffers) {
         delete[] _ctx->registered_buffers;
         _ctx->registered_buffers = nullptr;
+    }
+    if (_ctx->registered_buffer_lens) {
+        delete[] _ctx->registered_buffer_lens;
+        _ctx->registered_buffer_lens = nullptr;
     }
     if (_ctx->registered_files) {
         for (unsigned i = 0; i < _ctx->nr_registered_files; i++) {
@@ -1430,10 +2482,43 @@ static long io_uring_setup_impl(unsigned entries, struct io_uring_params *params
     if (!params)
         return -EFAULT;
 
+    /*
+     * Accepted setup flags.  A flag is accepted only if we honor its contract
+     * (honesty rule: a lie is worse than -EINVAL):
+     *   CQSIZE/CLAMP        - ring sizing, honored below.
+     *   SQPOLL/SQ_AFF       - kernel-side submit thread, pinned per sq_thread_cpu.
+     *   IOPOLL              - app reaps completions via enter(GETEVENTS); workers
+     *                         still post CQEs, so completions arrive and are
+     *                         reaped.  No busy-poll needed for correctness.
+     *   ATTACH_WQ           - each ring keeps its own io-wq pool; sharing is a
+     *                         resource optimization, not an observable contract.
+     *   SUBMIT_ALL          - our submit loop already never aborts a batch on a
+     *                         failing SQE (bad ops fail at exec and post their own
+     *                         CQE), so the contract already holds.
+     *   COOP_TASKRUN/TASKRUN_FLAG/DEFER_TASKRUN
+     *                       - completions are posted directly by workers + eventfd;
+     *                         there is no deferred task-work queue to coordinate,
+     *                         so "completions become visible" already holds.
+     *   SINGLE_ISSUER       - a promise from the app; we impose no extra locking.
+     *   R_DISABLED          - honored: ring starts disabled, ENABLE_RINGS clears it.
+     *
+     * Rejected (would require SQE/CQE geometry or mmap-ownership changes that
+     * pervade indexing and the setup mmap contract; faking them corrupts memory):
+     *   SQE128, CQE32, SQE_MIXED, CQE_MIXED, HYBRID_IOPOLL, SQ_REWIND,
+     *   NO_MMAP, REGISTERED_FD_ONLY, NO_SQARRAY.
+     */
     const uint32_t supported_flags = IORING_SETUP_CQSIZE
                                    | IORING_SETUP_SQPOLL
                                    | IORING_SETUP_SQ_AFF
-                                   | IORING_SETUP_CLAMP;
+                                   | IORING_SETUP_CLAMP
+                                   | IORING_SETUP_IOPOLL
+                                   | IORING_SETUP_ATTACH_WQ
+                                   | IORING_SETUP_SUBMIT_ALL
+                                   | IORING_SETUP_COOP_TASKRUN
+                                   | IORING_SETUP_TASKRUN_FLAG
+                                   | IORING_SETUP_SINGLE_ISSUER
+                                   | IORING_SETUP_DEFER_TASKRUN
+                                   | IORING_SETUP_R_DISABLED;
     if (params->flags & ~supported_flags)
         return -EINVAL;
 
@@ -1444,6 +2529,10 @@ static long io_uring_setup_impl(unsigned entries, struct io_uring_params *params
         entries = MAX_ENTRIES;
 
     auto *ctx = new io_uring_ctx;
+
+    ctx->setup_flags   = params->flags;
+    ctx->sq_thread_cpu = params->sq_thread_cpu;
+    ctx->disabled      = (params->flags & IORING_SETUP_R_DISABLED) != 0;
 
     ctx->sq.entries = entries;
     ctx->sq.mask    = entries - 1;
@@ -1500,11 +2589,26 @@ static long io_uring_setup_impl(unsigned entries, struct io_uring_params *params
 
         params->sq_entries = entries;
         params->cq_entries = cq_entries;
+        /*
+         * Advertise only feature bits we actually honor (honesty rule):
+         *   NODROP          - CQ overflow backlog, never silently dropped (A2-4).
+         *   SUBMIT_STABLE   - SQEs are copied at submit; app may reuse them.
+         *   RW_CUR_POS      - offset -1 uses the file's current position.
+         *   FAST_POLL       - POLL_ADD-backed readiness for pollable ops (A2-3).
+         *   SQPOLL_NONFIXED - SQPOLL works without pre-registered files.
+         *   CQE_SKIP        - IOSQE_CQE_SKIP_SUCCESS is honored at completion.
+         *   NATIVE_WORKERS  - real persistent io-wq worker pool (A2-1).
+         * SINGLE_MMAP is deliberately NOT advertised: we allocate the SQ ring,
+         * CQ ring, and SQE array as separate regions, so clients must perform
+         * the three-mmap dance rather than one combined mapping.
+         */
         params->features   = IORING_FEAT_NODROP
                            | IORING_FEAT_SUBMIT_STABLE
                            | IORING_FEAT_RW_CUR_POS
                            | IORING_FEAT_FAST_POLL
-                           | IORING_FEAT_SQPOLL_NONFIXED;
+                           | IORING_FEAT_SQPOLL_NONFIXED
+                           | IORING_FEAT_CQE_SKIP
+                           | IORING_FEAT_NATIVE_WORKERS;
 
         params->sq_off.head         = offsetof(struct io_uring_sq_ring, head);
         params->sq_off.tail         = offsetof(struct io_uring_sq_ring, tail);
@@ -1526,6 +2630,16 @@ static long io_uring_setup_impl(unsigned entries, struct io_uring_params *params
             ctx->sq_poll_thread = sched::thread::make(
                 [ctx] { sq_poll_loop(ctx); },
                 sched::thread::attr());
+            /*
+             * IORING_SETUP_SQ_AFF: pin the poll thread to sq_thread_cpu.
+             * Ignore an out-of-range CPU rather than fail setup (the ring is
+             * otherwise fully functional; the affinity hint is advisory).
+             */
+            if ((params->flags & IORING_SETUP_SQ_AFF) &&
+                ctx->sq_thread_cpu < sched::cpus.size()) {
+                sched::thread::pin(ctx->sq_poll_thread,
+                                   sched::cpus[ctx->sq_thread_cpu]);
+            }
             ctx->sq_poll_thread->start();
         }
 
@@ -1567,6 +2681,15 @@ int sys_io_uring_enter(int fd, unsigned to_submit, unsigned min_complete,
 static int io_uring_enter_impl(int fd, unsigned to_submit, unsigned min_complete,
                                unsigned flags, const void *sig, size_t sigsz)
 {
+    /*
+     * IORING_ENTER_REGISTERED_RING: fd is an index into the registered-ring-fd
+     * table.  We reject IORING_REGISTER_RING_FDS (A3-6), so no such table
+     * exists and any index would be meaningless -- reject rather than
+     * misinterpret a raw fd as an index.
+     */
+    if (flags & IORING_ENTER_REGISTERED_RING)
+        return -EINVAL;
+
     struct file *fp;
     int error = fget(fd, &fp);
     if (error)
@@ -1579,6 +2702,56 @@ static int io_uring_enter_impl(int fd, unsigned to_submit, unsigned min_complete
     }
 
     auto *ctx = static_cast<struct io_uring_ctx *>(fp->f_data);
+
+    /*
+     * Resolve the getevents wait bound from sig/sigsz (A2-12).
+     *
+     *   IORING_ENTER_EXT_ARG: sig points to a struct io_uring_getevents_arg
+     *   (sigsz must equal its size) carrying an optional relative timeout
+     *   (ts, a __kernel_timespec) and a min_wait_usec floor.  Its sigmask is
+     *   ignored: OSv delivers no POSIX signals to the blocked thread, so there
+     *   is no mask to apply -- masking would be a no-op we would rather not
+     *   pretend to honor.
+     *
+     *   Without EXT_ARG: sig is a raw sigset_t of size sigsz.  Linux requires
+     *   sigsz == sizeof(sigset_t); we validate that (rejecting a malformed
+     *   call) and then ignore the mask for the same reason.
+     */
+    bool deadline_valid = false;
+    osv::clock::uptime::time_point deadline;
+
+    if (flags & IORING_ENTER_EXT_ARG) {
+        if (!sig || sigsz != sizeof(struct io_uring_getevents_arg)) {
+            fdrop(fp);
+            return -EINVAL;
+        }
+        auto *arg = static_cast<const struct io_uring_getevents_arg *>(sig);
+        osv::clock::uptime::duration wait_dur(0);
+        bool have_wait = false;
+        if (arg->ts) {
+            auto *ts = reinterpret_cast<const struct __kernel_timespec *>(arg->ts);
+            wait_dur = std::chrono::seconds(ts->tv_sec)
+                     + std::chrono::nanoseconds(ts->tv_nsec);
+            have_wait = true;
+        }
+        if (arg->min_wait_usec) {
+            auto floor = std::chrono::duration_cast<osv::clock::uptime::duration>(
+                std::chrono::microseconds(arg->min_wait_usec));
+            if (!have_wait || floor > wait_dur) {
+                wait_dur = floor;
+                have_wait = true;
+            }
+        }
+        if (have_wait) {
+            deadline = osv::clock::uptime::now() + wait_dur;
+            deadline_valid = true;
+        }
+    } else if (sig) {
+        if (sigsz != sizeof(sigset_t)) {
+            fdrop(fp);
+            return -EINVAL;
+        }
+    }
 
     if (ctx->sq_poll_thread && (flags & IORING_ENTER_SQ_WAKEUP)) {
         WITH_LOCK(ctx->mtx) {
@@ -1596,7 +2769,7 @@ static int io_uring_enter_impl(int fd, unsigned to_submit, unsigned min_complete
     }
 
     if (flags & IORING_ENTER_GETEVENTS) {
-        int err = io_uring_wait_cqe(ctx, min_complete);
+        int err = io_uring_wait_cqe(ctx, min_complete, deadline_valid, deadline);
         if (err) {
             fdrop(fp);
             return err;
@@ -1647,8 +2820,11 @@ static int io_uring_register_impl(int fd, unsigned opcode, void *arg, unsigned n
 
             auto *iovecs = static_cast<struct iovec *>(arg);
             ctx->registered_buffers = new void *[nr_args];
-            for (unsigned i = 0; i < nr_args; i++)
+            ctx->registered_buffer_lens = new size_t[nr_args];
+            for (unsigned i = 0; i < nr_args; i++) {
                 ctx->registered_buffers[i] = iovecs[i].iov_base;
+                ctx->registered_buffer_lens[i] = iovecs[i].iov_len;
+            }
             ctx->nr_registered_buffers = nr_args;
             break;
         }
@@ -1656,7 +2832,9 @@ static int io_uring_register_impl(int fd, unsigned opcode, void *arg, unsigned n
         case IORING_UNREGISTER_BUFFERS:
             if (!ctx->registered_buffers) { ret = -EINVAL; break; }
             delete[] ctx->registered_buffers;
+            delete[] ctx->registered_buffer_lens;
             ctx->registered_buffers      = nullptr;
+            ctx->registered_buffer_lens  = nullptr;
             ctx->nr_registered_buffers   = 0;
             break;
 
@@ -1770,9 +2948,12 @@ static int io_uring_register_impl(int fd, unsigned opcode, void *arg, unsigned n
 
         case IORING_REGISTER_PBUF_RING: {
             /*
-             * Register a buffer ring for a buffer group.  The ring is an
-             * array of io_uring_buf entries maintained by the application.
-             * We copy the entries into our internal buf_group map.
+             * Register a live buffer ring for a buffer group.  The ring is an
+             * array of io_uring_buf entries maintained by the application; the
+             * kernel side reads ring->tail fresh on each buffer pick and
+             * advances its own head counter (see io_uring_pick_buffer).  We do
+             * NOT copy entries -- the ring stays live so buffers the app adds
+             * after registration are visible.
              */
             if (!arg) { ret = -EFAULT; break; }
             auto *reg = static_cast<struct io_uring_buf_reg *>(arg);
@@ -1789,23 +2970,23 @@ static int io_uring_register_impl(int fd, unsigned opcode, void *arg, unsigned n
                              reg->ring_addr);
             uint16_t bgid = reg->bgid;
 
-            auto &group = ctx->buf_groups[bgid];
-            group.clear();
-            uint16_t tail = __atomic_load_n(&ring->tail, __ATOMIC_ACQUIRE);
-            for (uint32_t i = 0; i < nent && i < tail; i++) {
-                struct io_uring_buf &b = ring->bufs[i & (nent - 1)];
-                provided_buf pb;
-                pb.addr = reinterpret_cast<void *>(b.addr);
-                pb.len  = b.len;
-                pb.bid  = b.bid;
-                group.push_back(pb);
+            if (!ring || nent == 0 || (nent & (nent - 1)) != 0) {
+                ret = -EINVAL;
+                break;
             }
+
+            buf_ring br;
+            br.ring = ring;
+            br.mask = nent - 1;
+            br.head = 0;
+            ctx->buf_rings[bgid] = br;
             break;
         }
 
         case IORING_UNREGISTER_PBUF_RING: {
             if (!arg) { ret = -EFAULT; break; }
             auto *reg = static_cast<struct io_uring_buf_reg *>(arg);
+            ctx->buf_rings.erase(reg->bgid);
             ctx->buf_groups.erase(reg->bgid);
             break;
         }
@@ -1821,13 +3002,94 @@ static int io_uring_register_impl(int fd, unsigned opcode, void *arg, unsigned n
             auto range = ctx->cancellable.equal_range(target);
             bool found = false;
             for (auto it = range.first; it != range.second; ++it) {
-                it->second->store(true, std::memory_order_relaxed);
+                cancel_token_fire(it->second);
                 found = true;
                 break;
             }
             ret = found ? 0 : -ENOENT;
             break;
         }
+
+        case IORING_REGISTER_ENABLE_RINGS:
+            /*
+             * Clears IORING_SETUP_R_DISABLED gating so submissions are accepted.
+             * Idempotent: enabling an already-enabled ring is not an error.
+             */
+            ctx->disabled = false;
+            break;
+
+        case IORING_REGISTER_IOWQ_MAX_WORKERS: {
+            /*
+             * arg -> uint32_t[2] = { bounded_max, unbounded_max }.  A zero entry
+             * means "leave unchanged" and the current value is returned in place
+             * (Linux semantics).  Wires directly to the io-wq pool caps.
+             */
+            if (!arg || nr_args != 2) { ret = -EINVAL; break; }
+            auto *vals = static_cast<uint32_t *>(arg);
+            for (int c = 0; c < 2; c++) {
+                uint32_t prev = ctx->wq_max_workers[c];
+                if (vals[c] != 0)
+                    ctx->wq_max_workers[c] = vals[c];
+                vals[c] = prev;
+            }
+            break;
+        }
+
+        case IORING_REGISTER_IOWQ_AFF:
+        case IORING_UNREGISTER_IOWQ_AFF:
+            /*
+             * io-wq CPU affinity mask.  OSv's scheduler load-balances worker
+             * threads across CPUs and we expose no per-pool cpumask pinning, so
+             * accept-and-ignore rather than lie about honoring a specific mask
+             * or fail a ring that is otherwise fully functional.
+             */
+            break;
+
+        case IORING_REGISTER_RING_FDS:
+        case IORING_UNREGISTER_RING_FDS:
+            /*
+             * Registered-ring-fd table (liburing default since 5.18) is a
+             * syscall-overhead optimization: enter() takes a small ring index
+             * instead of a raw fd.  liburing's io_uring_register_ring_fd()
+             * expects the kernel to write the assigned index back into
+             * arg->offset and then passes that index with
+             * IORING_ENTER_REGISTERED_RING.  OSv has no such per-thread index
+             * table, so reporting success without one would hand liburing a
+             * garbage index -- a lie worse than failure.  Reject so liburing
+             * keeps INT_FLAG_REG_RING unset and continues using the raw fd.
+             */
+            ret = -EINVAL;
+            break;
+
+        /*
+         * Honest rejections: declared in the ABI header but not implemented.
+         * Advertising success here would corrupt state or silently drop the
+         * caller's intent (personalities, restrictions, resource tagging,
+         * NAPI, zero-copy rx, BPF, ring resize/clone) -- a lie is worse than
+         * -EINVAL, so reject explicitly.
+         */
+        case IORING_REGISTER_PERSONALITY:
+        case IORING_UNREGISTER_PERSONALITY:
+        case IORING_REGISTER_RESTRICTIONS:
+        case IORING_REGISTER_FILES2:
+        case IORING_REGISTER_FILES_UPDATE2:
+        case IORING_REGISTER_BUFFERS2:
+        case IORING_REGISTER_BUFFERS_UPDATE:
+        case IORING_REGISTER_FILE_ALLOC_RANGE:
+        case IORING_REGISTER_PBUF_STATUS:
+        case IORING_REGISTER_NAPI:
+        case IORING_UNREGISTER_NAPI:
+        case IORING_REGISTER_CLOCK:
+        case IORING_REGISTER_CLONE_BUFFERS:
+        case IORING_REGISTER_SEND_MSG_RING:
+        case IORING_REGISTER_ZCRX_IFQ:
+        case IORING_REGISTER_RESIZE_RINGS:
+        case IORING_REGISTER_MEM_REGION:
+        case IORING_REGISTER_QUERY:
+        case IORING_REGISTER_ZCRX_CTRL:
+        case IORING_REGISTER_BPF_FILTER:
+            ret = -ENOSYS;
+            break;
 
         /* Unknown or unsupported register opcodes */
         default:

--- a/include/osv/io_uring.h
+++ b/include/osv/io_uring.h
@@ -73,7 +73,32 @@ enum {
     IORING_OP_MKDIRAT,          /* 37 */
     IORING_OP_SYMLINKAT,        /* 38 */
     IORING_OP_LINKAT,           /* 39 */
-    IORING_OP_LAST,             /* 40 - not a real op, used as sentinel */
+    IORING_OP_MSG_RING,         /* 40 */
+    IORING_OP_FSETXATTR,        /* 41 */
+    IORING_OP_SETXATTR,         /* 42 */
+    IORING_OP_FGETXATTR,        /* 43 */
+    IORING_OP_GETXATTR,         /* 44 */
+    IORING_OP_SOCKET,           /* 45 */
+    IORING_OP_URING_CMD,        /* 46 */
+    IORING_OP_SEND_ZC,          /* 47 */
+    IORING_OP_SENDMSG_ZC,       /* 48 */
+    IORING_OP_READ_MULTISHOT,   /* 49 */
+    IORING_OP_WAITID,           /* 50 */
+    IORING_OP_FUTEX_WAIT,       /* 51 */
+    IORING_OP_FUTEX_WAKE,       /* 52 */
+    IORING_OP_FUTEX_WAITV,      /* 53 */
+    IORING_OP_FIXED_FD_INSTALL, /* 54 */
+    IORING_OP_FTRUNCATE,        /* 55 */
+    IORING_OP_BIND,             /* 56 */
+    IORING_OP_LISTEN,           /* 57 */
+    IORING_OP_RECV_ZC,          /* 58 */
+    IORING_OP_EPOLL_WAIT,       /* 59 */
+    IORING_OP_READV_FIXED,      /* 60 */
+    IORING_OP_WRITEV_FIXED,     /* 61 */
+    IORING_OP_PIPE,             /* 62 */
+    IORING_OP_NOP128,           /* 63 */
+    IORING_OP_URING_CMD128,     /* 64 */
+    IORING_OP_LAST,             /* 65 - not a real op, used as sentinel */
 };
 
 /* SQE flags (sqe->flags) */
@@ -92,6 +117,21 @@ enum {
 #define IORING_SETUP_CQSIZE     (1U << 3)
 #define IORING_SETUP_CLAMP      (1U << 4)
 #define IORING_SETUP_ATTACH_WQ  (1U << 5)
+#define IORING_SETUP_R_DISABLED         (1U << 6)   /* start with ring disabled */
+#define IORING_SETUP_SUBMIT_ALL         (1U << 7)   /* continue submit on error */
+#define IORING_SETUP_COOP_TASKRUN       (1U << 8)
+#define IORING_SETUP_TASKRUN_FLAG       (1U << 9)
+#define IORING_SETUP_SQE128             (1U << 10)  /* SQEs are 128 byte */
+#define IORING_SETUP_CQE32              (1U << 11)  /* CQEs are 32 byte */
+#define IORING_SETUP_SINGLE_ISSUER      (1U << 12)
+#define IORING_SETUP_DEFER_TASKRUN      (1U << 13)
+#define IORING_SETUP_NO_MMAP            (1U << 14)
+#define IORING_SETUP_REGISTERED_FD_ONLY (1U << 15)
+#define IORING_SETUP_NO_SQARRAY         (1U << 16)
+#define IORING_SETUP_HYBRID_IOPOLL      (1U << 17)
+#define IORING_SETUP_CQE_MIXED          (1U << 18)
+#define IORING_SETUP_SQE_MIXED          (1U << 19)
+#define IORING_SETUP_SQ_REWIND          (1U << 20)
 
 /* Feature flags returned in io_uring_params.features */
 #define IORING_FEAT_SINGLE_MMAP         (1U << 0)
@@ -104,6 +144,14 @@ enum {
 #define IORING_FEAT_SQPOLL_NONFIXED     (1U << 7)
 #define IORING_FEAT_EXT_ARG             (1U << 8)
 #define IORING_FEAT_NATIVE_WORKERS      (1U << 9)
+#define IORING_FEAT_RSRC_TAGS           (1U << 10)
+#define IORING_FEAT_CQE_SKIP            (1U << 11)
+#define IORING_FEAT_LINKED_FILE         (1U << 12)
+#define IORING_FEAT_REG_REG_RING        (1U << 13)
+#define IORING_FEAT_RECVSEND_BUNDLE     (1U << 14)
+#define IORING_FEAT_MIN_TIMEOUT         (1U << 15)
+#define IORING_FEAT_RW_ATTR             (1U << 16)
+#define IORING_FEAT_NO_IOWAIT           (1U << 17)
 
 /* SQ ring flags (sq_ring->flags, written by kernel) */
 #define IORING_SQ_NEED_WAKEUP   (1U << 0)
@@ -112,10 +160,40 @@ enum {
 /* io_uring_enter() flags */
 #define IORING_ENTER_GETEVENTS  (1U << 0)
 #define IORING_ENTER_SQ_WAKEUP  (1U << 1)
+#define IORING_ENTER_SQ_WAIT            (1U << 2)
+#define IORING_ENTER_EXT_ARG            (1U << 3)
+#define IORING_ENTER_REGISTERED_RING    (1U << 4)
+#define IORING_ENTER_ABS_TIMER          (1U << 5)
+#define IORING_ENTER_EXT_ARG_REG        (1U << 6)
+#define IORING_ENTER_NO_IOWAIT          (1U << 7)
 
 /* CQE flags */
-#define IORING_CQE_F_BUFFER     (1U << 0)   /* upper 16 bits are buffer index */
-#define IORING_CQE_F_MORE       (1U << 1)   /* more completions follow (multishot) */
+#define IORING_CQE_F_BUFFER         (1U << 0)   /* upper 16 bits are buffer index */
+#define IORING_CQE_F_MORE           (1U << 1)   /* more completions follow (multishot) */
+#define IORING_CQE_F_SOCK_NONEMPTY  (1U << 2)   /* socket has more data to read */
+#define IORING_CQE_F_NOTIF          (1U << 3)   /* zero-copy notification CQE */
+#define IORING_CQE_F_BUF_MORE       (1U << 4)   /* current buffer not fully consumed */
+#define IORING_CQE_F_SKIP           (1U << 5)   /* skipped CQE */
+#define IORING_CQE_F_32             (1U << 15)  /* 32-byte CQE variant */
+
+/* POLL_ADD command flags (stored in sqe->len, NOT poll_events) */
+#define IORING_POLL_ADD_MULTI       (1U << 0)   /* multishot poll */
+#define IORING_POLL_UPDATE_EVENTS   (1U << 1)
+#define IORING_POLL_UPDATE_USER_DATA (1U << 2)
+#define IORING_POLL_ADD_LEVEL       (1U << 3)
+
+/* ACCEPT command flags (stored in sqe->ioprio) */
+#define IORING_ACCEPT_MULTISHOT     (1U << 0)   /* multishot accept */
+#define IORING_ACCEPT_DONTWAIT      (1U << 1)
+#define IORING_ACCEPT_POLL_FIRST    (1U << 2)
+
+/* RECV/SEND command flags (stored in sqe->ioprio) */
+#define IORING_RECVSEND_POLL_FIRST  (1U << 0)
+#define IORING_RECV_MULTISHOT       (1U << 1)   /* multishot recv */
+#define IORING_RECVSEND_FIXED_BUF   (1U << 2)
+#define IORING_SEND_ZC_REPORT_USAGE (1U << 3)
+#define IORING_RECVSEND_BUNDLE      (1U << 4)
+#define IORING_SEND_VECTORIZED      (1U << 5)
 
 /* Timeout flags (sqe->timeout_flags) */
 #define IORING_TIMEOUT_ABS              (1U << 0)
@@ -128,6 +206,14 @@ enum {
 
 /* SPLICE_F_FD_IN_FIXED: fd_in for IORING_OP_SPLICE is a registered file */
 #define SPLICE_F_FD_IN_FIXED    (1U << 31)
+
+/* IORING_OP_MSG_RING command (sqe->addr) */
+#define IORING_MSG_DATA         0   /* pass sqe->len as res, sqe->off as user_data */
+#define IORING_MSG_SEND_FD      1   /* send a registered file descriptor */
+
+/* IORING_OP_MSG_RING flags (sqe->msg_ring_flags == sqe->rw_flags/fsync_flags union) */
+#define IORING_MSG_RING_CQE_SKIP    (1U << 0)   /* don't post a CQE on the source ring */
+#define IORING_MSG_RING_FLAGS_PASS  (1U << 1)   /* pass sqe->file_index as cqe->flags */
 
 /* Submission Queue Entry */
 struct io_uring_sqe {
@@ -271,6 +357,23 @@ enum {
     IORING_REGISTER_PBUF_RING           = 22,
     IORING_UNREGISTER_PBUF_RING        = 23,
     IORING_REGISTER_SYNC_CANCEL         = 24,
+    IORING_REGISTER_FILE_ALLOC_RANGE    = 25,
+    IORING_REGISTER_PBUF_STATUS         = 26,
+    IORING_REGISTER_NAPI                = 27,
+    IORING_UNREGISTER_NAPI              = 28,
+    IORING_REGISTER_CLOCK               = 29,
+    IORING_REGISTER_CLONE_BUFFERS       = 30,
+    IORING_REGISTER_SEND_MSG_RING       = 31,
+    IORING_REGISTER_ZCRX_IFQ            = 32,
+    IORING_REGISTER_RESIZE_RINGS        = 33,
+    IORING_REGISTER_MEM_REGION          = 34,
+    IORING_REGISTER_QUERY               = 35,
+    IORING_REGISTER_ZCRX_CTRL           = 36,
+    IORING_REGISTER_BPF_FILTER          = 37,
+    IORING_REGISTER_LAST,
+
+    /* set iff a registered-ring fd index (not a raw fd) is being passed */
+    IORING_REGISTER_USE_REGISTERED_RING = 1U << 31,
 };
 
 /* Probe operation entry for IORING_REGISTER_PROBE */
@@ -359,6 +462,14 @@ struct io_uring_sync_cancel_reg {
     uint32_t flags;
     struct __kernel_timespec timeout;
     uint64_t pad[4];
+};
+
+/* Passed as the sig argument when io_uring_enter() sets IORING_ENTER_EXT_ARG */
+struct io_uring_getevents_arg {
+    uint64_t sigmask;
+    uint32_t sigmask_sz;
+    uint32_t min_wait_usec;
+    uint64_t ts;
 };
 
 /* System call entry points */

--- a/tests/tst-io_uring.cc
+++ b/tests/tst-io_uring.cc
@@ -115,6 +115,407 @@ static void test_ring_cleanup(struct test_ring *ring)
     }
 }
 
+/* -------------------------------------------------------------------------
+ * Submit a single already-filled SQE (at the current tail) and reap exactly
+ * one CQE, returning its res.  *out_flags (if non-null) receives cqe->flags.
+ * The SQE must have been written into ring->sqes[tail & mask] and its
+ * user_data set by the caller; this helper advances the SQ tail, enters, and
+ * consumes one CQE, asserting user_data round-trips.
+ * ---------------------------------------------------------------------- */
+static int submit_reap_one(struct test_ring *ring, uint64_t user_data,
+                           uint32_t *out_flags)
+{
+    unsigned tail  = ring->sq_ring->tail;
+    unsigned index = tail & ring->sq_ring->ring_mask;
+    ring->sqes[index].user_data = user_data;
+    ring->sq_ring->tail = tail + 1;
+
+    int ret = sys_io_uring_enter(ring->fd, 1, 1, IORING_ENTER_GETEVENTS, NULL, 0);
+    if (ret != 1)
+        return -1000000 + ret;   /* sentinel: enter did not submit exactly one */
+
+    unsigned cq_head = ring->cq_ring->head;
+    if (ring->cq_ring->tail == cq_head)
+        return -2000000;         /* sentinel: no CQE posted */
+
+    struct io_uring_cqe *cqe =
+        &ring->cq_ring->cqes[cq_head & ring->cq_ring->ring_mask];
+    assert(cqe->user_data == user_data);
+    int res = cqe->res;
+    if (out_flags)
+        *out_flags = cqe->flags;
+    ring->cq_ring->head = cq_head + 1;
+    return res;
+}
+
+/* Fill the SQE at the current tail, zeroed, and return a pointer to it. */
+static struct io_uring_sqe *next_sqe(struct test_ring *ring)
+{
+    unsigned index = ring->sq_ring->tail & ring->sq_ring->ring_mask;
+    struct io_uring_sqe *sqe = &ring->sqes[index];
+    memset(sqe, 0, sizeof(*sqe));
+    return sqe;
+}
+
+/* A3-1/A3-4: modern setup flags PostgreSQL uses must be accepted; geometry-
+ * changing flags that break the mmap contract must be honestly rejected. */
+static void test_io_uring_setup_flags(void)
+{
+    printf("Testing io_uring setup flag acceptance/rejection...\n");
+
+    /* DEFER_TASKRUN|SINGLE_ISSUER = modern liburing/PG default: must succeed. */
+    struct io_uring_params p = {};
+    p.flags = IORING_SETUP_DEFER_TASKRUN | IORING_SETUP_SINGLE_ISSUER;
+    int fd = sys_io_uring_setup(8, &p);
+    assert(fd >= 0);
+    close(fd);
+
+    /* SQE128 changes SQE size -> breaks our fixed mmap geometry: reject. */
+    struct io_uring_params p2 = {};
+    p2.flags = IORING_SETUP_SQE128;
+    int fd2 = sys_io_uring_setup(8, &p2);
+    assert(fd2 == -EINVAL);
+
+    /* CQE32 likewise. */
+    struct io_uring_params p3 = {};
+    p3.flags = IORING_SETUP_CQE32;
+    int fd3 = sys_io_uring_setup(8, &p3);
+    assert(fd3 == -EINVAL);
+
+    printf("  PASSED - setup flags accepted/rejected per honesty rule\n");
+}
+
+/* A3-8: only implemented FEAT bits may be advertised. */
+static void test_io_uring_features(void)
+{
+    printf("Testing advertised feature bits...\n");
+
+    struct io_uring_params p = {};
+    int fd = sys_io_uring_setup(8, &p);
+    assert(fd >= 0);
+
+    /* These are backed by real behavior. */
+    assert(p.features & IORING_FEAT_NODROP);          /* A2-4 backlog */
+    assert(p.features & IORING_FEAT_SUBMIT_STABLE);
+    assert(p.features & IORING_FEAT_NATIVE_WORKERS);  /* A2-1 io-wq pool */
+    assert(p.features & IORING_FEAT_CQE_SKIP);        /* CQE_SKIP_SUCCESS */
+
+    /* SINGLE_MMAP is deliberately NOT advertised (3 separate regions). */
+    assert(!(p.features & IORING_FEAT_SINGLE_MMAP));
+
+    close(fd);
+    printf("  PASSED - feature bits honest\n");
+}
+
+/* A3: R_DISABLED ring rejects submissions with -EBADFD until ENABLE_RINGS. */
+static void test_io_uring_disabled_ring(void)
+{
+    printf("Testing R_DISABLED + ENABLE_RINGS...\n");
+
+    struct test_ring ring;
+    memset(&ring, 0, sizeof(ring));
+    ring.fd = sys_io_uring_setup(8, &ring.params);
+    /* R_DISABLED needs the ring set up disabled: re-open with the flag. */
+    close(ring.fd);
+
+    struct io_uring_params p = {};
+    p.flags = IORING_SETUP_R_DISABLED;
+    int fd = sys_io_uring_setup(8, &p);
+    assert(fd >= 0);
+
+    /* map SQ ring + SQE array so we can submit */
+    size_t sq_size = sizeof(struct io_uring_sq_ring) +
+                     p.sq_entries * sizeof(uint32_t);
+    size_t sqe_size = p.sq_entries * sizeof(struct io_uring_sqe);
+    struct io_uring_sq_ring *sq = (struct io_uring_sq_ring *)mmap(
+        NULL, sq_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    assert(sq != MAP_FAILED);
+    struct io_uring_sqe *sqes = (struct io_uring_sqe *)mmap(
+        NULL, sqe_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0x10000000ULL);
+    assert(sqes != MAP_FAILED);
+
+    unsigned index = sq->tail & sq->ring_mask;
+    memset(&sqes[index], 0, sizeof(sqes[index]));
+    sqes[index].opcode = IORING_OP_NOP;
+    sq->tail = sq->tail + 1;
+
+    /* While disabled, submit must be rejected with -EBADFD. */
+    int ret = sys_io_uring_enter(fd, 1, 0, 0, NULL, 0);
+    assert(ret == -EBADFD);
+
+    /* Enable the ring. */
+    ret = sys_io_uring_register(fd, IORING_REGISTER_ENABLE_RINGS, NULL, 0);
+    assert(ret == 0);
+
+    /* Now the submission goes through. */
+    ret = sys_io_uring_enter(fd, 1, 1, IORING_ENTER_GETEVENTS, NULL, 0);
+    assert(ret == 1);
+
+    munmap(sqes, sqe_size);
+    munmap(sq, sq_size);
+    close(fd);
+    printf("  PASSED - disabled ring gates submissions\n");
+}
+
+/* A3-6: IORING_REGISTER_IOWQ_MAX_WORKERS returns previous caps in place. */
+static void test_io_uring_iowq_max_workers(void)
+{
+    printf("Testing IOWQ_MAX_WORKERS register...\n");
+
+    struct test_ring ring;
+    int ret = test_ring_init(&ring, 8);
+    assert(ret == 0);
+
+    uint32_t vals[2] = { 0, 0 };   /* 0 = "leave unchanged, report current" */
+    ret = sys_io_uring_register(ring.fd, IORING_REGISTER_IOWQ_MAX_WORKERS,
+                                vals, 2);
+    assert(ret == 0);
+    /* Non-zero defaults must have been reported back. */
+    assert(vals[0] > 0);           /* bounded */
+    assert(vals[1] > 0);           /* unbounded */
+
+    /* Set new caps and confirm the previous ones are returned. */
+    uint32_t set[2] = { 3, 7 };
+    ret = sys_io_uring_register(ring.fd, IORING_REGISTER_IOWQ_MAX_WORKERS,
+                                set, 2);
+    assert(ret == 0);
+    /* set[] now holds the PREVIOUS values (the defaults from above). */
+    assert(set[0] == vals[0]);
+    assert(set[1] == vals[1]);
+
+    test_ring_cleanup(&ring);
+    printf("  PASSED - IOWQ_MAX_WORKERS reports prior caps\n");
+}
+
+/* Axis-1 opcode 55: FTRUNCATE. */
+static void test_io_uring_ftruncate(void)
+{
+    printf("Testing FTRUNCATE opcode...\n");
+
+    struct test_ring ring;
+    int ret = test_ring_init(&ring, 8);
+    assert(ret == 0);
+
+    const char *path = "/tmp/io_uring_ftrunc.bin";
+    int tfd = open(path, O_RDWR | O_CREAT | O_TRUNC, 0644);
+    assert(tfd >= 0);
+
+    struct io_uring_sqe *sqe = next_sqe(&ring);
+    sqe->opcode = IORING_OP_FTRUNCATE;
+    sqe->fd = tfd;
+    sqe->off = 4096;   /* new length */
+
+    int res = submit_reap_one(&ring, 0x77, NULL);
+    assert(res == 0);
+
+    struct stat st;
+    assert(fstat(tfd, &st) == 0);
+    assert(st.st_size == 4096);
+
+    close(tfd);
+    unlink(path);
+    test_ring_cleanup(&ring);
+    printf("  PASSED - FTRUNCATE sets file length\n");
+}
+
+/* A2-10: SPLICE copies bytes between two regular files through the VFS. */
+static void test_io_uring_splice(void)
+{
+    printf("Testing SPLICE opcode (file->file copy)...\n");
+
+    struct test_ring ring;
+    int ret = test_ring_init(&ring, 8);
+    assert(ret == 0);
+
+    const char *src_path = "/tmp/io_uring_splice_src.bin";
+    const char *dst_path = "/tmp/io_uring_splice_dst.bin";
+    int src = open(src_path, O_RDWR | O_CREAT | O_TRUNC, 0644);
+    int dst = open(dst_path, O_RDWR | O_CREAT | O_TRUNC, 0644);
+    assert(src >= 0 && dst >= 0);
+
+    const char payload[] = "splice-me-through-the-vfs-layer";
+    size_t plen = sizeof(payload) - 1;
+    assert(write(src, payload, plen) == (ssize_t)plen);
+    lseek(src, 0, SEEK_SET);
+
+    struct io_uring_sqe *sqe = next_sqe(&ring);
+    sqe->opcode = IORING_OP_SPLICE;
+    sqe->splice_fd_in = src;
+    sqe->splice_off_in = 0;         /* explicit source offset */
+    sqe->fd = dst;
+    sqe->off = 0;                   /* explicit dest offset */
+    sqe->len = plen;
+
+    int res = submit_reap_one(&ring, 0x99, NULL);
+    assert(res == (int)plen);
+
+    char buf[64] = {0};
+    lseek(dst, 0, SEEK_SET);
+    assert(read(dst, buf, plen) == (ssize_t)plen);
+    assert(memcmp(buf, payload, plen) == 0);
+
+    close(src);
+    close(dst);
+    unlink(src_path);
+    unlink(dst_path);
+    test_ring_cleanup(&ring);
+    printf("  PASSED - SPLICE copies file->file\n");
+}
+
+/* A2-11: SYNC_FILE_RANGE validates its arguments (unknown flag -> -EINVAL). */
+static void test_io_uring_sync_file_range(void)
+{
+    printf("Testing SYNC_FILE_RANGE argument validation...\n");
+
+    struct test_ring ring;
+    int ret = test_ring_init(&ring, 8);
+    assert(ret == 0);
+
+    const char *path = "/tmp/io_uring_sfr.bin";
+    int tfd = open(path, O_RDWR | O_CREAT | O_TRUNC, 0644);
+    assert(tfd >= 0);
+    assert(write(tfd, "data", 4) == 4);
+
+    /* Bogus flag bit must be rejected. */
+    struct io_uring_sqe *sqe = next_sqe(&ring);
+    sqe->opcode = IORING_OP_SYNC_FILE_RANGE;
+    sqe->fd = tfd;
+    sqe->off = 0;
+    sqe->len = 4;
+    sqe->sync_range_flags = 0x8000;   /* not a valid SYNC_FILE_RANGE_* bit */
+    int res = submit_reap_one(&ring, 0xAA, NULL);
+    assert(res == -EINVAL);
+
+    /* Valid full-file sync (off=0,len=0 = to EOF) succeeds. */
+    sqe = next_sqe(&ring);
+    sqe->opcode = IORING_OP_SYNC_FILE_RANGE;
+    sqe->fd = tfd;
+    sqe->off = 0;
+    sqe->len = 0;
+    sqe->sync_range_flags = SYNC_FILE_RANGE_WRITE;
+    res = submit_reap_one(&ring, 0xAB, NULL);
+    assert(res == 0);
+
+    close(tfd);
+    unlink(path);
+    test_ring_cleanup(&ring);
+    printf("  PASSED - SYNC_FILE_RANGE validates args\n");
+}
+
+/* A2-9: READ_FIXED must bounds-check the target against the registered buffer
+ * length; an over-length read into a registered buffer returns -EFAULT. */
+static void test_io_uring_fixed_buffer_bounds(void)
+{
+    printf("Testing READ_FIXED/WRITE_FIXED bounds check...\n");
+
+    struct test_ring ring;
+    int ret = test_ring_init(&ring, 8);
+    assert(ret == 0);
+
+    /* Register a single 512-byte buffer. */
+    static char regbuf[512];
+    struct iovec iov = { regbuf, sizeof(regbuf) };
+    ret = sys_io_uring_register(ring.fd, IORING_REGISTER_BUFFERS, &iov, 1);
+    assert(ret == 0);
+
+    const char *path = "/tmp/io_uring_fixed.bin";
+    int tfd = open(path, O_RDWR | O_CREAT | O_TRUNC, 0644);
+    assert(tfd >= 0);
+    assert(write(tfd, regbuf, sizeof(regbuf)) == (ssize_t)sizeof(regbuf));
+
+    /* WRITE_FIXED with len exceeding the registered buffer -> -EFAULT. */
+    struct io_uring_sqe *sqe = next_sqe(&ring);
+    sqe->opcode = IORING_OP_WRITE_FIXED;
+    sqe->fd = tfd;
+    sqe->addr = (uint64_t)regbuf;
+    sqe->len = sizeof(regbuf) + 1;    /* one byte past the region */
+    sqe->off = 0;
+    sqe->buf_index = 0;
+    int res = submit_reap_one(&ring, 0xBB, NULL);
+    assert(res == -EFAULT);
+
+    /* In-bounds WRITE_FIXED succeeds. */
+    sqe = next_sqe(&ring);
+    sqe->opcode = IORING_OP_WRITE_FIXED;
+    sqe->fd = tfd;
+    sqe->addr = (uint64_t)regbuf;
+    sqe->len = sizeof(regbuf);
+    sqe->off = 0;
+    sqe->buf_index = 0;
+    res = submit_reap_one(&ring, 0xBC, NULL);
+    assert(res == (int)sizeof(regbuf));
+
+    close(tfd);
+    unlink(path);
+    test_ring_cleanup(&ring);
+    printf("  PASSED - fixed-buffer bounds enforced\n");
+}
+
+/* Axis-1 opcode 40: MSG_RING (IORING_MSG_DATA) posts a CQE on a target ring. */
+static void test_io_uring_msg_ring(void)
+{
+    printf("Testing MSG_RING (data) cross-ring post...\n");
+
+    struct test_ring src, dst;
+    assert(test_ring_init(&src, 8) == 0);
+    assert(test_ring_init(&dst, 8) == 0);
+
+    struct io_uring_sqe *sqe = next_sqe(&src);
+    sqe->opcode = IORING_OP_MSG_RING;
+    sqe->fd = dst.fd;                 /* target ring fd */
+    sqe->addr = IORING_MSG_DATA;      /* command */
+    sqe->len = 0x1234;                /* becomes target CQE res */
+    sqe->off = 0xCAFEF00D;            /* becomes target CQE user_data */
+
+    /* The source CQE reports success of the post itself. */
+    int res = submit_reap_one(&src, 0xD0, NULL);
+    assert(res == 0);
+
+    /* Drain the target ring: a CQE with our injected res/user_data. */
+    int ent = sys_io_uring_enter(dst.fd, 0, 1, IORING_ENTER_GETEVENTS, NULL, 0);
+    assert(ent == 0);
+    unsigned h = dst.cq_ring->head;
+    assert(dst.cq_ring->tail != h);
+    struct io_uring_cqe *tcqe = &dst.cq_ring->cqes[h & dst.cq_ring->ring_mask];
+    assert(tcqe->user_data == 0xCAFEF00D);
+    assert(tcqe->res == 0x1234);
+    dst.cq_ring->head = h + 1;
+
+    test_ring_cleanup(&src);
+    test_ring_cleanup(&dst);
+    printf("  PASSED - MSG_RING posts to target ring\n");
+}
+
+/* A2-12: io_uring_enter EXT_ARG timeout returns -ETIME when no CQEs arrive. */
+static void test_io_uring_enter_ext_arg_timeout(void)
+{
+    printf("Testing enter EXT_ARG timeout (-ETIME)...\n");
+
+    struct test_ring ring;
+    int ret = test_ring_init(&ring, 8);
+    assert(ret == 0);
+
+    /* Wait for 1 completion that will never come, with a short timeout. */
+    struct __kernel_timespec ts = { 0, 20 * 1000 * 1000 };   /* 20 ms */
+    struct io_uring_getevents_arg arg = {};
+    arg.ts = (uint64_t)(uintptr_t)&ts;
+
+    ret = sys_io_uring_enter(ring.fd, 0, 1,
+                             IORING_ENTER_GETEVENTS | IORING_ENTER_EXT_ARG,
+                             &arg, sizeof(arg));
+    assert(ret == -ETIME);
+
+    /* REGISTERED_RING enter flag must be rejected (-EINVAL). */
+    ret = sys_io_uring_enter(ring.fd, 0, 0, IORING_ENTER_REGISTERED_RING,
+                             NULL, 0);
+    assert(ret == -EINVAL);
+
+    test_ring_cleanup(&ring);
+    printf("  PASSED - EXT_ARG timeout + REGISTERED_RING reject\n");
+}
+
+
+
 static void test_io_uring_setup(void)
 {
     printf("Testing io_uring_setup...\n");
@@ -274,8 +675,8 @@ static void test_io_uring_invalid_params(void)
     fd = sys_io_uring_setup(32, NULL);
     assert(fd == -EFAULT);
 
-    /* Test unsupported flag IORING_SETUP_ATTACH_WQ (bit 5): not implemented */
-    params.flags = IORING_SETUP_ATTACH_WQ;
+    /* SQE128 requires 128-byte SQE ring geometry we do not provide: rejected */
+    params.flags = IORING_SETUP_SQE128;
     fd = sys_io_uring_setup(32, &params);
     assert(fd == -EINVAL);
 
@@ -553,6 +954,18 @@ int main(int argc, char **argv)
     test_io_uring_enter_return_value();
     test_io_uring_file_io();
     test_io_uring_syscall_dispatch();
+
+    printf("\nFeature/fidelity tests (Axis 1/2/3):\n");
+    test_io_uring_setup_flags();
+    test_io_uring_features();
+    test_io_uring_disabled_ring();
+    test_io_uring_iowq_max_workers();
+    test_io_uring_ftruncate();
+    test_io_uring_splice();
+    test_io_uring_sync_file_range();
+    test_io_uring_fixed_buffer_bounds();
+    test_io_uring_msg_ring();
+    test_io_uring_enter_ext_arg_timeout();
 
     printf("\n===========================================\n");
     printf("All io_uring tests PASSED!\n");


### PR DESCRIPTION
## Summary

Builds on the merged `core/io_uring.cc` base to close fidelity gaps against the Linux io_uring ABI:

- **Opcodes**: adds `FTRUNCATE`, `SPLICE`, `SYNC_FILE_RANGE`, `READ_FIXED`/`WRITE_FIXED`, and `MSG_RING`; the opcode table is extended to `IORING_OP_LAST`.
- **CQ overflow**: replaces the drop-and-count behavior with a `std::deque` backlog (`IORING_FEAT_NODROP`), drained via `flush_cq_overflow_locked()` through a centralized `io_uring_post_cqe_locked()`; the SQ `CQ_OVERFLOW` flag is tracked.
- **POLL_ADD**: sliced 100ms cancellable `::poll` that honors thread interruption and ring shutdown so `POLL_REMOVE`/`ASYNC_CANCEL` yield `-ECANCELED`.
- **TIMEOUT**: `io_uring_deadline()` (ABS/BOOTTIME/REALTIME) backed by `sched::timer` and the `wait_cq` waitqueue, replacing the 1ms busy-poll while keeping the NULL/negative-timespec validation from the hardening pass.
- **enter/register**: `EXT_ARG` enter timeout, feature-bit honesty, `R_DISABLED` gating, and `IOWQ_MAX_WORKERS` reporting.

Ring head/tail/flags reads/writes use the `io_uring_au32` atomic member API; the Linux-ABI `buf_ring` tail stays a plain `uint16_t` accessed via `__atomic` builtins.

## Test plan

- [x] `core/io_uring.cc` compiles clean against the enhanced `include/osv/io_uring.h`.
- [x] `tests/tst-io_uring.cc` (all opcode and fidelity cases) compiles clean and passes under x86_64.