### PR TITLE
vfs: saturate block-device I/O by removing two serialization layers

### DIFF
--- a/fs/vfs/vfs_bdev.cc
+++ b/fs/vfs/vfs_bdev.cc
@@ -17,6 +17,75 @@
 #include <osv/buf.h>
 #include <osv/bio.h>
 
+/*
+ * Can this whole transfer take the fast path? That requires the starting
+ * offset and every iovec length to be a whole multiple of BSIZE, because the
+ * block drivers address and transfer in whole sectors. The buffer address
+ * itself need not be aligned: virtio-blk (and the other block drivers) DMA
+ * arbitrary guest addresses. Any unaligned offset or sub-sector length falls
+ * back to the buffer-cache slow path.
+ */
+static bool
+bdev_uio_sector_aligned(struct uio *uio)
+{
+	if ((uio->uio_offset % BSIZE) != 0)
+		return false;
+	for (int i = 0; i < uio->uio_iovcnt; i++) {
+		if ((uio->uio_iov[i].iov_len % BSIZE) != 0)
+			return false;
+	}
+	return true;
+}
+
+/*
+ * Fast path: issue one bio per iovec straight through the device's strategy
+ * (multiplex_strategy for real block devices, which splits by max_io_size and
+ * dispatches all children before waiting). Because make_request only holds the
+ * driver lock across ring submit, N concurrent callers keep N requests in
+ * flight -- unlike the buffer-cache path, which serialized every 512-byte block
+ * behind a single global lock and one synchronous bio.
+ *
+ * strategy() adds dev->offset exactly once (partition base), mirroring the
+ * rw_buf()->strategy() path this replaces, so partition addressing is
+ * unchanged.
+ */
+static int
+bdev_strategy_rw(struct device *dev, struct uio *uio, int bio_cmd)
+{
+	while (uio->uio_resid > 0 && uio->uio_iovcnt > 0) {
+		struct iovec *iov = uio->uio_iov;
+
+		if (iov->iov_len == 0) {
+			uio->uio_iov++;
+			uio->uio_iovcnt--;
+			continue;
+		}
+
+		struct bio *bio = alloc_bio();
+		if (!bio)
+			return ENOMEM;
+
+		bio->bio_cmd = bio_cmd;
+		bio->bio_dev = dev;
+		bio->bio_data = iov->iov_base;
+		bio->bio_offset = uio->uio_offset;
+		bio->bio_bcount = iov->iov_len;
+
+		dev->driver->devops->strategy(bio);
+		int ret = bio_wait(bio);
+		destroy_bio(bio);
+		if (ret)
+			return ret;
+
+		uio->uio_offset += iov->iov_len;
+		uio->uio_resid -= iov->iov_len;
+		uio->uio_iov++;
+		uio->uio_iovcnt--;
+	}
+
+	return 0;
+}
+
 int
 bdev_read(struct device *dev, struct uio *uio, int ioflags)
 {
@@ -25,26 +94,32 @@ bdev_read(struct device *dev, struct uio *uio, int ioflags)
 
 	assert(uio->uio_rw == UIO_READ);
 
-	/*
-	 * These should be handled gracefully, but this gives us the
-	 * best debugging for now.
-	 */
-	assert((uio->uio_offset % BSIZE) == 0);
-	assert((uio->uio_resid % BSIZE) == 0);
-
 	if (uio->uio_offset + uio->uio_resid > dev->size)
 		return EIO;
 	if (uio->uio_offset < 0)
 		return EINVAL;
 	if (uio->uio_resid == 0)
 		return 0;
-    
+
+	if (bdev_uio_sector_aligned(uio))
+		return bdev_strategy_rw(dev, uio, BIO_READ);
+
+	/*
+	 * Slow path: unaligned offset or sub-sector length. Read a whole BSIZE
+	 * block through the buffer cache and copy from the correct byte offset
+	 * within it. uiomove clamps each copy to min(remaining-in-block,
+	 * uio_resid), so partial leading and trailing sectors are handled.
+	 */
 	while (uio->uio_resid > 0) {
-		ret = bread(dev, uio->uio_offset >> 9, &bp);
+		off_t blkno = uio->uio_offset >> 9;
+		size_t off_in_blk = uio->uio_offset & (BSIZE - 1);
+
+		ret = bread(dev, blkno, &bp);
 		if (ret)
 			return ret;
 
-		ret = uiomove(bp->b_data, BSIZE, uio);
+		ret = uiomove((char *)bp->b_data + off_in_blk,
+			      BSIZE - off_in_blk, uio);
 		brelse(bp);
 
 		if (ret)
@@ -62,24 +137,33 @@ bdev_write(struct device *dev, struct uio *uio, int ioflags)
 
 	assert(uio->uio_rw == UIO_WRITE);
 
-	/*
-	 * These should be handled gracefully, but this gives us the
-	 * best debugging for now.
-	 */
-	assert((uio->uio_offset % BSIZE) == 0);
-	assert((uio->uio_resid % BSIZE) == 0);
-
 	if (uio->uio_offset + uio->uio_resid > dev->size)
 		return EIO;
 	if (uio->uio_offset < 0)
 		return EINVAL;
 	if (uio->uio_resid == 0)
 		return 0;
-    
-	while (uio->uio_resid > 0) {
-		bp = getblk(dev, uio->uio_offset >> 9);
 
-		ret = uiomove(bp->b_data, BSIZE, uio);
+	if (bdev_uio_sector_aligned(uio))
+		return bdev_strategy_rw(dev, uio, BIO_WRITE);
+
+	/*
+	 * Slow path: unaligned offset or sub-sector length. Read-modify-write
+	 * each affected BSIZE block through the buffer cache so the bytes
+	 * outside the written range are preserved. (getblk alone returns an
+	 * unread buffer, which would corrupt the untouched remainder of the
+	 * sector; bread reads it first.)
+	 */
+	while (uio->uio_resid > 0) {
+		off_t blkno = uio->uio_offset >> 9;
+		size_t off_in_blk = uio->uio_offset & (BSIZE - 1);
+
+		ret = bread(dev, blkno, &bp);
+		if (ret)
+			return ret;
+
+		ret = uiomove((char *)bp->b_data + off_in_blk,
+			      BSIZE - off_in_blk, uio);
 		if (ret) {
 			brelse(bp);
 			return ret;

--- a/fs/vfs/vfs_fops.cc
+++ b/fs/vfs/vfs_fops.cc
@@ -47,6 +47,20 @@ int vfs_file::read(struct uio *uio, int flags)
 
 	bytes = uio->uio_resid;
 
+	/*
+	 * Block devices carry no mutable per-vnode state that VOP_READ touches,
+	 * and the block layer below (bdev_read -> strategy -> driver) is already
+	 * thread-safe and asynchronous. Holding the exclusive per-vnode mutex
+	 * across the whole synchronous VOP_READ (which blocks in bio_wait)
+	 * serializes every concurrent pread on a shared fd, pinning throughput at
+	 * the queue-depth-1 value. A pread supplies its own offset (FOF_OFFSET),
+	 * so there is no fp->f_offset to protect: skip the lock and let N callers
+	 * keep N requests in flight. The FOF_OFFSET==0 path still shares
+	 * fp->f_offset, so it keeps the lock.
+	 */
+	if (vp->v_type == VBLK && (flags & FOF_OFFSET) != 0)
+		return VOP_READ(vp, fp, uio, 0);
+
 	vn_lock(vp);
 	if ((flags & FOF_OFFSET) == 0)
 		uio->uio_offset = fp->f_offset;
@@ -73,6 +87,19 @@ int vfs_file::write(struct uio *uio, int flags)
 	ssize_t bytes;
 
 	bytes = uio->uio_resid;
+
+	/*
+	 * See vfs_file::read: a pwrite to a block device supplies its own offset
+	 * and the block layer is thread-safe, so drop the per-vnode mutex that
+	 * would otherwise serialize concurrent pwrites and cap queue depth at 1.
+	 * O_APPEND cannot apply to a block device, so the ioflags computed below
+	 * are irrelevant here.
+	 */
+	if (vp->v_type == VBLK && (flags & FOF_OFFSET) != 0) {
+		if (fp->f_flags & (O_DSYNC|O_SYNC))
+			ioflags |= IO_SYNC;
+		return VOP_WRITE(vp, uio, ioflags);
+	}
 
 	vn_lock(vp);
 


### PR DESCRIPTION
## Problem

OSv could not saturate the host's block-device bandwidth. Measured on real AWS Nitro (m6a.large / m6i.large, EBS gp3) against a raw device node: throughput was pinned at **QD1 == QD-high** - queue depth had no effect. randread held ~200 IOPS flat from QD1 to QD64; randwrite ~136 IOPS flat. A ramfs io_uring run on the same build hit 241k IOPS, so the io_uring engine was not the bottleneck. The bottleneck was the device read/write path.

Two independent serialization layers were pinning concurrency to one in-flight request.

### Layer 1 - buffer-cache 512B bio loop (`fs/vfs/vfs_bdev.cc`)

`bdev_read`/`bdev_write` looped one `BSIZE` (512-byte) block per iteration through the buffer cache (`bread`/`getblk` -> `rw_buf`), issuing exactly one synchronous bio and `bio_wait`ing on it before starting the next, all under the single global `bio_lock`. A 128k read became 256 serialized 512B round-trips at EBS ~0.5-1ms each.

The async fan-out primitive already existed and was unused by this path: `multiplex_strategy()` (the registered `devops->strategy`) splits a large bio by `max_io_size`, pre-inits the refcount, and issues all children in flight before any wait.

**Fix:** when the request is 512-aligned (offset and every `iov_len`), build ONE bio per iovec and dispatch through `dev->driver->devops->strategy` (== `multiplex_strategy`, which preserves `seg_max` splitting and adds `dev->offset` exactly once), then `bio_wait`. Unaligned / sub-block requests fall back to the existing `bread`/`uiomove` slow path for correctness (VFS does not force 512-alignment on device-node reads, e.g. `read(fd,buf,100)`).

### Layer 2 - exclusive per-vnode lock held across bio_wait (`fs/vfs/vfs_fops.cc`)

`vfs_file::read`/`write` took `vn_lock(vp)` - the exclusive per-vnode mutex - and held it across the entire synchronous `VOP_READ`/`VOP_WRITE`, including `bio_wait`. All threads sharing one block-device fd share one vnode, so concurrent `pread`/`pwrite` fully serialized (QD1 == QD64) even after Layer 1 was fixed.

**Fix:** for `VBLK` vnodes on the `FOF_OFFSET` path (`pread`/`pwrite`, which carry their own offset and do not touch `fp->f_offset`), skip `vn_lock` so N callers keep N requests in flight. The plain `read`/`write` path (`FOF_OFFSET == 0`, shared `fp->f_offset`) still takes the lock. `O_DSYNC`/`O_SYNC` -> `IO_SYNC` is preserved on the write fast path. Non-block filesystems (ramfs / ZFS / rofs) are unchanged.

## Results

### AWS Nitro EC2 (m6a.large, EBS gp3 4GiB volume = 3000 IOPS provisioned cap), raw device node

| workload | pre-fix | post-fix |
|---|---|---|
| randread QD1 | ~200 IOPS | 1658 IOPS |
| randread QD2 | ~200 IOPS | 3249 IOPS |
| randread QD4..QD64 | ~200 IOPS (flat) | ~3003 IOPS (device cap) |

Post-fix latency grows linearly with QD (Little's Law: QD64 x ~333us p50 ≈ 21ms), confirming requests run concurrently and the plateau is the gp3 provisioned IOPS ceiling, not an OSv serialization limit.

### Local KVM, uncapped host NVMe (isolates OSv scaling from the EBS cap)

| workload | QD1 | QD16 |
|---|---|---|
| randread | 2080 IOPS | 20597 IOPS (9.9x) |
| randwrite | - | 20738 IOPS |

Clean ~10x scaling on an uncapped device proves genuine queue concurrency.

### Same-host OSv-vs-Linux parity (i4i.large, uncapped local instance-store NVMe)

The EBS numbers above are masked by the gp3 provisioned-IOPS cap. To prove OSv now saturates the hardware rather than hitting a software serialization limit, I ran an A/B on **i4i.large** (local instance-store NVMe ~436 GB, uncapped, us-east-2a): OSv `block-bench` against `/dev/vblk1` vs Linux `fio` (3.32, direct=1 libaio, 4K) against the same device `/dev/nvme1n1`, 8s/cell, QD matrix {1,2,4,8,16,32,64}.

| workload | OSv QD1 | OSv peak | scaling | OSv vs Linux @ QD>=8 |
|---|---|---|---|---|
| randread | 14.6k IOPS | 57.8k IOPS | 4.0x | 95-110% |
| randwrite | 14.2k IOPS | 29.8k IOPS | 2.1x | 95-103% |

Both stacks plateau at the identical device ceiling (reads ~52k, writes ~29k IOPS), so OSv now saturates the NVMe rather than a software limit. The one honest caveat: at QD1-2 OSv trails Linux (36-50% of its IOPS) because OSv per-op latency is higher (p50 57us vs 23us). That is a per-request path-length gap, not the concurrency collapse this PR fixes, and it is irrelevant at any realistic queue depth.

## Scope / regression safety

- Both fixes are confined to `fs/vfs/vfs_bdev.cc` and `fs/vfs/vfs_fops.cc`.
- ZFS calls `devops->strategy` directly and never touches `bdev_read` -> unaffected. rofs builds its own bio via `strategy()` -> unaffected. The only other buffer-cache consumer, `read_partition_table`, runs once at attach before runtime I/O -> unaffected. An end-to-end synthetic-Postgres ZFS harness over local NVMe confirms ZFS I/O is functionally unchanged on this branch: it neither regresses nor benefits, exactly as the dispatch path predicts.
- Layer-2 change is gated on `v_type == VBLK && (flags & FOF_OFFSET)`; all other vnode types and the shared-offset `read`/`write` path retain the lock.

## Verification

- Local KVM: seqwrite-then-seqread byte-identical readback; 100-byte unaligned read returns correct bytes (slow-path correctness).
- EC2: full randread/seqread/randwrite/seqwrite sweep across QD {1,2,4,8,16,32,64} on both m6a.large and m6i.large, plus the i4i.large same-host OSv-vs-Linux-fio parity leg on uncapped NVMe.
