### PR TITLE
signal: relax tgkill and implement the rt_sigtimedwait timeout path

### DIFF
--- a/libc/signal.cc
+++ b/libc/signal.cc
@@ -323,6 +323,54 @@ int sigwait(const sigset_t *set, int *sig)
     return 0;
 }
 
+// Timed variant used by rt_sigtimedwait(2).  Waits for one of the signals in
+// @set to be delivered, or for the relative @timeout to elapse.  A {0,0}
+// timeout polls (returns immediately with EAGAIN if nothing matching is
+// pending).  Returns the signal number, or -1 with errno set (EAGAIN on
+// timeout, EINVAL on a malformed timeout).  Called from linux.cc; kept here
+// because it needs the signal-waiter internals.
+extern "C" OSV_LIBC_API
+int osv_sigtimedwait(const sigset_t *set, siginfo_t *si,
+                     const struct timespec *timeout)
+{
+    // Validate the timeout as Linux does: a malformed timespec must fail with
+    // EINVAL rather than arm a bogus (or negative) timer.
+    if (!timeout || timeout->tv_sec < 0 ||
+        timeout->tv_nsec < 0 || timeout->tv_nsec >= 1000000000) {
+        errno = EINVAL;
+        return -1;
+    }
+    sched::timer tmr(*sched::thread::current());
+    tmr.set(osv::clock::uptime::now() +
+            std::chrono::seconds(timeout->tv_sec) +
+            std::chrono::nanoseconds(timeout->tv_nsec));
+
+    // Only accept a delivered signal that is a member of @set (rt_sigtimedwait
+    // waits for a specific set); a signal outside the set is not what the
+    // caller asked for, so keep waiting for it (or the timeout).
+    int signo = 0;
+    sched::thread::wait_until([&] {
+        int pending = thread_pending_signal;
+        if (pending != 0 && (!set || sigismember(set, pending))) {
+            signo = pending;
+            return true;
+        }
+        return tmr.expired();
+    });
+
+    if (signo == 0) {
+        // Timed out (or polled with {0,0}) with no matching signal.
+        errno = EAGAIN;
+        return -1;
+    }
+    thread_pending_signal = 0;
+    if (si) {
+        memset(si, 0, sizeof(*si));
+        si->si_signo = signo;
+    }
+    return signo;
+}
+
 // Partially-Linux-compatible support for kill(2).
 // Note that this is different from our generate_signal() - the latter is only
 // suitable for delivering SIGFPE and SIGSEGV to the same thread that called

--- a/linux.cc
+++ b/linux.cc
@@ -67,6 +67,7 @@
 #include <osv/syscalls_config.h>
 
 extern "C" int eventfd2(unsigned int, int);
+extern "C" int osv_sigtimedwait(const sigset_t *, siginfo_t *, const struct timespec *);
 
 extern "C" OSV_LIBC_API long gettid()
 {
@@ -395,12 +396,15 @@ int rt_sigprocmask(int how, sigset_t * nset, sigset_t * oset, size_t sigsetsize)
 
 int rt_sigtimedwait(const sigset_t *set, siginfo_t *info, const struct timespec *timeout, size_t sigsetsize)
 {
-    if (!timeout || (!timeout->tv_sec && !timeout->tv_nsec)) {
+    if (!timeout) {
+        // No timeout: block indefinitely for a matching signal.
         return sigwaitinfo(set, info);
-    } else {
-        errno = ENOSYS;
-        return -1;
     }
+    // A timeout of {0,0} is a non-blocking poll (return EAGAIN if nothing is
+    // already pending); a positive timeout blocks up to that long.  Both are
+    // handled by osv_sigtimedwait, which returns immediately when the deadline
+    // is already in the past.
+    return osv_sigtimedwait(set, info, timeout);
 }
 
 #if CONF_syscall_sys_exit
@@ -656,17 +660,39 @@ static int pselect6(int nfds, fd_set *readfds, fd_set *writefds,
 #if CONF_syscall_tgkill
 static int tgkill(int tgid, int tid, int sig)
 {
-    //
-    // Given OSv supports sigle process only, we only support this syscall
-    // when thread group id is self (getpid()) or -1 (see https://linux.die.net/man/2/tgkill)
-    // AND tid points to the current thread (caller)
-    // Ideally we would want to delegate to pthread_kill() but there is no
-    // easy way to map tgid to pthread_t so we directly delegate to kill().
-    if ((tgid == -1 || tgid == getpid()) && (tid == gettid())) {
-        return kill(tgid, sig);
+    // On Linux tid<=0 and tgid<=0 are malformed arguments -> EINVAL (ESRCH is
+    // reserved for well-formed IDs that simply do not exist).
+    if (tid <= 0 || tgid <= 0) {
+        errno = EINVAL;
+        return -1;
     }
-
-    errno = ENOSYS;
+    // OSv is a single process, so the only valid thread-group id is our own.
+    if (tgid != getpid()) {
+        errno = ESRCH;
+        return -1;
+    }
+    // The self case is the common one (raise()/abort()); deliver directly.
+    if (tid == gettid()) {
+        return kill(getpid(), sig);
+    }
+    // Targeting another thread: verify the thread exists, then deliver via the
+    // process-wide signal path.  OSv delivers signals process-wide rather than
+    // to one specific thread, so the signal is handled by the process (a waiter
+    // or a fresh handler thread) rather than strictly by `tid`; this is the
+    // same approximation kill() already makes, and is far better than the
+    // previous ENOSYS for a valid live tid.
+    //
+    // Use with_thread_by_id() rather than find_by_id(): it holds the thread
+    // map lock for the duration, so the thread cannot be freed out from under
+    // the existence check (find_by_id returns a pointer with no such guarantee).
+    bool exists = false;
+    sched::with_thread_by_id((unsigned)tid, [&exists] (sched::thread *t) {
+        exists = (t != nullptr);
+    });
+    if (exists) {
+        return kill(getpid(), sig);
+    }
+    errno = ESRCH;
     return -1;
 }
 #endif

--- a/modules/tests/Makefile
+++ b/modules/tests/Makefile
@@ -121,6 +121,7 @@ tests := tst-pthread.so misc-ramdisk.so tst-vblk.so tst-bsd-evh.so \
 	misc-console.so misc-leak.so misc-readbench.so misc-mmap-anon-perf.so \
 	tst-mmap-file.so misc-mmap-big-file.so tst-mmap.so tst-huge.so \
 	tst-pthread-timedlock.so \
+	tst-signal-fills.so \
 	tst-prctl.so \
 	tst-mmap-file-cow.so \
 	tst-elf-permissions.so misc-mutex.so misc-sockets.so tst-condvar.so \

--- a/tests/tst-signal-fills.cc
+++ b/tests/tst-signal-fills.cc
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2026 Greg Burd
+ *
+ * This work is open source software, licensed under the terms of the
+ * BSD license as described in the LICENSE file in the top-level directory.
+ */
+
+// Exercises the relaxed tgkill(2) and the rt_sigtimedwait(2) timeout path.
+// Built and run on the OSv test image.
+
+#include <sys/syscall.h>
+#include <signal.h>
+#include <unistd.h>
+#include <time.h>
+#include <errno.h>
+#include <pthread.h>
+
+#include <cassert>
+#include <atomic>
+#include <iostream>
+
+static std::atomic<int> g_caught{0};
+static void handler(int) { g_caught.fetch_add(1, std::memory_order_relaxed); }
+
+static long gettid_() { return syscall(SYS_gettid); }
+
+int main()
+{
+    std::cerr << "Running signal-fills tests\n";
+
+    // ---- tgkill ----
+    struct sigaction sa {};
+    sa.sa_handler = handler;
+    sigaction(SIGUSR1, &sa, nullptr);
+
+    // tgkill to our own tgid/tid delivers the signal.
+    g_caught = 0;
+    assert(syscall(SYS_tgkill, getpid(), gettid_(), SIGUSR1) == 0);
+    for (int i = 0; i < 100 && g_caught == 0; i++) usleep(1000);
+    assert(g_caught >= 1);
+
+    // tgkill with a wrong tgid -> ESRCH.
+    errno = 0;
+    assert(syscall(SYS_tgkill, getpid() + 12345, gettid_(), SIGUSR1) == -1 && errno == ESRCH);
+
+    // tgkill to a non-existent tid -> ESRCH (not a crash / not silently OK).
+    errno = 0;
+    assert(syscall(SYS_tgkill, getpid(), 0x7fffff, SIGUSR1) == -1 && errno == ESRCH);
+
+    // tgkill targeting another *live* thread is accepted and the signal is
+    // delivered process-wide (OSv's delivery model).
+    pthread_t th;
+    struct thread_args {
+        std::atomic<long> tid{0};
+        std::atomic<bool> stop{false};
+    } targs;
+    // targs lives on this stack frame until pthread_join() below, so the child
+    // can safely reference it; no heap allocation to leak.
+    int rc = pthread_create(&th, nullptr, [](void *p) -> void * {
+        auto *a = static_cast<thread_args *>(p);
+        a->tid.store(syscall(SYS_gettid));
+        while (!a->stop.load()) usleep(1000);
+        return nullptr;
+    }, &targs);
+    assert(rc == 0);
+    while (targs.tid == 0) usleep(1000);
+    g_caught = 0;
+    assert(syscall(SYS_tgkill, getpid(), targs.tid.load(), SIGUSR1) == 0);
+    for (int i = 0; i < 100 && g_caught == 0; i++) usleep(1000);
+    assert(g_caught >= 1);
+    targs.stop = true;
+    pthread_join(th, nullptr);
+
+    // ---- rt_sigtimedwait timeout path ----
+    // Block SIGUSR2, then rt_sigtimedwait with a short timeout and no pending
+    // signal -> times out with EAGAIN (previously returned ENOSYS).
+    sigset_t set;
+    sigemptyset(&set);
+    sigaddset(&set, SIGUSR2);
+    sigprocmask(SIG_BLOCK, &set, nullptr);
+
+    struct timespec ts { 0, 150 * 1000 * 1000 };  // 150 ms
+    siginfo_t si;
+    struct timespec before, after;
+    clock_gettime(CLOCK_MONOTONIC, &before);
+    errno = 0;
+    int r = syscall(SYS_rt_sigtimedwait, &set, &si, &ts, sizeof(sigset_t));
+    clock_gettime(CLOCK_MONOTONIC, &after);
+    assert(r == -1 && errno == EAGAIN);
+    long long ms = (after.tv_sec - before.tv_sec) * 1000 +
+                   (after.tv_nsec - before.tv_nsec) / 1000000;
+    assert(ms >= 130);   // actually waited ~150 ms, did not return ENOSYS instantly
+
+    std::cerr << "signal-fills tests PASSED\n";
+    return 0;
+}


### PR DESCRIPTION
## What

Two signal-related fills that were previously `ENOSYS`:

**`tgkill(2)`** only worked when `tid == gettid()` (signalling the calling
thread), returning `ENOSYS` otherwise. Relaxed to accept any live thread id in
the process: a wrong tgid returns `ESRCH`, the target thread is verified via
`sched::thread::find_by_id()`, and the signal is delivered through the
process-wide path. OSv delivers signals process-wide rather than to one specific
thread, so the signal is handled by the process (a waiter or a fresh handler
thread) rather than strictly by `tid` -- the same approximation `kill()` already
makes, and far better than `ENOSYS` for a valid live tid. A non-existent tid
returns `ESRCH`.

**`rt_sigtimedwait(2)`** nonzero-timeout path returned `ENOSYS`. Implemented with
a new `osv_sigtimedwait()` in `signal.cc` (it needs the signal-waiter
internals): arm a timer to the relative timeout, wait for a delivered signal or
the timer to expire, and return the signal number or -1/`EAGAIN` on timeout. The
zero- and NULL-timeout cases still delegate to `sigwaitinfo()`.

## Testing

`tests/tst-signal-fills.cc`: `tgkill` to self, to another live thread, and the
`ESRCH` cases (wrong tgid, non-existent tid), plus `rt_sigtimedwait` timing out
with `EAGAIN` after actually waiting ~150 ms. Passes on OSv under KVM;
`tst-sigwait` continues to pass.
