### PR TITLE
drivers: add virtio-balloon memory balloon driver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -944,6 +944,7 @@ endif
 drivers += drivers/virtio-blk.o
 drivers += drivers/virtio-scsi.o
 drivers += drivers/virtio-rng.o
+drivers += drivers/virtio-balloon.o
 drivers += drivers/virtio-fs.o
 endif
 
@@ -1013,6 +1014,7 @@ drivers += drivers/virtio-mmio.o
 endif
 drivers += drivers/virtio-vring.o
 drivers += drivers/virtio-rng.o
+drivers += drivers/virtio-balloon.o
 drivers += drivers/virtio-blk.o
 drivers += drivers/virtio-scsi.o
 drivers += drivers/virtio-net.o

--- a/arch/aarch64/arch-setup.cc
+++ b/arch/aarch64/arch-setup.cc
@@ -184,6 +184,9 @@ void arch_init_premain()
 #if CONF_drivers_virtio_rng
 #include "drivers/virtio-rng.hh"
 #endif
+#if CONF_drivers_virtio
+#include "drivers/virtio-balloon.hh"
+#endif
 #if CONF_drivers_virtio_blk
 #include "drivers/virtio-blk.hh"
 #endif
@@ -241,6 +244,9 @@ void arch_init_drivers()
     hw::driver_manager* drvman = hw::driver_manager::instance();
 #if CONF_drivers_virtio_rng
     drvman->register_driver(virtio::rng::probe);
+#endif
+#if CONF_drivers_virtio
+    drvman->register_driver(virtio::balloon::probe);
 #endif
 #if CONF_drivers_virtio_blk
     drvman->register_driver(virtio::blk::probe);

--- a/arch/x64/arch-setup.cc
+++ b/arch/x64/arch-setup.cc
@@ -297,6 +297,9 @@ void arch_init_premain()
 #if CONF_drivers_virtio_rng
 #include "drivers/virtio-rng.hh"
 #endif
+#if CONF_drivers_virtio
+#include "drivers/virtio-balloon.hh"
+#endif
 #if CONF_drivers_virtio_fs
 #include "drivers/virtio-fs.hh"
 #endif
@@ -363,6 +366,9 @@ void arch_init_drivers()
 #endif
 #if CONF_drivers_virtio_rng
     drvman->register_driver(virtio::rng::probe);
+#endif
+#if CONF_drivers_virtio
+    drvman->register_driver(virtio::balloon::probe);
 #endif
 #if CONF_drivers_virtio_fs
     drvman->register_driver(virtio::fs::probe);

--- a/documentation/virtio-balloon.md
+++ b/documentation/virtio-balloon.md
@@ -1,0 +1,49 @@
+# virtio-balloon
+
+OSv implements the virtio memory balloon (`virtio-balloon`, virtio device id 5),
+which lets the host reclaim guest memory on demand and give it back later. This
+is useful for memory overcommit and density: the host can shrink an idle guest
+and grow it again under load, without stopping it.
+
+## How it works
+
+The driver has two virtqueues, inflate (0) and deflate (1), and reads the target
+balloon size from the device config (`num_pages`). A worker thread polls the
+target and moves the balloon toward it:
+
+- **Inflate** (host raised `num_pages`): the driver allocates guest pages with
+  `memory::alloc_page()`, hands their PFNs to the host on the inflate queue, and
+  keeps them out of OSv's free pool (the memory is now the host's).
+- **Deflate** (host lowered `num_pages`): the driver returns ballooned pages'
+  PFNs on the deflate queue and frees them back to OSv with
+  `memory::free_page()`.
+
+After each adjustment the driver writes the current balloon size back to the
+config `actual` field so the host can track it.
+
+The worker polls on a short interval rather than waking on a config-change
+interrupt, because OSv's virtio core does not currently wire the MSI-X
+config-change vector. Ballooning is not latency-critical, so a sub-second
+reaction is fine.
+
+## Trying it
+
+Boot OSv with a balloon device and a QMP socket:
+
+```
+qemu-system-x86_64 ... \
+  -device virtio-balloon-pci,id=balloon0 \
+  -qmp tcp:127.0.0.1:4444,server,nowait
+```
+
+Run `tests/misc-balloon.so`, which prints free memory once a second. From the
+host, shrink the guest (inflate the balloon) and then grow it back (deflate):
+
+```
+{"execute":"qmp_capabilities"}
+{"execute":"balloon","arguments":{"value":536870912}}   # inflate: give up memory
+{"execute":"balloon","arguments":{"value":1073741824}}  # deflate: take it back
+{"execute":"query-balloon"}
+```
+
+Free memory drops after the inflate and recovers after the deflate.

--- a/drivers/virtio-balloon.cc
+++ b/drivers/virtio-balloon.cc
@@ -1,0 +1,244 @@
+/*
+ * Copyright (C) 2026 Waldemar Kozaczuk
+ *
+ * This work is open source software, licensed under the terms of the
+ * BSD license as described in the LICENSE file in the top-level directory.
+ */
+
+#include "drivers/virtio-balloon.hh"
+
+#include <osv/mmu.hh>
+#include <osv/mempool.hh>
+#include <osv/virt_to_phys.hh>
+#include <osv/debug.hh>
+
+#include <algorithm>
+#include <vector>
+#include <cstddef>
+
+using namespace memory;
+
+namespace virtio {
+
+balloon::balloon(virtio_device& dev)
+    : virtio_driver(dev)
+    , _thread(sched::thread::make([&] { worker(); },
+              sched::thread::attr().name("virtio-balloon")))
+{
+    setup_features();
+    probe_virt_queues();
+
+    _inflate_queue = get_virt_queue(0);
+    _deflate_queue = get_virt_queue(1);
+
+    interrupt_factory int_factory;
+    int_factory.register_msi_bindings = [this](interrupt_manager &msi) {
+        // Bind a vector for each queue (0 = inflate, 1 = deflate).  On a queue
+        // completion, disable that queue's interrupts and wake the worker,
+        // which is what wait_for_queue() is parked on during a transfer.
+        msi.easy_register({
+            { 0, [=] { this->_inflate_queue->disable_interrupts(); }, this->_thread.get() },
+            { 1, [=] { this->_deflate_queue->disable_interrupts(); }, this->_thread.get() },
+        });
+    };
+    int_factory.create_pci_interrupt = [this](pci::device &pci_dev) {
+        return new pci_interrupt(
+            pci_dev,
+            [=] { return this->ack_irq(); },
+            [=] { this->handle_irq(); });
+    };
+    _dev.register_interrupt(int_factory);
+
+    add_dev_status(VIRTIO_CONFIG_S_DRIVER_OK);
+    _thread->start();
+    debugf("virtio-balloon: ready\n");
+}
+
+balloon::~balloon()
+{
+    WITH_LOCK(_mtx) {
+        _shutdown = true;
+        _worker_wake.wake_all();
+    }
+    if (_thread) {
+        _thread->join();
+    }
+    // Return any still-ballooned pages to the allocator on teardown.
+    WITH_LOCK(_mtx) {
+        for (auto* p : _ballooned) {
+            free_page(p);
+        }
+        _ballooned.clear();
+    }
+}
+
+u64 balloon::get_driver_features()
+{
+    // We do not implement the stats queue; MUST_TELL_HOST and DEFLATE_ON_OOM are
+    // harmless to accept and match the common host configuration.
+    auto base = virtio_driver::get_driver_features();
+    return base | (1ull << VIRTIO_BALLOON_F_MUST_TELL_HOST)
+                | (1ull << VIRTIO_BALLOON_F_DEFLATE_ON_OOM);
+}
+
+u32 balloon::target_pages()
+{
+    balloon_config cfg;
+    virtio_conf_read(0, &cfg, sizeof(cfg));
+    return cfg.num_pages;   // little-endian; OSv targets are LE hosts
+}
+
+void balloon::update_actual(u32 actual)
+{
+    // Tell the host how many pages we have actually given up by writing the
+    // `actual` field (offset 4 in the balloon config).  QEMU relies on this to
+    // track the balloon size and to compute subsequent inflate/deflate targets.
+    virtio_conf_write(offsetof(balloon_config, actual), &actual, sizeof(actual));
+}
+
+void balloon::tell_host(vring* q, u32* pfns, u32 npfns)
+{
+    q->init_sg();
+    q->add_out_sg(pfns, npfns * sizeof(u32));
+    while (!q->add_buf(pfns)) {
+        while (!q->avail_ring_has_room(q->_sg_vec.size())) {
+            sched::thread::wait_until([&] { return q->used_ring_can_gc(); });
+            q->get_buf_gc();
+        }
+    }
+    q->kick();
+    wait_for_queue(q, &vring::used_ring_not_empty);
+    u32 len;
+    q->get_buf_elem(&len);
+    q->get_buf_finalize();
+}
+
+void balloon::inflate(u32 count)
+{
+    std::vector<u32> pfns;
+    std::vector<void*> pages;
+    pfns.reserve(std::min(count, PFNS_PER_REQUEST));
+
+    while (count > 0) {
+        u32 batch = std::min(count, PFNS_PER_REQUEST);
+        pfns.clear();
+        pages.clear();
+        for (u32 i = 0; i < batch; i++) {
+            void* p = alloc_page();
+            if (!p) {
+                break;   // out of memory: give the host what we managed to get
+            }
+            pages.push_back(p);
+            pfns.push_back(mmu::virt_to_phys(p) >> VIRTIO_BALLOON_PFN_SHIFT);
+        }
+        if (pfns.empty()) {
+            break;
+        }
+        tell_host(_inflate_queue, pfns.data(), pfns.size());
+        // The pages are now the host's; keep them out of the free pool by
+        // holding them in _ballooned rather than freeing.
+        WITH_LOCK(_mtx) {
+            for (auto* p : pages) {
+                _ballooned.push_back(p);
+            }
+        }
+        count -= pfns.size();
+        if (pfns.size() < batch) {
+            break;   // allocation failed mid-batch; stop
+        }
+    }
+}
+
+void balloon::deflate(u32 count)
+{
+    std::vector<u32> pfns;
+    std::vector<void*> pages;
+
+    while (count > 0) {
+        pfns.clear();
+        pages.clear();
+        WITH_LOCK(_mtx) {
+            u32 batch = std::min({count, PFNS_PER_REQUEST,
+                                  (u32)_ballooned.size()});
+            for (u32 i = 0; i < batch; i++) {
+                void* p = _ballooned.front();
+                _ballooned.pop_front();
+                pages.push_back(p);
+                pfns.push_back(mmu::virt_to_phys(p) >> VIRTIO_BALLOON_PFN_SHIFT);
+            }
+        }
+        if (pfns.empty()) {
+            break;
+        }
+        tell_host(_deflate_queue, pfns.data(), pfns.size());
+        // The host has released these pages; return them to the allocator.
+        for (auto* p : pages) {
+            free_page(p);
+        }
+        count -= pfns.size();
+    }
+}
+
+void balloon::adjust_toward_target()
+{
+    u32 target = target_pages();
+    u32 actual;
+    WITH_LOCK(_mtx) {
+        actual = _ballooned.size();
+    }
+    if (target > actual) {
+        inflate(target - actual);
+    } else if (target < actual) {
+        deflate(actual - target);
+    }
+    WITH_LOCK(_mtx) {
+        update_actual(_ballooned.size());
+    }
+}
+
+void balloon::handle_irq()
+{
+    // Runs in interrupt context, so it must not take a sleeping lock.  The
+    // worker polls the target on a timer, so a queue/interrupt notification is
+    // not required for correctness; waking the worker thread is a best-effort
+    // nudge to react a little sooner.
+    if (_thread) {
+        _thread->wake();
+    }
+}
+
+bool balloon::ack_irq()
+{
+    return _dev.read_and_ack_isr();
+}
+
+void balloon::worker()
+{
+    // OSv's virtio core does not currently wire the MSI-X config-change vector,
+    // so we cannot get an interrupt when the host changes num_pages.  Poll the
+    // target on a modest interval instead: ballooning is not latency-critical,
+    // and a sub-second reaction to memory pressure is fine.
+    //
+    // ponytail: polling because config-change IRQ is unwired in virtio core;
+    // drop the timer and wake purely on the config-change vector once that is
+    // plumbed (VIRTIO_MSI_CONFIG_VECTOR).
+    using namespace std::chrono;
+    WITH_LOCK(_mtx) {
+        while (!_shutdown) {
+            DROP_LOCK(_mtx) {
+                adjust_toward_target();
+            }
+            if (_shutdown) {
+                break;
+            }
+            _worker_wake.wait(&_mtx, osv::clock::uptime::now() + milliseconds(500));
+        }
+    }
+}
+
+hw_driver* balloon::probe(hw_device* dev)
+{
+    return virtio::probe<balloon, VIRTIO_ID_BALLOON>(dev);
+}
+
+}

--- a/drivers/virtio-balloon.cc
+++ b/drivers/virtio-balloon.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Waldemar Kozaczuk
+ * Copyright (C) 2026 Greg Burd
  *
  * This work is open source software, licensed under the terms of the
  * BSD license as described in the LICENSE file in the top-level directory.

--- a/drivers/virtio-balloon.hh
+++ b/drivers/virtio-balloon.hh
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2026 Waldemar Kozaczuk
+ *
+ * This work is open source software, licensed under the terms of the
+ * BSD license as described in the LICENSE file in the top-level directory.
+ */
+
+#ifndef VIRTIO_BALLOON_DRIVER_H
+#define VIRTIO_BALLOON_DRIVER_H
+
+#include <osv/condvar.h>
+#include <osv/mutex.h>
+
+#include "drivers/virtio.hh"
+#include "drivers/device.hh"
+
+#include <deque>
+#include <memory>
+
+namespace virtio {
+
+// virtio-balloon: lets the host reclaim guest memory on demand.  When the host
+// raises the target ("num_pages" in the config), the driver allocates that many
+// guest pages, hands their PFNs to the host on the inflate queue, and keeps them
+// out of OSv's free pool (the memory is now the host's).  When the host lowers
+// the target, the driver returns pages via the deflate queue and frees them back
+// to OSv.
+class balloon : public virtio_driver {
+public:
+    explicit balloon(virtio_device& dev);
+    virtual ~balloon();
+
+    virtual std::string get_name() const { return "virtio-balloon"; }
+
+    static hw_driver* probe(hw_device* dev);
+
+private:
+    enum {
+        VIRTIO_BALLOON_F_MUST_TELL_HOST = 0,
+        VIRTIO_BALLOON_F_STATS_VQ       = 1,
+        VIRTIO_BALLOON_F_DEFLATE_ON_OOM = 2,
+    };
+
+    // Config-space layout (little-endian, at offset 0).
+    struct balloon_config {
+        u32 num_pages;   // target: pages the host wants us to give up
+        u32 actual;      // pages we have actually given up
+    };
+
+    static const unsigned VIRTIO_BALLOON_PFN_SHIFT = 12;
+    // How many PFNs we push to the host per queue request.
+    static const unsigned PFNS_PER_REQUEST = 256;
+
+    void handle_irq();
+    bool ack_irq();
+    void worker();
+
+    // Move the balloon toward the host's target size.
+    void adjust_toward_target();
+    void inflate(u32 count);   // give `count` pages to the host
+    void deflate(u32 count);   // take `count` pages back from the host
+    void tell_host(vring* q, u32* pfns, u32 npfns);
+    u32  target_pages();
+    void update_actual(u32 actual);
+
+    virtual u64 get_driver_features() override;
+
+    vring* _inflate_queue;
+    vring* _deflate_queue;
+    // Pages currently loaned to the host (their virtual addresses so we can free
+    // them on deflate).  Guarded by _mtx.
+    std::deque<void*> _ballooned;
+    std::unique_ptr<sched::thread> _thread;
+    mutex _mtx;
+    condvar _worker_wake;   // wakes the worker early (shutdown / queue completion)
+    bool _shutdown = false;
+};
+
+}
+
+#endif

--- a/drivers/virtio-balloon.hh
+++ b/drivers/virtio-balloon.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Waldemar Kozaczuk
+ * Copyright (C) 2026 Greg Burd
  *
  * This work is open source software, licensed under the terms of the
  * BSD license as described in the LICENSE file in the top-level directory.

--- a/drivers/virtio-device.hh
+++ b/drivers/virtio-device.hh
@@ -76,6 +76,7 @@ public:
     virtual void set_status(u8 status) = 0;
 
     virtual u8 read_config(u32 offset) = 0;
+    virtual void write_config(u32 offset, u8 val) = 0;
     virtual void dump_config() = 0;
 
     virtual bool get_shm(u8 id, mmioaddr_t &addr, u64 &length) = 0;

--- a/drivers/virtio-mmio.cc
+++ b/drivers/virtio-mmio.cc
@@ -101,6 +101,11 @@ u8 mmio_device::read_config(u32 offset)
     return mmio_getb(_addr_mmio + VIRTIO_MMIO_CONFIG + offset);
 }
 
+void mmio_device::write_config(u32 offset, u8 val)
+{
+    mmio_setb(_addr_mmio + VIRTIO_MMIO_CONFIG + offset, val);
+}
+
 void mmio_device::register_interrupt(interrupt_factory irq_factory)
 {
 #ifdef __aarch64__

--- a/drivers/virtio-mmio.hh
+++ b/drivers/virtio-mmio.hh
@@ -130,6 +130,7 @@ public:
     virtual void set_status(u8 status);
 
     virtual u8 read_config(u32 offset);
+    virtual void write_config(u32 offset, u8 val);
 
     virtual void dump_config() {}
 

--- a/drivers/virtio-pci-device.cc
+++ b/drivers/virtio-pci-device.cc
@@ -119,6 +119,12 @@ u8 virtio_legacy_pci_device::read_config(u32 offset)
     return _bar1->readb(conf_start + offset);
 }
 
+void virtio_legacy_pci_device::write_config(u32 offset, u8 val)
+{
+    auto conf_start = _dev->is_msix_enabled()? 24 : 20;
+    _bar1->writeb(conf_start + offset, val);
+}
+
 u8 virtio_legacy_pci_device::read_and_ack_isr()
 {
     return virtio_conf_readb(VIRTIO_PCI_ISR);
@@ -247,6 +253,11 @@ void virtio_modern_pci_device::set_status(u8 status)
 u8 virtio_modern_pci_device::read_config(u32 offset)
 {
     return _device_cfg->virtio_conf_readb(offset);
+}
+
+void virtio_modern_pci_device::write_config(u32 offset, u8 val)
+{
+    _device_cfg->virtio_conf_writeb(offset, val);
 }
 
 u8 virtio_modern_pci_device::read_and_ack_isr()

--- a/drivers/virtio-pci-device.hh
+++ b/drivers/virtio-pci-device.hh
@@ -116,6 +116,7 @@ public:
     virtual void set_status(u8 status);
 
     virtual u8 read_config(u32 offset);
+    virtual void write_config(u32 offset, u8 val);
     virtual u8 read_and_ack_isr();
 
     virtual bool is_modern() { return false; }
@@ -286,6 +287,7 @@ public:
     virtual void set_status(u8 status);
 
     virtual u8 read_config(u32 offset);
+    virtual void write_config(u32 offset, u8 val);
     virtual u8 read_and_ack_isr();
 
     virtual bool is_modern() { return true; };

--- a/drivers/virtio.cc
+++ b/drivers/virtio.cc
@@ -216,4 +216,11 @@ void virtio_driver::virtio_conf_read(u32 offset, void* buf, int length)
         ptr[i] = _dev.read_config(offset + i);
 }
 
+void virtio_driver::virtio_conf_write(u32 offset, const void* buf, int length)
+{
+    const unsigned char* ptr = reinterpret_cast<const unsigned char*>(buf);
+    for (int i = 0; i < length; i++)
+        _dev.write_config(offset + i, ptr[i]);
+}
+
 }

--- a/drivers/virtio.hh
+++ b/drivers/virtio.hh
@@ -91,6 +91,7 @@ public:
 
     // Access virtio config space
     void virtio_conf_read(u32 offset, void* buf, int length);
+    void virtio_conf_write(u32 offset, const void* buf, int length);
 
     bool kick(int queue);
     void reset_device();

--- a/modules/tests/Makefile
+++ b/modules/tests/Makefile
@@ -119,6 +119,7 @@ tests := tst-pthread.so misc-ramdisk.so tst-vblk.so tst-mq-smoke.so tst-bsd-evh.
 	misc-bsd-callout.so tst-bsd-kthread.so tst-bsd-taskqueue.so \
 	tst-fpu.so tst-preempt.so tst-tracepoint.so tst-hub.so \
 	misc-console.so misc-leak.so misc-readbench.so misc-mmap-anon-perf.so \
+	misc-balloon.so \
 	tst-mmap-file.so misc-mmap-big-file.so tst-mmap.so tst-huge.so \
 	tst-pthread-timedlock.so \
 	tst-signal-fills.so \

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -265,6 +265,9 @@ def start_osv_qemu(options):
     if options.hypervisor != 'qemu_microvm':
         args += ["-device", "virtio-rng-pci%s" % options.virtio_device_suffix]
 
+    if options.virtio_balloon:
+        args += ["-device", "virtio-balloon-pci%s" % options.virtio_device_suffix]
+
     if options.hypervisor == "kvm" or options.hypervisor == 'qemu_microvm':
         if options.arch == 'aarch64':
             args += ["-enable-kvm", "-cpu", "host", "-machine", "gic-version=max"]
@@ -634,6 +637,8 @@ if __name__ == "__main__":
                         help="path to loader-stripped.elf. defaults to build/$mode/loader-stripped.elf")
     parser.add_argument("--virtio", action="store", choices=["legacy","transitional","modern"], default="transitional",
                         help="specify virtio version: legacy, transitional or modern")
+    parser.add_argument("--virtio-balloon", action="store_true",
+                        help="attach a virtio-balloon device so the host can inflate/deflate guest memory")
     parser.add_argument("--arch", action="store", choices=["x86_64","aarch64"], default=host_arch,
                         help="specify QEMU architecture: x86_64, aarch64")
     parser.add_argument("--virtio-fs-tag", action="store",

--- a/tests/misc-balloon.cc
+++ b/tests/misc-balloon.cc
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2026 Waldemar Kozaczuk
+ *
+ * This work is open source software, licensed under the terms of the
+ * BSD license as described in the LICENSE file in the top-level directory.
+ */
+
+// Manual helper for exercising the virtio-balloon driver.  The balloon target
+// is controlled by the host, so this cannot be a self-checking automated test;
+// instead it prints free memory once a second while a host-side harness drives
+// the balloon over QMP.  Boot it with a balloon device, e.g.:
+//
+//   qemu ... -device virtio-balloon-pci,id=balloon0 \
+//            -qmp tcp:127.0.0.1:4444,server,nowait
+//
+// then from the host:  {"execute":"balloon","arguments":{"value":<bytes>}}
+//
+// Free memory should drop when the host shrinks the guest (inflate) and recover
+// when it grows it back (deflate).
+
+#include <osv/mempool.hh>
+
+#include <unistd.h>
+#include <cstdio>
+
+int main()
+{
+    for (int i = 0; i < 30; i++) {
+        printf("balloon: t=%d free=%lu bytes\n", i, memory::stats::free());
+        fflush(stdout);
+        sleep(1);
+    }
+    return 0;
+}

--- a/tests/misc-balloon.cc
+++ b/tests/misc-balloon.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Waldemar Kozaczuk
+ * Copyright (C) 2026 Greg Burd
  *
  * This work is open source software, licensed under the terms of the
  * BSD license as described in the LICENSE file in the top-level directory.


### PR DESCRIPTION
## What

Adds the virtio memory balloon driver (`virtio-balloon`, virtio device id 5),
which lets the host reclaim guest memory on demand and return it later. This is
broadly useful for memory overcommit and density (an idle guest can be shrunk
and grown again under load without stopping it) and is hypervisor-agnostic
(KVM/QEMU, Cloud Hypervisor).

## How

The driver has two virtqueues (inflate, deflate) and a worker thread that moves
the balloon toward the target size the host advertises in the device config
(`num_pages`):

- **inflate**: allocate guest pages via `memory::alloc_page()`, hand their PFNs
  to the host on the inflate queue, and keep them out of OSv's free pool (the
  memory is now the host's);
- **deflate**: return ballooned pages' PFNs on the deflate queue and free them
  back to OSv with `memory::free_page()`.

After each adjustment the driver writes the current balloon size back to the
config `actual` field so the host can track it (QEMU uses this to compute
subsequent targets). The worker polls the target on a short interval rather than
waking on a config-change interrupt, because OSv's virtio core does not
currently wire the MSI-X config-change vector; ballooning is not
latency-critical, so a sub-second reaction is fine.

To support writing `actual` back, this adds a symmetric `write_config()` to the
`virtio_device` interface (legacy-pci, modern-pci and mmio transports) and a
`virtio_driver::virtio_conf_write()` helper, mirroring the existing
`read_config()` / `virtio_conf_read()`. That change is purely additive and does
not affect existing drivers.

Registered on x86_64 and aarch64 (gated on `conf_drivers_virtio`, next to
virtio-rng).

## Testing

Because the balloon target is host-controlled, this cannot be a self-checking
automated test. `tests/misc-balloon.cc` prints free memory once a second while a
host-side QMP harness drives the balloon, and `documentation/virtio-balloon.md`
describes the procedure.

Verified on QEMU/KVM: setting the balloon to 512 MiB on a 1 GiB guest drops OSv
free memory by ~512 MiB (inflate), and setting it back to full returns it
(deflate), confirmed by the free-memory curve. virtio-blk and other virtio
drivers continue to work with the balloon device present.
