### PR TITLE
mm: implement mremap(2)

### DIFF
--- a/core/mmu.cc
+++ b/core/mmu.cc
@@ -19,6 +19,7 @@
 #include <safe-ptr.hh>
 #include "fs/vfs/vfs.h"
 #include <osv/error.h>
+#include <sys/mman.h>
 #include <osv/trace.hh>
 #include <stack>
 #include <fs/fs.hh>
@@ -1405,6 +1406,135 @@ void* map_file(const void* addr, size_t size, unsigned flags, unsigned perm,
         }
     }
     return v;
+}
+
+// Is the whole [start, end) range free of any vma?  Caller must hold
+// vma_list_mutex for read or write.
+static bool range_is_free(uintptr_t start, uintptr_t end)
+{
+    auto range = find_intersecting_vmas(addr_range(start, end));
+    return range.first == range.second;
+}
+
+// Snapshot of the source mapping taken under the vma lock so the rest of
+// mremap() can operate through the public (self-locking) primitives without
+// holding vma_list_mutex across nested locking calls.
+struct mremap_src {
+    bool ok;          // false => source is not a single, fully-mapped vma
+    unsigned perm;
+    unsigned flags;
+    bool is_file;
+    bool tail_free;   // region immediately after the source is unmapped
+    fileref file;
+    f_offset offset;
+};
+
+static mremap_src inspect_mremap_src(uintptr_t start, size_t size, size_t grow)
+{
+    mremap_src s{};
+    PREVENT_STACK_PAGE_FAULT
+    SCOPE_LOCK(vma_list_mutex.for_read());
+    auto i = find_intersecting_vma(start);
+    if (i == vma_list.end() ||
+        i->start() > start || i->end() < start + size) {
+        s.ok = false;
+        return s;
+    }
+    s.ok = true;
+    s.perm = i->perm();
+    s.flags = i->flags();
+    auto* fvma = dynamic_cast<file_vma*>(&*i);
+    s.is_file = fvma != nullptr;
+    if (fvma) {
+        s.file = fvma->file();
+        s.offset = fvma->offset();
+    }
+    uintptr_t end = start + size;
+    s.tail_free = (i->end() == end) && range_is_free(end, end + grow);
+    return s;
+}
+
+// mremap(2): resize (and possibly move) an existing mapping.  Returns the new
+// address on success, or MAP_FAILED with errno set.  Only a single, wholly
+// mapped source vma is supported (Linux requires the old range to fall in one
+// mapping too); a range spanning several vmas or a hole yields EFAULT.
+//
+// ponytail: anon and file-backed mappings are handled; the move path preserves
+// the mapping type/perm/flags (file offset for file vmas).  MREMAP_FIXED is not
+// supported yet (returns EINVAL) -- add when a real caller needs it.
+void* mremap(void* old_addr, size_t old_size, size_t new_size, unsigned flags)
+{
+    auto old_start = reinterpret_cast<uintptr_t>(old_addr);
+    old_size = align_up(old_size, page_size);
+    new_size = align_up(new_size, page_size);
+
+    if (new_size == 0 || (flags & MREMAP_FIXED)) {
+        errno = EINVAL;
+        return MAP_FAILED;
+    }
+
+    size_t grow = new_size > old_size ? new_size - old_size : 0;
+    auto src = inspect_mremap_src(old_start, old_size, grow);
+    if (!src.ok) {
+        errno = EFAULT;
+        return MAP_FAILED;
+    }
+
+    // Shrink or no-op: drop the tail in place, address is unchanged.
+    if (new_size <= old_size) {
+        if (new_size < old_size) {
+            munmap(reinterpret_cast<void*>(old_start + new_size),
+                   old_size - new_size);
+        }
+        return old_addr;
+    }
+
+    // Grow.  Try to extend in place if the following region is free.
+    uintptr_t old_end = old_start + old_size;
+    if (src.tail_free) {
+        void* tail = reinterpret_cast<void*>(old_end);
+        unsigned f = (src.flags | mmap_fixed) & ~mmap_populate;
+        void* got = src.is_file
+            ? map_file(tail, grow, f, src.perm, src.file, src.offset + old_size)
+            : map_anon(tail, grow, f, src.perm);
+        if (got == tail) {
+            return old_addr;
+        }
+        // Unexpected: undo any partial tail mapping and fall back to a move.
+        if (got && got != MAP_FAILED) {
+            munmap(got, grow);
+        }
+    }
+
+    if (!(flags & MREMAP_MAYMOVE)) {
+        errno = ENOMEM;
+        return MAP_FAILED;
+    }
+
+    // Move: allocate a fresh region of the new size, migrate the contents,
+    // then unmap the old one.  Both mappings coexist briefly during the copy.
+    unsigned f = src.flags & ~mmap_populate;
+    if (src.is_file) {
+        // File-backed: remap the file at a new location with the same offset;
+        // the grown tail is served from the file (or zero-filled past EOF) by
+        // the fault path, so no copy is needed.
+        void* n = map_file(nullptr, new_size, f, src.perm, src.file, src.offset);
+        if (!n || n == MAP_FAILED) {
+            errno = ENOMEM;
+            return MAP_FAILED;
+        }
+        munmap(old_addr, old_size);
+        return n;
+    }
+
+    void* n = map_anon(nullptr, new_size, f | mmap_populate, src.perm);
+    if (!n || n == MAP_FAILED) {
+        errno = ENOMEM;
+        return MAP_FAILED;
+    }
+    memcpy(n, old_addr, old_size);
+    munmap(old_addr, old_size);
+    return n;
 }
 
 bool is_linear_mapped(const void *addr, size_t size)

--- a/exported_symbols/osv_ld-musl.so.1.symbols
+++ b/exported_symbols/osv_ld-musl.so.1.symbols
@@ -664,6 +664,7 @@ modff
 modfl
 mount
 mprotect
+mremap
 mrand48
 msync
 munlock

--- a/exported_symbols/osv_libc.so.6.symbols
+++ b/exported_symbols/osv_libc.so.6.symbols
@@ -555,6 +555,7 @@ modff
 modfl
 mount
 mprotect
+mremap
 mrand48
 msync
 munlock

--- a/include/osv/mmu.hh
+++ b/include/osv/mmu.hh
@@ -207,6 +207,7 @@ public:
 void* map_file(const void* addr, size_t size, unsigned flags, unsigned perm,
               fileref file, f_offset offset);
 void* map_anon(const void* addr, size_t size, unsigned flags, unsigned perm);
+void* mremap(void* old_addr, size_t old_size, size_t new_size, unsigned flags);
 
 error munmap(const void* addr, size_t size);
 error mprotect(const void *addr, size_t size, unsigned int perm);

--- a/libc/mman.cc
+++ b/libc/mman.cc
@@ -257,6 +257,37 @@ int madvise(void *addr, size_t length, int advice)
     return err.to_libc();
 }
 
+// mremap(2).  The variadic tail carries new_address only when MREMAP_FIXED is
+// set (not supported yet -- mmu::mremap rejects it with EINVAL), so it is
+// ignored here.
+OSV_LIBC_API
+void *mremap(void *old_addr, size_t old_size, size_t new_size, int flags, ...)
+{
+    if (!mmu::is_page_aligned(old_addr)) {
+        errno = EINVAL;
+        return MAP_FAILED;
+    }
+    if (flags & ~(MREMAP_MAYMOVE | MREMAP_FIXED)) {
+        errno = EINVAL;
+        return MAP_FAILED;
+    }
+    void *ret;
+    try {
+        ret = mmu::mremap(old_addr, old_size, new_size, flags);
+    } catch (error& err) {
+        err.to_libc();
+        return MAP_FAILED;
+    }
+    return ret;
+}
+
+// musl's realloc() calls the internal __mremap() for mmap-backed chunks.
+extern "C" OSV_LIBC_API
+void *__mremap(void *old_addr, size_t old_size, size_t new_size, int flags, ...)
+{
+    return mremap(old_addr, old_size, new_size, flags);
+}
+
 // The brk/sbrk/program break implementation is quite simple
 // and is based on mmap().
 // In essence, on the very 1st call to brk() or sbr(), we call

--- a/linux.cc
+++ b/linux.cc
@@ -246,10 +246,18 @@ static int sys_sched_setaffinity(
 
 #define __NR_long_mmap __NR_mmap
 
+#define __NR_long_mremap __NR_mremap
+
 #define __NR_long_shmat __NR_shmat
 // Only void* return value of mmap is type casted, as syscall returns long.
 long long_mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset) {
     return (long) mmap(addr, length, prot, flags, fd, offset);
+}
+
+// mremap's 5th argument (new_address) is only consumed with MREMAP_FIXED, which
+// is not supported yet; the 4-arg form covers every case we honor.
+long long_mremap(void *old_addr, size_t old_size, size_t new_size, int flags) {
+    return (long) mremap(old_addr, old_size, new_size, flags);
 }
 
 long long_shmat(int shmid, const void *shmaddr, int shmflg) {

--- a/modules/tests/Makefile
+++ b/modules/tests/Makefile
@@ -120,6 +120,7 @@ tests := tst-pthread.so misc-ramdisk.so tst-vblk.so tst-bsd-evh.so \
 	tst-fpu.so tst-preempt.so tst-tracepoint.so tst-hub.so \
 	misc-console.so misc-leak.so misc-readbench.so misc-mmap-anon-perf.so \
 	tst-mmap-file.so misc-mmap-big-file.so tst-mmap.so tst-huge.so \
+	tst-mremap.so \
 	tst-elf-permissions.so misc-mutex.so misc-sockets.so tst-condvar.so \
 	tst-queue-mpsc.so tst-af-local.so tst-pipe.so tst-yield.so \
 	misc-ctxsw.so tst-read.so tst-symlink.so tst-openat.so \

--- a/syscalls/syscall_tracepoints.cc.in
+++ b/syscalls/syscall_tracepoints.cc.in
@@ -26,6 +26,7 @@ TRACEPOINT(trace_syscall_connect, "%d <= %d 0x%x %d", int, int, struct sockaddr 
 TRACEPOINT(trace_syscall_get_mempolicy, "%lu <= %p %p %lu %p %d", long, int *, unsigned long *, unsigned long, void *, int);
 TRACEPOINT(trace_syscall_sys_sched_getaffinity, "%d <= %d %u %p", int, pid_t, unsigned, unsigned long *);
 TRACEPOINT(trace_syscall_long_mmap, "0x%x <= 0x%x %lu %d %d %d %lu", long, void *, size_t, int, int, int, off_t);
+TRACEPOINT(trace_syscall_long_mremap, "0x%x <= 0x%x %lu %lu %d", long, void *, size_t, size_t, int);
 TRACEPOINT(trace_syscall_munmap, "%d <= 0x%x %lu", int, void *, size_t);
 TRACEPOINT(trace_syscall_rt_sigaction, "%d <= %d %p %p %lu", int, int, const struct k_sigaction *, struct k_sigaction *, size_t);
 TRACEPOINT(trace_syscall_rt_sigprocmask, "%d <= %d %p %p %lu", int, int, sigset_t *, sigset_t *, size_t);

--- a/syscalls/syscalls.cc.in
+++ b/syscalls/syscalls.cc.in
@@ -26,6 +26,7 @@
     SYSCALL5(get_mempolicy, int *, unsigned long *, unsigned long, void *, int);
     SYSCALL3(sys_sched_getaffinity, pid_t, unsigned, unsigned long *);
     SYSCALL6(long_mmap, void *, size_t, int, int, int, off_t);
+    SYSCALL4(long_mremap, void *, size_t, size_t, int);
     SYSCALL2(munmap, void *, size_t);
     SYSCALL4(rt_sigaction, int, const struct k_sigaction *, struct k_sigaction *, size_t);
     SYSCALL4(rt_sigprocmask, int, sigset_t *, sigset_t *, size_t);

--- a/tests/tst-mremap.cc
+++ b/tests/tst-mremap.cc
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2026 Waldemar Kozaczuk
+ *
+ * This work is open source software, licensed under the terms of the
+ * BSD license as described in the LICENSE file in the top-level directory.
+ */
+
+// To compile this test on Linux, use:
+// g++ -g -std=c++11 tests/tst-mremap.cc -o /tmp/tst-mremap && /tmp/tst-mremap
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+#include <sys/mman.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include <cassert>
+#include <cstdint>
+#include <iostream>
+
+static size_t page;
+
+// Fill a region with a recognizable pattern derived from its length.
+static void fill(void *p, size_t len)
+{
+    unsigned char *b = static_cast<unsigned char *>(p);
+    for (size_t i = 0; i < len; i++) {
+        b[i] = static_cast<unsigned char>((i * 31 + 7) & 0xff);
+    }
+}
+
+static bool check(void *p, size_t len)
+{
+    unsigned char *b = static_cast<unsigned char *>(p);
+    for (size_t i = 0; i < len; i++) {
+        if (b[i] != static_cast<unsigned char>((i * 31 + 7) & 0xff)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+// Grow an anonymous mapping.  With MREMAP_MAYMOVE it must always succeed and
+// preserve the original bytes, wherever it lands.
+static void test_grow_anon()
+{
+    void *p = mmap(nullptr, page, PROT_READ | PROT_WRITE,
+                   MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+    assert(p != MAP_FAILED);
+    fill(p, page);
+
+    void *q = mremap(p, page, 4 * page, MREMAP_MAYMOVE);
+    assert(q != MAP_FAILED);
+    assert(check(q, page));            // original data survived the move/grow
+    // The grown tail is usable.
+    fill(q, 4 * page);
+    assert(check(q, 4 * page));
+    assert(munmap(q, 4 * page) == 0);
+}
+
+// Shrinking never moves the mapping and never fails.
+static void test_shrink_anon()
+{
+    void *p = mmap(nullptr, 4 * page, PROT_READ | PROT_WRITE,
+                   MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+    assert(p != MAP_FAILED);
+    fill(p, 4 * page);
+
+    void *q = mremap(p, 4 * page, page, 0);  // no MAYMOVE needed for shrink
+    assert(q == p);                          // address unchanged
+    assert(check(q, page));                  // kept bytes intact
+    assert(munmap(q, page) == 0);
+}
+
+// Growing without MREMAP_MAYMOVE must fail with ENOMEM when the mapping cannot
+// be extended in place.  Here the source is the first page of a larger single
+// mapping, so the bytes immediately after it are occupied and in-place growth
+// is impossible.
+static void test_grow_no_maymove_blocked()
+{
+    void *p = mmap(nullptr, 8 * page, PROT_READ | PROT_WRITE,
+                   MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+    assert(p != MAP_FAILED);
+    errno = 0;
+    void *q = mremap(p, page, 2 * page, 0 /* no MAYMOVE */);
+    assert(q == MAP_FAILED);
+    assert(errno == ENOMEM);
+    assert(munmap(p, 8 * page) == 0);
+}
+
+// A file-backed mapping can be grown/moved and still reflect the file bytes.
+static void test_file_move()
+{
+    char path[] = "/tmp/tst-mremap-XXXXXX";
+    int fd = mkstemp(path);
+    assert(fd >= 0);
+    // Write two pages of pattern to the file.
+    unsigned char *buf = static_cast<unsigned char *>(malloc(2 * page));
+    for (size_t i = 0; i < 2 * page; i++) {
+        buf[i] = static_cast<unsigned char>((i * 17 + 3) & 0xff);
+    }
+    assert(write(fd, buf, 2 * page) == (ssize_t)(2 * page));
+
+    void *p = mmap(nullptr, page, PROT_READ, MAP_PRIVATE, fd, 0);
+    assert(p != MAP_FAILED);
+    void *q = mremap(p, page, 2 * page, MREMAP_MAYMOVE);
+    assert(q != MAP_FAILED);
+    unsigned char *b = static_cast<unsigned char *>(q);
+    for (size_t i = 0; i < 2 * page; i++) {
+        assert(b[i] == static_cast<unsigned char>((i * 17 + 3) & 0xff));
+    }
+    assert(munmap(q, 2 * page) == 0);
+    free(buf);
+    close(fd);
+    unlink(path);
+}
+
+// Error paths.
+static void test_errors()
+{
+    void *p = mmap(nullptr, page, PROT_READ | PROT_WRITE,
+                   MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+    assert(p != MAP_FAILED);
+
+    // new_size == 0 -> EINVAL
+    errno = 0;
+    assert(mremap(p, page, 0, MREMAP_MAYMOVE) == MAP_FAILED && errno == EINVAL);
+
+    // Remapping an unmapped address -> EFAULT (single-vma requirement).
+    errno = 0;
+    void *bogus = static_cast<char *>(p) + 0x40000000ull;  // far, unmapped
+    assert(mremap(bogus, page, 2 * page, MREMAP_MAYMOVE) == MAP_FAILED &&
+           errno == EFAULT);
+
+    assert(munmap(p, page) == 0);
+}
+
+int main()
+{
+    std::cerr << "Running mremap tests\n";
+    page = sysconf(_SC_PAGESIZE);
+
+    test_grow_anon();
+    test_shrink_anon();
+    test_grow_no_maymove_blocked();
+    test_file_move();
+    test_errors();
+
+    std::cerr << "mremap tests PASSED\n";
+    return 0;
+}


### PR DESCRIPTION
## What

Implements `mremap(2)`, which was missing entirely on OSv: it was not in the
syscall table and had no libc entry point, so applications and allocators that
resize an mmap region failed (glibc/musl `realloc` of an mmap-backed chunk calls
the internal `__mremap`).

## How

`mmu::mremap()` (core/mmu.cc) is built on the existing VMA machinery and the
public, self-locking `map_anon()`/`map_file()`/`munmap()` primitives. It handles
a single, wholly mapped source vma (Linux likewise requires the old range to
fall within one mapping; a range spanning several vmas or a hole yields
`EFAULT`):

- **shrink / no-op**: drop the tail in place, address unchanged;
- **grow in place**: when the region immediately after the source is free;
- **grow with `MREMAP_MAYMOVE`**: allocate a new region of the new size, migrate
  the contents (anonymous: copy; file-backed: remap the file at the same offset
  so the grown tail is served by the fault path with no copy), then unmap the old
  range.

The source vma is inspected once under `vma_list_mutex` to snapshot its
perm/flags/type/file/offset and whether its tail is free, so the rest of the
function can call the self-locking primitives without nesting the non-recursive
vma write lock.

`MREMAP_FIXED` is not supported yet and returns `EINVAL` rather than doing the
wrong thing; the anonymous and file-backed paths cover the callers we have.

Wired as syscall `SYS_mremap` (via `long_mremap`, mirroring `long_mmap` since the
return value is a pointer) with a matching tracepoint, plus the libc
`mremap()`/`__mremap()` entry points, and both symbols exported from
`libc.so.6` and `ld-musl.so.1`.

## Testing

`tests/tst-mremap.cc` covers grow, shrink, in-place-blocked (`ENOMEM` without
`MREMAP_MAYMOVE`), file-backed move, and the `EINVAL`/`EFAULT` error paths. It
passes on OSv under KVM and on native Linux (semantics match). `tst-mmap`
continues to pass, so there is no regression in the VMA path.
