### PR TITLE
runtime: expand prctl() beyond PR_SET_DUMPABLE

### DIFF
--- a/modules/tests/Makefile
+++ b/modules/tests/Makefile
@@ -120,6 +120,7 @@ tests := tst-pthread.so misc-ramdisk.so tst-vblk.so tst-bsd-evh.so \
 	tst-fpu.so tst-preempt.so tst-tracepoint.so tst-hub.so \
 	misc-console.so misc-leak.so misc-readbench.so misc-mmap-anon-perf.so \
 	tst-mmap-file.so misc-mmap-big-file.so tst-mmap.so tst-huge.so \
+	tst-prctl.so \
 	tst-elf-permissions.so misc-mutex.so misc-sockets.so tst-condvar.so \
 	tst-queue-mpsc.so tst-af-local.so tst-pipe.so tst-yield.so \
 	misc-ctxsw.so tst-read.so tst-symlink.so tst-openat.so \

--- a/runtime.cc
+++ b/runtime.cc
@@ -606,8 +606,57 @@ int initgroups(const char *user, gid_t group)
 OSV_LIBC_API
 int prctl(int option, ...)
 {
+    va_list ap;
+    va_start(ap, option);
+    unsigned long arg2 = va_arg(ap, unsigned long);
+    va_end(ap);
+
     switch (option) {
+    case PR_SET_NAME: {
+        // Set the current thread's name.  Linux limits it to 16 bytes
+        // including the NUL; OSv's thread name is likewise 16 bytes.
+        const char *name = reinterpret_cast<const char *>(arg2);
+        if (!name) {
+            errno = EFAULT;
+            return -1;
+        }
+        char buf[16];
+        strncpy(buf, name, sizeof(buf) - 1);
+        buf[sizeof(buf) - 1] = '\0';
+        sched::thread::current()->set_name(buf);
+        return 0;
+    }
+    case PR_GET_NAME: {
+        char *out = reinterpret_cast<char *>(arg2);
+        if (!out) {
+            errno = EFAULT;
+            return -1;
+        }
+        auto raw = sched::thread::current()->name_raw();
+        // Copy up to 16 bytes; the caller-supplied buffer must be >= 16.
+        memcpy(out, raw.data(), raw.size());
+        out[raw.size() - 1] = '\0';
+        return 0;
+    }
     case PR_SET_DUMPABLE:
+    case PR_GET_DUMPABLE:
+        // OSv has a single address space; dumpability is a no-op.  GET reports
+        // "dumpable" (1), the Linux default.
+        return option == PR_GET_DUMPABLE ? 1 : 0;
+    case PR_SET_PDEATHSIG:
+        // No parent process to die, so nothing to signal.  Accept silently.
+        return 0;
+    case PR_GET_PDEATHSIG:
+        if (arg2) {
+            *reinterpret_cast<int *>(arg2) = 0;
+        }
+        return 0;
+    case PR_SET_KEEPCAPS:
+    case PR_SET_NO_NEW_PRIVS:
+        // No capability/privilege model in a unikernel; accept as no-ops.
+        return 0;
+    case PR_GET_KEEPCAPS:
+    case PR_GET_NO_NEW_PRIVS:
         return 0;
     }
     errno = EINVAL;

--- a/tests/tst-prctl.cc
+++ b/tests/tst-prctl.cc
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2026 Waldemar Kozaczuk
+ *
+ * This work is open source software, licensed under the terms of the
+ * BSD license as described in the LICENSE file in the top-level directory.
+ */
+
+// Exercises the expanded prctl(2): PR_SET_NAME/PR_GET_NAME (real thread names)
+// and the no-op options that used to return EINVAL.  Built and run as part of
+// the OSv test image.
+
+#include <sys/prctl.h>
+
+#include <errno.h>
+#include <string.h>
+
+#include <cassert>
+#include <iostream>
+
+int main()
+{
+    std::cerr << "Running prctl tests\n";
+
+    // PR_SET_NAME then PR_GET_NAME must round-trip (Linux caps at 16 bytes).
+    assert(prctl(PR_SET_NAME, "worker-1") == 0);
+    char name[16] = {};
+    assert(prctl(PR_GET_NAME, name) == 0);
+    assert(strcmp(name, "worker-1") == 0);
+
+    // A name longer than 15 chars is truncated, not rejected.
+    assert(prctl(PR_SET_NAME, "this-name-is-way-too-long") == 0);
+    assert(prctl(PR_GET_NAME, name) == 0);
+    assert(strlen(name) == 15);
+    assert(strncmp(name, "this-name-is-wa", 15) == 0);
+
+    // Dumpable: SET accepted, GET reports the Linux default (1).
+    assert(prctl(PR_SET_DUMPABLE, 0) == 0);
+    assert(prctl(PR_GET_DUMPABLE) == 1);
+
+    // Benign no-op options are accepted rather than returning EINVAL.
+    assert(prctl(PR_SET_PDEATHSIG, 9) == 0);
+    int sig = -1;
+    assert(prctl(PR_GET_PDEATHSIG, &sig) == 0);
+    assert(sig == 0);
+    assert(prctl(PR_SET_KEEPCAPS, 1) == 0);
+    assert(prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) == 0);
+
+    // An unknown option still returns EINVAL.
+    errno = 0;
+    assert(prctl(0x7fffffff) == -1 && errno == EINVAL);
+
+    std::cerr << "prctl tests PASSED\n";
+    return 0;
+}


### PR DESCRIPTION
## What

`prctl()` handled only `PR_SET_DUMPABLE` and returned `EINVAL` for everything
else, so common, harmless calls that many programs and language runtimes make
(setting a thread name, `PR_SET_PDEATHSIG`, `PR_SET_NO_NEW_PRIVS`) failed.

## How

Add real support and honest no-ops:

- **`PR_SET_NAME` / `PR_GET_NAME`**: set and read the current thread's name via
  OSv's `sched::thread` name (16-byte cap, matching Linux). This makes thread
  names visible in traces and debugging, which is the main reason programs call
  it.
- **`PR_GET_DUMPABLE`**: report the Linux default (1); `PR_SET_DUMPABLE` stays a
  no-op (single address space, nothing to gate).
- **`PR_SET_PDEATHSIG` / `PR_GET_PDEATHSIG`**: accept and report 0. There is no
  parent process in a unikernel, so there is nothing to signal.
- **`PR_SET_KEEPCAPS` / `PR_SET_NO_NEW_PRIVS`** (and their GET forms): accept as
  no-ops; a unikernel has no capability or privilege-escalation model.
- Unknown options still return `EINVAL`.

## Testing

`tests/tst-prctl.cc` covers the `PR_SET_NAME`/`PR_GET_NAME` round-trip (including
truncation), dumpable, the no-op options, and the `EINVAL` path. Passes on OSv
under KVM.
