### PR TITLE
build: stop passing loader_options.ld twice to the linker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2251,7 +2251,7 @@ endif
 $(out)/loader.elf: $(stage1_targets) arch/$(arch)/loader.ld $(out)/bootfs.o $(out)/libvdso-content.o $(loader_options_dep) $(version_script_file)
 	$(call quiet, $(LD) -o $@ $(def_symbols) \
 		-Bdynamic --export-dynamic --eh-frame-hdr --enable-new-dtags -L$(out)/arch/$(arch) \
-            $(patsubst %version_script,--version-script=%version_script,$(patsubst %.ld,-T %.ld,$^)) \
+            $(patsubst %version_script,--version-script=%version_script,$(patsubst %.ld,-T %.ld,$(filter-out $(loader_options_dep),$^))) \
 	    $(linker_archives_options) $(conf_linker_extra_options), \
 		LINK loader.elf)
 	@# Build libosv.so matching this loader.elf. This is not a separate
@@ -2266,7 +2266,7 @@ $(out)/loader.elf: $(stage1_targets) arch/$(arch)/loader.ld $(out)/bootfs.o $(ou
 $(out)/zfs_builder.elf: $(stage1_targets) arch/$(arch)/loader.ld $(out)/zfs_builder_bootfs.o $(out)/libvdso-content.o $(loader_options_dep) $(version_script_file)
 	$(call quiet, $(LD) -o $@ $(def_symbols) \
 		-Bdynamic --export-dynamic --eh-frame-hdr --enable-new-dtags -L$(out)/arch/$(arch) \
-            $(patsubst %version_script,--version-script=%version_script,$(patsubst %.ld,-T %.ld,$^)) \
+            $(patsubst %version_script,--version-script=%version_script,$(patsubst %.ld,-T %.ld,$(filter-out $(loader_options_dep),$^))) \
 	    $(linker_archives_options) $(conf_linker_extra_options), \
 		LINK zfs_builder.elf)
 $(out)/zfs_builder-stripped.elf:  $(out)/zfs_builder.elf


### PR DESCRIPTION
## Summary

`arch/x64/loader.ld` includes `loader_options.ld` with an `INCLUDE`
directive (added in 0b8eb874). The `loader.elf` and `zfs_builder.elf`
link rules also list `$(loader_options_dep)` as a prerequisite, and the
link line runs `$(patsubst %.ld,-T %.ld,$^)` over the whole prerequisite
list, so `loader_options.ld` is *also* passed as `-T loader_options.ld`
on the `ld` command line.

Older binutils tolerated the same linker script being pulled in twice.
binutils 2.46 does not — it errors with:

```
loader_options.ld appears multiple times
```

which breaks the build on any toolchain shipping binutils >= 2.46.

## Fix

Filter `loader_options.ld` out of the `-T` patsubst input in both link
rules, while keeping it as a prerequisite so a change to its generated
contents (`APP_LOCAL_EXEC_TLS_SIZE`) still forces a relink. The `INCLUDE`
inside `loader.ld` continues to resolve it via the existing
`-L$(out)/arch/$(arch)` search path, so nothing is lost.

## Test plan

- [x] `make build/release.x64/loader.elf` links cleanly under binutils 2.46 (previously failed with "appears multiple times")
- [x] `make build/release.x64/zfs_builder.elf` links cleanly under binutils 2.46
- [x] Diff is two lines, no behavioral change beyond removing the duplicate `-T`