### PR TITLE
numa: discover NUMA topology from ACPI SRAT/SLIT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1131,6 +1131,7 @@ endif
 objects += linux.o
 objects += core/commands.o
 objects += core/sched.o
+objects += core/numa.o
 objects += core/mmio.o
 objects += core/kprintf.o
 ifeq ($(conf_tracepoints),1)

--- a/core/numa.cc
+++ b/core/numa.cc
@@ -1,0 +1,178 @@
+/*
+ * Copyright (C) 2026 Waldemar Kozaczuk
+ *
+ * This work is open source software, licensed under the terms of the
+ * BSD license as described in the LICENSE file in the top-level directory.
+ */
+
+#include <osv/numa.hh>
+#include <osv/sched.hh>
+#include <osv/debug.hh>
+
+#include <unordered_map>
+#include <algorithm>
+
+#include <osv/drivers_config.h>
+
+#if CONF_drivers_acpi
+extern "C" {
+#include "acpi.h"
+}
+#include <boost/intrusive/parent_from_member.hpp>
+#endif
+
+namespace numa {
+
+static bool s_available = false;
+static unsigned s_nr_nodes = 1;
+// Map from a raw APIC id to the NUMA node it belongs to (from SRAT).
+static std::unordered_map<uint32_t, unsigned> s_apic_to_node;
+// Map from a sched cpu id to its NUMA node (resolved via APIC id).
+static std::unordered_map<unsigned, unsigned> s_cpu_to_node;
+// SLIT distance matrix, row-major, s_nr_nodes x s_nr_nodes; empty if no SLIT.
+static std::vector<uint8_t> s_distances;
+static std::vector<mem_range> s_mem_ranges;
+static bool s_initialized = false;
+
+unsigned nr_nodes() { return s_nr_nodes; }
+bool available() { return s_available; }
+const std::vector<mem_range>& memory_ranges() { return s_mem_ranges; }
+
+unsigned node_of_cpu(unsigned cpu_id)
+{
+    auto it = s_cpu_to_node.find(cpu_id);
+    return it == s_cpu_to_node.end() ? 0 : it->second;
+}
+
+unsigned distance(unsigned from, unsigned to)
+{
+    if (from == to) {
+        return 10;   // ACPI convention: 10 == local.
+    }
+    if (!s_distances.empty() && from < s_nr_nodes && to < s_nr_nodes) {
+        return s_distances[from * s_nr_nodes + to];
+    }
+    return 20;       // Default remote distance when no SLIT is present.
+}
+
+#if CONF_drivers_acpi
+using boost::intrusive::get_parent_from_member;
+
+// Record the (apic id -> node) mapping and track the highest node seen.
+static void record_cpu_affinity(uint32_t apic_id, unsigned node, unsigned& max_node)
+{
+    s_apic_to_node[apic_id] = node;
+    max_node = std::max(max_node, node);
+}
+
+static void parse_srat()
+{
+    char sig[] = ACPI_SIG_SRAT;
+    ACPI_TABLE_HEADER* header;
+    if (AcpiGetTable(sig, 0, &header) != AE_OK) {
+        return;   // No SRAT: leave the single-node fallback in place.
+    }
+    auto srat = get_parent_from_member(header, &ACPI_TABLE_SRAT::Header);
+    void* sub = srat + 1;
+    void* end = static_cast<void*>(srat) + srat->Header.Length;
+    unsigned max_node = 0;
+
+    while (sub < end) {
+        auto s = static_cast<ACPI_SUBTABLE_HEADER*>(sub);
+        if (s->Length == 0) {
+            break;   // Guard against a malformed zero-length subtable.
+        }
+        switch (s->Type) {
+        case ACPI_SRAT_TYPE_CPU_AFFINITY: {
+            auto a = get_parent_from_member(s, &ACPI_SRAT_CPU_AFFINITY::Header);
+            if (a->Flags & ACPI_SRAT_CPU_ENABLED) {
+                unsigned node = a->ProximityDomainLo |
+                    (a->ProximityDomainHi[0] << 8) |
+                    (a->ProximityDomainHi[1] << 16) |
+                    (a->ProximityDomainHi[2] << 24);
+                record_cpu_affinity(a->ApicId, node, max_node);
+            }
+            break;
+        }
+        case ACPI_SRAT_TYPE_X2APIC_CPU_AFFINITY: {
+            auto a = get_parent_from_member(s, &ACPI_SRAT_X2APIC_CPU_AFFINITY::Header);
+            if (a->Flags & ACPI_SRAT_CPU_ENABLED) {
+                record_cpu_affinity(a->ApicId, a->ProximityDomain, max_node);
+            }
+            break;
+        }
+        case ACPI_SRAT_TYPE_MEMORY_AFFINITY: {
+            auto m = get_parent_from_member(s, &ACPI_SRAT_MEM_AFFINITY::Header);
+            if (m->Flags & ACPI_SRAT_MEM_ENABLED) {
+                s_mem_ranges.push_back(mem_range{
+                    m->BaseAddress, m->Length, m->ProximityDomain,
+                    (m->Flags & ACPI_SRAT_MEM_HOT_PLUGGABLE) != 0});
+                max_node = std::max(max_node, (unsigned)m->ProximityDomain);
+            }
+            break;
+        }
+        default:
+            break;
+        }
+        sub = static_cast<void*>(sub) + s->Length;
+    }
+
+    if (!s_apic_to_node.empty() || !s_mem_ranges.empty()) {
+        s_available = true;
+        s_nr_nodes = max_node + 1;
+    }
+}
+
+static void parse_slit()
+{
+    char sig[] = ACPI_SIG_SLIT;
+    ACPI_TABLE_HEADER* header;
+    if (AcpiGetTable(sig, 0, &header) != AE_OK) {
+        return;
+    }
+    auto slit = get_parent_from_member(header, &ACPI_TABLE_SLIT::Header);
+    uint64_t n = slit->LocalityCount;
+    // Only trust SLIT if it agrees with the node count we saw in SRAT.
+    if (n == 0 || n != s_nr_nodes) {
+        return;
+    }
+    s_distances.assign(slit->Entry, slit->Entry + n * n);
+}
+
+// Resolve the (apic id -> node) map into a (sched cpu id -> node) map.
+static void resolve_cpus()
+{
+    for (auto* c : sched::cpus) {
+        auto it = s_apic_to_node.find(c->arch.apic_id);
+        if (it != s_apic_to_node.end()) {
+            s_cpu_to_node[c->id] = it->second;
+        }
+    }
+}
+#endif
+
+void init()
+{
+    if (s_initialized) {
+        return;
+    }
+    s_initialized = true;
+
+#if CONF_drivers_acpi
+    parse_srat();
+    if (s_available) {
+        parse_slit();
+        resolve_cpus();
+    }
+#endif
+
+    if (s_available) {
+        debugf("NUMA: %u node(s), %zu CPU(s) mapped, %zu memory range(s)%s\n",
+               s_nr_nodes, s_cpu_to_node.size(), s_mem_ranges.size(),
+               s_distances.empty() ? ", no SLIT" : "");
+    } else {
+        debugf("NUMA: no SRAT, assuming a single flat node\n");
+    }
+}
+
+}

--- a/include/osv/numa.hh
+++ b/include/osv/numa.hh
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2026 Waldemar Kozaczuk
+ *
+ * This work is open source software, licensed under the terms of the
+ * BSD license as described in the LICENSE file in the top-level directory.
+ */
+
+#ifndef OSV_NUMA_HH
+#define OSV_NUMA_HH
+
+#include <cstdint>
+#include <vector>
+#include <cstddef>
+
+// NUMA topology discovery.
+//
+// This module parses the ACPI SRAT (System Resource Affinity Table) and SLIT
+// (System Locality Distance Information Table) to learn the machine's NUMA
+// layout: which node each CPU belongs to, which physical memory ranges belong
+// to each node, and the relative distances between nodes.
+//
+// This is discovery only: it does not change how memory is allocated or how
+// threads are scheduled.  It exposes the topology so later work (a node-aware
+// allocator, scheduler affinity, mbind/get_mempolicy) can use it.  On a machine
+// with no SRAT (the common single-node virtual machine), the whole system is
+// reported as one node (node 0) containing every CPU.
+
+namespace numa {
+
+// A contiguous physical memory range assigned to a NUMA node.
+struct mem_range {
+    uint64_t base;
+    uint64_t length;
+    unsigned node;
+    bool     hotpluggable;
+};
+
+// Discover the topology by parsing SRAT/SLIT.  Safe to call once, after ACPI is
+// initialized and the CPUs have been enumerated (so APIC ids are known).  If no
+// SRAT is present, initializes a single flat node.  Idempotent.
+void init();
+
+// Number of NUMA nodes (>= 1).
+unsigned nr_nodes();
+
+// True if the topology came from a real SRAT (as opposed to the synthesized
+// single-node fallback).
+bool available();
+
+// The node a CPU (by sched cpu id) belongs to, or 0 if unknown.
+unsigned node_of_cpu(unsigned cpu_id);
+
+// The SLIT distance from node `from` to node `to`.  Linux/ACPI convention:
+// 10 == local (same node), higher == farther.  Returns 10 for the diagonal and
+// a default (10 local / 20 remote) when no SLIT is present.
+unsigned distance(unsigned from, unsigned to);
+
+// The memory ranges discovered from SRAT (empty if none).
+const std::vector<mem_range>& memory_ranges();
+
+}
+
+#endif

--- a/loader.cc
+++ b/loader.cc
@@ -26,6 +26,7 @@
 #endif /* __x86_64__ */
 
 #include <osv/sched.hh>
+#include <osv/numa.hh>
 #include <osv/barrier.hh>
 #include "arch.hh"
 #include "arch-setup.hh"
@@ -824,6 +825,7 @@ void main_cont(int loader_argc, char** loader_argv)
 #ifdef __x86_64__
 #if CONF_drivers_acpi
     acpi::init();
+    numa::init();
 #endif
 #endif /* __x86_64__ */
 

--- a/modules/tests/Makefile
+++ b/modules/tests/Makefile
@@ -120,6 +120,7 @@ tests := tst-pthread.so misc-ramdisk.so tst-vblk.so tst-bsd-evh.so \
 	tst-fpu.so tst-preempt.so tst-tracepoint.so tst-hub.so \
 	misc-console.so misc-leak.so misc-readbench.so misc-mmap-anon-perf.so \
 	tst-mmap-file.so misc-mmap-big-file.so tst-mmap.so tst-huge.so \
+	tst-numa.so \
 	tst-elf-permissions.so misc-mutex.so misc-sockets.so tst-condvar.so \
 	tst-queue-mpsc.so tst-af-local.so tst-pipe.so tst-yield.so \
 	misc-ctxsw.so tst-read.so tst-symlink.so tst-openat.so \

--- a/tests/tst-numa.cc
+++ b/tests/tst-numa.cc
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2026 Waldemar Kozaczuk
+ *
+ * This work is open source software, licensed under the terms of the
+ * BSD license as described in the LICENSE file in the top-level directory.
+ */
+
+// Verifies NUMA topology discovery.  Boot with QEMU's -numa options to see more
+// than one node; without them (the default) the machine is reported as a single
+// flat node.  Built and run as part of the OSv test image.
+
+#include <osv/numa.hh>
+#include <osv/sched.hh>
+
+#include <cassert>
+#include <iostream>
+
+int main()
+{
+    std::cerr << "Running numa tests\n";
+
+    // There is always at least one node.
+    unsigned n = numa::nr_nodes();
+    assert(n >= 1);
+    std::cerr << "  nodes=" << n << " available=" << numa::available() << "\n";
+
+    // Every CPU maps to a node within range.
+    for (auto* c : sched::cpus) {
+        unsigned node = numa::node_of_cpu(c->id);
+        assert(node < n);
+    }
+
+    // Distances: the diagonal is local (10); off-diagonal is >= local.
+    for (unsigned a = 0; a < n; a++) {
+        assert(numa::distance(a, a) == 10);
+        for (unsigned b = 0; b < n; b++) {
+            assert(numa::distance(a, b) >= 10);
+        }
+    }
+
+    // Memory ranges (if any) all name a node within range.
+    for (auto& r : numa::memory_ranges()) {
+        assert(r.node < n);
+        assert(r.length > 0);
+    }
+
+    // When SRAT is present, every CPU should have been mapped and the node
+    // count should match at least one memory range or cpu affinity.
+    if (numa::available()) {
+        std::cerr << "  memory ranges=" << numa::memory_ranges().size() << "\n";
+    }
+
+    std::cerr << "numa tests PASSED\n";
+    return 0;
+}


### PR DESCRIPTION
## What

OSv has no notion of NUMA: the scheduler and allocator treat memory as flat,
which leaves performance on the table on multi-socket bare-metal (the large
EC2/GCP metal instances that are a target for Postgres-over-ZFS workloads).

This is the first, **discovery-only** step of NUMA support. It adds a `numa::`
module that parses the ACPI SRAT (System Resource Affinity Table) and SLIT
(System Locality Distance Information Table) at boot, right after
`acpi::init()`, and exposes the topology.

## API

- `numa::nr_nodes()` / `numa::available()`
- `numa::node_of_cpu(cpu_id)` -- resolved by correlating SRAT APIC ids with the
  APIC ids the MADT parse already recorded on each `sched::cpu`
- `numa::distance(from, to)` -- from SLIT (10 == local, per ACPI convention),
  defaulting to 10 local / 20 remote when no SLIT is present
- `numa::memory_ranges()` -- physical ranges tagged with their node

It handles the SRAT CPU-affinity, x2APIC CPU-affinity and memory-affinity
subtables, and only trusts SLIT if its locality count matches the node count
SRAT reported. On a machine with no SRAT (the common single-node VM) it reports
one flat node and `available() == false`.

## Scope

This intentionally does **not** yet change allocation or scheduling; it only
makes the topology available so later work (a node-aware allocator, scheduler
affinity, `mbind`/`get_mempolicy`) can build on it. Nothing changes behavior on
existing single-node setups.

## Testing

`tests/tst-numa.cc` validates the invariants (>= 1 node, every CPU maps in
range, distance diagonal == 10 and off-diagonal >= 10, memory ranges name valid
nodes). Verified on OSv under KVM both without NUMA (reports 1 flat node) and
with a QEMU 2-node `-numa` config (reports 2 nodes, 3 memory ranges,
available).
