### PR TITLE
drivers: build the AWS ENA network driver for aarch64 (Graviton)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -704,6 +704,10 @@ endif
 ifeq ($(conf_drivers_hyperv),1)
 bsd += bsd/sys/dev/hyperv/vmbus/hyperv.o
 endif
+endif
+
+# ENA (AWS Elastic Network Adapter) is arch-neutral: it is a pci::device
+# driver with no port I/O, so it builds for both x64 and aarch64 (Graviton).
 ifeq ($(conf_networking_stack),1)
 ifeq ($(conf_drivers_ena),1)
 bsd += bsd/sys/contrib/ena_com/ena_eth_com.o
@@ -711,7 +715,6 @@ bsd += bsd/sys/contrib/ena_com/ena_com.o
 bsd += bsd/sys/dev/ena/ena_datapath.o
 bsd += bsd/sys/dev/ena/ena.o
 $(out)/bsd/sys/dev/ena/%.o: CXXFLAGS += -Ibsd/sys/contrib
-endif
 endif
 endif
 
@@ -980,11 +983,6 @@ drivers += drivers/xenclock.o
 drivers += drivers/xenfront.o drivers/xenfront-xenbus.o drivers/xenfront-blk.o
 drivers += drivers/xenplatform-pci.o
 endif
-ifeq ($(conf_networking_stack),1)
-ifeq ($(conf_drivers_ena),1)
-drivers += drivers/ena.o
-endif
-endif
 endif # x64
 
 ifeq ($(arch),aarch64)
@@ -1021,6 +1019,14 @@ ifeq ($(conf_drivers_scsi),1)
 drivers += drivers/scsi-common.o
 endif
 endif # aarch64
+
+# ENA (AWS Elastic Network Adapter) is arch-neutral: it is a pci::device
+# driver with no port I/O, so it builds for both x64 and aarch64 (Graviton).
+ifeq ($(conf_networking_stack),1)
+ifeq ($(conf_drivers_ena),1)
+drivers += drivers/ena.o
+endif
+endif
 
 ifeq ($(conf_tracepoints),1)
 objects += arch/$(arch)/arch-trace.o

--- a/bsd/aarch64/machine/atomic.h
+++ b/bsd/aarch64/machine/atomic.h
@@ -39,6 +39,17 @@
 #define	rmb()	__asm __volatile("dmb ISHLD;" : : : "memory")
 
 /*
+ * Acquire fence. Ordered so that no subsequent load/store is reordered
+ * before it. On ARM64 an inner-shareable load-acquire barrier (dmb ishld)
+ * provides the required load->load / load->store ordering. Used by
+ * bsd/sys/sys/buf_ring.h in its ARM-only single-consumer dequeue path.
+ */
+static __inline void atomic_thread_fence_acq(void)
+{
+	__asm __volatile("dmb ishld" : : : "memory");
+}
+
+/*
  * Various simple operations on memory, each of which is atomic in the
  * presence of interrupts and multiple processors.
  *
@@ -74,12 +85,42 @@
  * This allows kernel modules to be portable between UP and SMP systems.
  */
 #define __GNUCLIKE_ASM
-#define	ATOMIC_ASM(NAME, TYPE, OP, CONS, V)			\
-void atomic_##NAME##_##TYPE(volatile u_##TYPE *p, u_##TYPE v);	\
-void atomic_##NAME##_barr_##TYPE(volatile u_##TYPE *p, u_##TYPE v)
+/*
+ * atomic_set/clear/add/subtract for char/short/int/long. Unlike x86 (whose
+ * strong memory model lets these be non-barrier RMW ops), aarch64 needs real
+ * atomic read-modify-write. We implement them with the GCC __atomic builtins,
+ * which lower to LSE (or LL/SC) sequences. The _barr_ variant is the acquire+
+ * release-ordered form FreeBSD uses for atomic_{set,clear,...}_acq/rel_*.
+ * These were previously prototype-only (no definitions), which was fine until
+ * the first aarch64 driver — ENA — actually referenced them.
+ */
+#define	ATOMIC_ASM(NAME, TYPE, OP, CONS, V)				\
+static __inline void							\
+atomic_##NAME##_##TYPE(volatile u_##TYPE *p, u_##TYPE v)		\
+{									\
+	(void)__atomic_##OP((volatile u_##TYPE *)p, V,			\
+	    __ATOMIC_RELAXED);						\
+}									\
+static __inline void							\
+atomic_##NAME##_barr_##TYPE(volatile u_##TYPE *p, u_##TYPE v)		\
+{									\
+	(void)__atomic_##OP((volatile u_##TYPE *)p, V,			\
+	    __ATOMIC_SEQ_CST);						\
+}
 
-int	atomic_cmpset_int(volatile u_int *dst, u_int expect, u_int src);
-int	atomic_cmpset_long(volatile u_long *dst, u_long expect, u_long src);
+static __inline int
+atomic_cmpset_int(volatile u_int *dst, u_int expect, u_int src)
+{
+	return __atomic_compare_exchange_n(dst, &expect, src, 0,
+	    __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+}
+
+static __inline int
+atomic_cmpset_long(volatile u_long *dst, u_long expect, u_long src)
+{
+	return __atomic_compare_exchange_n(dst, &expect, src, 0,
+	    __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+}
 
 static __inline u_int atomic_fetchadd_int(volatile u_int *p, u_int val)
 {
@@ -127,60 +168,35 @@ static __inline void atomic_store_rel_long(volatile u_long *p, u_long val)
     __asm __volatile("stlr %1, %0 ; " : "+Q"(*p) : "r"(val));
 }
 
-static __inline void atomic_add_int(volatile u_int *p, u_int val)
-{
-    (void)atomic_fetchadd_int(p, val);
-}
-
-static __inline void atomic_add_barr_int(volatile u_int *p, u_int val)
-{
-    (void)atomic_fetchadd_int(p, val);
-}
-
-static __inline void atomic_add_long(volatile u_long *p, u_long val)
-{
-    (void)atomic_fetchadd_long(p, val);
-}
-
-static __inline void atomic_add_barr_long(volatile u_long *p, u_long val)
-{
-    (void)atomic_fetchadd_long(p, val);
-}
-
-static __inline void atomic_subtract_int(volatile u_int *p, u_int val)
-{
-    (void)atomic_fetchadd_int(p, -val);
-}
-
-static __inline void atomic_subtract_long(volatile u_long *p, u_long val)
-{
-    (void)atomic_fetchadd_long(p, -val);
-}
-
 #define	ATOMIC_LOAD(TYPE, LOP)					\
-u_##TYPE	atomic_load_acq_##TYPE(volatile u_##TYPE *p)
+static __inline u_##TYPE					\
+atomic_load_acq_##TYPE(volatile u_##TYPE *p)			\
+{								\
+	return __atomic_load_n((volatile u_##TYPE *)p,		\
+	    __ATOMIC_ACQUIRE);					\
+}
 #define	ATOMIC_STORE(TYPE)					\
 void		atomic_store_rel_##TYPE(volatile u_##TYPE *p, u_##TYPE v)
 
-ATOMIC_ASM(set,	     char,  "unused", "unused",  v);
-ATOMIC_ASM(clear,    char,  "unused", "unused", ~v);
-ATOMIC_ASM(add,	     char,  "unused", "unused", v);
-ATOMIC_ASM(subtract, char,  "unused", "unused", v);
+ATOMIC_ASM(set,	     char,  fetch_or,  "unused",  v);
+ATOMIC_ASM(clear,    char,  fetch_and, "unused", ~v);
+ATOMIC_ASM(add,	     char,  fetch_add, "unused", v);
+ATOMIC_ASM(subtract, char,  fetch_sub, "unused", v);
 
-ATOMIC_ASM(set,	     short, "unused", "unused", v);
-ATOMIC_ASM(clear,    short, "unused", "unused", ~v);
-ATOMIC_ASM(add,	     short, "unused", "unused",  v);
-ATOMIC_ASM(subtract, short, "unused", "unused",  v);
+ATOMIC_ASM(set,	     short, fetch_or,  "unused", v);
+ATOMIC_ASM(clear,    short, fetch_and, "unused", ~v);
+ATOMIC_ASM(add,	     short, fetch_add, "unused",  v);
+ATOMIC_ASM(subtract, short, fetch_sub, "unused",  v);
 
-ATOMIC_ASM(set,	     int,   "unused", "unused",  v);
-ATOMIC_ASM(clear,    int,   "unused", "unused", ~v);
-ATOMIC_ASM(add,	     int,   "unused", "unused",  v);
-ATOMIC_ASM(subtract, int,   "unused", "unused",  v);
+ATOMIC_ASM(set,	     int,   fetch_or,  "unused",  v);
+ATOMIC_ASM(clear,    int,   fetch_and, "unused", ~v);
+ATOMIC_ASM(add,	     int,   fetch_add, "unused",  v);
+ATOMIC_ASM(subtract, int,   fetch_sub, "unused",  v);
 
-ATOMIC_ASM(set,	     long,  "unused", "unused",  v);
-ATOMIC_ASM(clear,    long,  "unused", "unused", ~v);
-ATOMIC_ASM(add,	     long,  "unused", "unused",  v);
-ATOMIC_ASM(subtract, long,  "unused", "unused",  v);
+ATOMIC_ASM(set,	     long,  fetch_or,  "unused",  v);
+ATOMIC_ASM(clear,    long,  fetch_and, "unused", ~v);
+ATOMIC_ASM(add,	     long,  fetch_add, "unused",  v);
+ATOMIC_ASM(subtract, long,  fetch_sub, "unused",  v);
 
 ATOMIC_LOAD(char,  "unused");
 ATOMIC_LOAD(short, "unused");

--- a/bsd/sys/kern/subr_bufring.c
+++ b/bsd/sys/kern/subr_bufring.c
@@ -37,7 +37,12 @@
 #include <machine/atomic.h>
 static inline void critical_enter()  { abort(); }
 static inline void critical_exit() { abort(); }
+#if !defined(__aarch64__)
+// On aarch64 machine/atomic.h provides a real atomic_thread_fence_acq(),
+// which buf_ring.h's single-consumer dequeue path uses. On other arches
+// that path is compiled out, so a stub is enough to satisfy the header.
 static inline void atomic_thread_fence_acq() { abort(); }
+#endif
 
 #include <sys/buf_ring.h>
 

--- a/conf/profiles/aarch64/all.mk
+++ b/conf/profiles/aarch64/all.mk
@@ -1,6 +1,7 @@
 include conf/profiles/$(arch)/virtio-mmio.mk
 include conf/profiles/$(arch)/virtio-pci.mk
 include conf/profiles/$(arch)/xen.mk
+include conf/profiles/$(arch)/aws.mk
 include conf/profiles/$(arch)/nvme.mk
 
 conf_drivers_cadence?=1

--- a/conf/profiles/aarch64/aws.mk
+++ b/conf/profiles/aarch64/aws.mk
@@ -1,0 +1,3 @@
+conf_drivers_pci?=1
+
+conf_drivers_ena?=1

--- a/conf/profiles/aarch64/base.mk
+++ b/conf/profiles/aarch64/base.mk
@@ -31,6 +31,11 @@ ifeq ($(conf_drivers_nvme),1)
 export conf_drivers_pci?=1
 endif
 
+export conf_drivers_ena?=0
+ifeq ($(conf_drivers_ena),1)
+export conf_drivers_pci?=1
+endif
+
 export conf_drivers_cadence?=0
 export conf_drivers_virtio?=0
 export conf_drivers_pci?=0

--- a/conf/profiles/aarch64/kconfig
+++ b/conf/profiles/aarch64/kconfig
@@ -6,6 +6,8 @@ config drivers_profile_base
   bool "No Device Drivers"
 config drivers_profile_all
   bool "All Device Drivers"
+config drivers_profile_aws_nitro
+  bool "AWS Nitro Device Drivers"
 config drivers_profile_microvm
   bool "MicroVM Device Drivers"
 config drivers_profile_virtio-mmio

--- a/include/api/aarch64/bits/syscall.h
+++ b/include/api/aarch64/bits/syscall.h
@@ -281,6 +281,9 @@
 #define __NR_io_uring_setup 425
 #define __NR_io_uring_enter 426
 #define __NR_io_uring_register 427
+#define __NR_sys_io_uring_setup __NR_io_uring_setup
+#define __NR_sys_io_uring_enter __NR_io_uring_enter
+#define __NR_sys_io_uring_register __NR_io_uring_register
 #define __NR_open_tree		428
 #define __NR_move_mount		429
 #define __NR_fsopen		430


### PR DESCRIPTION
## Summary

Enables the existing AWS ENA (Elastic Network Adapter) driver to build and link
on aarch64, so OSv can run on EC2 Graviton instances with ENA networking. The
ENA driver is arch-neutral (a `pci::device` driver with no port I/O), so the
same driver sources compile for both x64 and aarch64; this change moves the
driver's object rules out of the x64-only block and adds the aarch64 profile
gating.

## What changed

- **Makefile**: move the `drivers/ena.o` + `bsd/sys/dev/ena/*` + `ena_com`
  object rules so they build for both x64 and aarch64 (gated on the same
  `conf_drivers_ena` flag as before).
- **conf/profiles/aarch64/{base.mk,aws.mk,kconfig,all.mk}**: add
  `conf_drivers_ena` gating (defaults to `0` in base.mk, so no behavior change
  for existing aarch64 builds), a new `aws.mk` profile that opts ENA on for
  Nitro, and the matching kconfig entry.
- **bsd/aarch64/machine/atomic.h**: implement the BSD atomic ops the ENA driver
  needs (`atomic_cmpset_int/long`, the `ATOMIC_ASM` set) using `__atomic_*`
  builtins, and add `atomic_thread_fence_acq()` (`dmb ishld`). These were
  prototype-only before; ENA is the first aarch64 driver to reference them.
- **bsd/sys/kern/subr_bufring.c**: guard the stub `atomic_thread_fence_acq()`
  with `#if !defined(__aarch64__)` now that aarch64 provides a real one.
- **include/api/aarch64/bits/syscall.h**: add the three
  `__NR_sys_io_uring_{setup,enter,register}` aliases that x64 already defines.
  This is an aarch64 kernel-build prerequisite, not ENA-specific: io_uring is
  compiled unconditionally into the kernel (core/io_uring.cc) and the generated
  syscall table references `sys_io_uring_setup` unconditionally, so the aarch64
  kernel does not link without these aliases. The aarch64 ENA build below fails
  to link without this hunk.

## Testing

Full aarch64 kernel link verified on a native Graviton3 instance (c7g,
Ubuntu 24.04 arm64, gcc 13.3.0):

```
CROSS_PREFIX=aarch64-linux-gnu- make -j8 arch=aarch64 conf_drivers_profile=aws \
  bootfs_manifest=bootfs_empty.manifest.skel loader.elf
```

- `loader.elf` links clean (AArch64 / ELF64), zero compiler errors.
- 256 ENA symbols present in the kernel image; driver entry points
  `ena_attach`, `ena_detach`, `ena_up`, `ena_probe` all resolved.

x64 is unaffected: ENA still defaults off in the aarch64 base profile and the
x64 build path is unchanged.