### PR TITLE
libaio: implement the Linux async I/O interface

### DIFF
--- a/core/libaio.cc
+++ b/core/libaio.cc
@@ -6,27 +6,265 @@
  */
 
 // This is the Linux-specific asynchronous I/O API / ABI from libaio.
-// Note that this API is different the Posix AIO API.
+// Note that this API is different from the POSIX AIO API.
+//
+// OSv has no user/kernel boundary, so "async" I/O is achieved the same way
+// io_uring does it: each submitted iocb is run on a short-lived worker thread
+// that performs the blocking read/write/fsync via the VFS, then queues an
+// io_event and wakes any thread parked in io_getevents().  A context caps the
+// number of in-flight ops at the nr_events requested at io_setup() time.
 
 #include <api/libaio.h>
 
-#include <osv/stubbing.hh>
+#include <sys/uio.h>
+#include <unistd.h>
+#include <errno.h>
+#include <deque>
+
 #include <osv/export.h>
+#include <osv/mutex.h>
+#include <osv/condvar.h>
+#include <osv/sched.hh>
+#include <osv/file.h>
+#include <osv/clock.hh>
+
+#include "fs/vfs/vfs.h"
+
+struct io_context {
+    mutex                   mtx;
+    condvar                 cv;             // signalled when an event completes
+    unsigned                max_events;     // capacity requested at io_setup()
+    unsigned                inflight = 0;   // ops submitted but not yet retired
+    unsigned                waiters = 0;    // threads parked in io_getevents()
+    bool                    destroying = false;
+    std::deque<io_event>    completed;      // retired events awaiting io_getevents
+};
+
+// Run one iocb to completion and record its io_event.  Executed on a worker
+// thread so the submitting thread returns immediately.
+static void libaio_run_one(struct io_context *ctx, struct iocb *cb)
+{
+    int64_t res;
+    struct file *fp = nullptr;
+
+    if (fget(cb->aio_fildes, &fp) != 0) {
+        res = -EBADF;
+    } else {
+        size_t done = 0;
+        int error = 0;
+        switch (cb->aio_lio_opcode) {
+        case IO_CMD_PREAD: {
+            struct iovec iov { reinterpret_cast<void*>(cb->aio_buf),
+                               static_cast<size_t>(cb->aio_nbytes) };
+            error = sys_read(fp, &iov, 1, cb->aio_offset, &done);
+            break;
+        }
+        case IO_CMD_PWRITE: {
+            struct iovec iov { reinterpret_cast<void*>(cb->aio_buf),
+                               static_cast<size_t>(cb->aio_nbytes) };
+            error = sys_write(fp, &iov, 1, cb->aio_offset, &done);
+            break;
+        }
+        case IO_CMD_PREADV:
+            error = sys_read(fp, reinterpret_cast<struct iovec*>(cb->aio_buf),
+                             cb->aio_nbytes, cb->aio_offset, &done);
+            break;
+        case IO_CMD_PWRITEV:
+            error = sys_write(fp, reinterpret_cast<struct iovec*>(cb->aio_buf),
+                              cb->aio_nbytes, cb->aio_offset, &done);
+            break;
+        case IO_CMD_FSYNC:
+        case IO_CMD_FDSYNC:
+            error = sys_fsync(fp);
+            done = 0;
+            break;
+        case IO_CMD_NOOP:
+            error = 0;
+            done = 0;
+            break;
+        default:
+            error = EINVAL;
+            break;
+        }
+        res = error ? -error : static_cast<int64_t>(done);
+        fdrop(fp);
+    }
+
+    io_event ev {};
+    ev.data = cb->aio_data;
+    ev.obj  = reinterpret_cast<uint64_t>(cb);
+    ev.res  = res;
+    ev.res2 = 0;
+
+    WITH_LOCK(ctx->mtx) {
+        ctx->completed.push_back(ev);
+        ctx->inflight--;
+        ctx->cv.wake_all();
+    }
+
+    // Best-effort eventfd notification if the iocb asked for one.
+    if (cb->aio_flags & IOCB_FLAG_RESFD) {
+        uint64_t val = 1;
+        (void)::write(cb->aio_resfd, &val, sizeof(val));
+    }
+}
 
 OSV_LIBAIO_API
-int io_setup(int nr_events, io_context_t *ctxp_idp) {
-    // This is a stub that doesn't actually do anything. If the caller tries
-    // to follow the io_setup() call with any other libaio call, those will
-    // fail.
-    WARN_STUBBED();
-    if (nr_events < 0) {
+int io_setup(int nr_events, io_context_t *ctxp)
+{
+    if (!ctxp) {
+        return -EFAULT;
+    }
+    // Linux requires a positive event capacity; a zero/negative nr_events is
+    // EINVAL (a zero cap would otherwise mean "unbounded", allowing unbounded
+    // worker-thread creation).
+    if (nr_events <= 0) {
         return -EINVAL;
     }
+    auto *ctx = new (std::nothrow) io_context;
+    if (!ctx) {
+        return -ENOMEM;
+    }
+    ctx->max_events = nr_events;
+    *ctxp = ctx;
     return 0;
 }
 
-UNIMPL(OSV_LIBAIO_API int io_submit(io_context_t ctx, long nr, struct iocb *ios[]))
-UNIMPL(OSV_LIBAIO_API int io_getevents(io_context_t ctx_id, long min_nr, long nr,
-        struct io_event *events, struct timespec *timeout))
-UNIMPL(OSV_LIBAIO_API int io_destroy(io_context_t ctx))
-UNIMPL(OSV_LIBAIO_API int io_cancel(io_context_t ctx, struct iocb *iocb, struct io_event *evt))
+OSV_LIBAIO_API
+int io_submit(io_context_t ctx, long nr, struct iocb *ios[])
+{
+    if (!ctx || nr < 0) {
+        return -EINVAL;
+    }
+    if (nr == 0) {
+        return 0;
+    }
+    if (!ios) {
+        return -EFAULT;
+    }
+
+    long submitted = 0;
+    for (long i = 0; i < nr; i++) {
+        struct iocb *cb = ios[i];
+        if (!cb) {
+            // A null iocb in the batch: report EFAULT if nothing was accepted,
+            // else return the partial count already submitted (Linux-style).
+            return submitted > 0 ? submitted : -EFAULT;
+        }
+        sched::thread *w;
+        WITH_LOCK(ctx->mtx) {
+            if (ctx->destroying) {
+                break;
+            }
+            // Respect the context's in-flight capacity.  If we already accepted
+            // at least one op, return the partial count (Linux does the same);
+            // otherwise signal EAGAIN.
+            if (ctx->max_events && ctx->inflight >= ctx->max_events) {
+                if (submitted > 0) {
+                    return submitted;
+                }
+                return -EAGAIN;
+            }
+            // one detached worker thread per iocb.  Simple and correct; if a
+            // caller submits huge batches and thread-create cost shows up, swap
+            // in a bounded worker pool like core/io_uring.cc's.
+            // TODO: bounded worker pool if batch thread-create cost matters.
+            w = sched::thread::make([ctx, cb]() { libaio_run_one(ctx, cb); },
+                    sched::thread::attr().detached().name("libaio"));
+            if (!w) {
+                // Thread allocation failed: do not count it as inflight (that
+                // would make io_destroy() wait forever).
+                return submitted > 0 ? submitted : -EAGAIN;
+            }
+            ctx->inflight++;
+        }
+        w->start();
+        submitted++;
+    }
+    return submitted > 0 ? submitted : -EINVAL;
+}
+
+OSV_LIBAIO_API
+int io_getevents(io_context_t ctx, long min_nr, long nr,
+        struct io_event *events, struct timespec *timeout)
+{
+    if (!ctx || min_nr < 0 || nr < 0 || min_nr > nr) {
+        return -EINVAL;
+    }
+    if (nr == 0) {
+        return 0;
+    }
+    if (!events) {
+        return -EFAULT;
+    }
+
+    // Compute an absolute deadline from the (relative) timeout, if any.
+    bool have_deadline = timeout != nullptr;
+    if (have_deadline && (timeout->tv_sec < 0 || timeout->tv_nsec < 0 ||
+                          timeout->tv_nsec >= 1000000000L)) {
+        return -EINVAL;
+    }
+    auto deadline = osv::clock::uptime::now();
+    if (have_deadline) {
+        deadline += std::chrono::seconds(timeout->tv_sec) +
+                    std::chrono::nanoseconds(timeout->tv_nsec);
+    }
+
+    long collected = 0;
+    WITH_LOCK(ctx->mtx) {
+        ctx->waiters++;
+        while (collected < nr && !ctx->destroying) {
+            while (!ctx->completed.empty() && collected < nr) {
+                events[collected++] = ctx->completed.front();
+                ctx->completed.pop_front();
+            }
+            if (collected >= min_nr) {
+                break;     // satisfied the caller's minimum
+            }
+            if (have_deadline) {
+                if (ctx->cv.wait(&ctx->mtx, deadline) != 0) {
+                    break; // timed out
+                }
+            } else {
+                ctx->cv.wait(ctx->mtx);
+            }
+        }
+        // Let a concurrent io_destroy() know we have stopped touching ctx.
+        if (--ctx->waiters == 0) {
+            ctx->cv.wake_all();
+        }
+    }
+    return collected;
+}
+
+OSV_LIBAIO_API
+int io_destroy(io_context_t ctx)
+{
+    if (!ctx) {
+        return -EINVAL;
+    }
+    WITH_LOCK(ctx->mtx) {
+        ctx->destroying = true;
+        // Wake any thread parked in io_getevents() so it observes destroying
+        // and stops touching ctx.
+        ctx->cv.wake_all();
+        // Wait for all in-flight ops to retire AND for every io_getevents()
+        // waiter to leave, so no worker or waiter still references ctx once we
+        // free it (each worker is detached and self-reaps).
+        while (ctx->inflight > 0 || ctx->waiters > 0) {
+            ctx->cv.wait(ctx->mtx);
+        }
+    }
+    delete ctx;
+    return 0;
+}
+
+OSV_LIBAIO_API
+int io_cancel(io_context_t ctx, struct iocb *iocb, struct io_event *evt)
+{
+    // An op is executed on a worker thread that runs the blocking VFS call to
+    // completion; there is no safe mid-flight cancellation point, so report
+    // EINVAL (a valid Linux response when the op cannot be cancelled).
+    (void)ctx; (void)iocb; (void)evt;
+    return -EINVAL;
+}

--- a/include/api/libaio.h
+++ b/include/api/libaio.h
@@ -6,16 +6,66 @@
  */
 
 // This is the Linux-specific asynchronous I/O API / ABI from libaio.
-// Note that this API is different the Posix AIO API.
+// Note that this API is different from the POSIX AIO API.
 
 #ifndef INCLUDED_LIBAIO_H
 #define INCLUDED_LIBAIO_H
+
+#include <stdint.h>
+#include <time.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 typedef struct io_context *io_context_t;
+
+// Command opcodes, matching the Linux aio ABI (linux/aio_abi.h).
+typedef enum io_iocb_cmd {
+    IO_CMD_PREAD   = 0,
+    IO_CMD_PWRITE  = 1,
+    IO_CMD_FSYNC   = 2,
+    IO_CMD_FDSYNC  = 3,
+    IO_CMD_POLL    = 5,
+    IO_CMD_NOOP    = 6,
+    IO_CMD_PREADV  = 7,
+    IO_CMD_PWRITEV = 8,
+} io_iocb_cmd_t;
+
+// read() from an aio context returns these; also filled by io_getevents().
+struct io_event {
+    uint64_t data;   // the aio_data field copied from the iocb
+    uint64_t obj;    // pointer to the iocb this event came from
+    int64_t  res;    // primary result (bytes transferred, or -errno)
+    int64_t  res2;   // secondary result (unused, always 0 here)
+};
+
+// The iocb layout matches the Linux aio ABI (64 bytes on x86-64/aarch64).  We
+// use the same field split as libaio's <libaio.h> so binaries built against it
+// interoperate: the first union member exposes the common PREAD/PWRITE fields.
+struct iocb {
+    uint64_t aio_data;         // returned in io_event.data
+
+    // aio_key/aio_rw_flags on little-endian.  We do not consume these.
+    uint32_t aio_key;
+    int32_t  aio_rw_flags;
+
+    uint16_t aio_lio_opcode;   // IO_CMD_*
+    int16_t  aio_reqprio;
+    uint32_t aio_fildes;
+
+    uint64_t aio_buf;          // buffer (PREAD/PWRITE) or iovec* (PREADV/PWRITEV)
+    uint64_t aio_nbytes;       // byte count, or iovec count for the V variants
+    int64_t  aio_offset;       // file offset
+
+    uint64_t aio_reserved2;
+
+    uint32_t aio_flags;        // IOCB_FLAG_*
+    uint32_t aio_resfd;        // eventfd when IOCB_FLAG_RESFD is set
+};
+
+#define IOCB_FLAG_RESFD  (1 << 0)
+#define IOCB_FLAG_IOPRIO (1 << 1)
 
 int io_setup(int nr_events, io_context_t *ctxp_idp);
 int io_submit(io_context_t ctx, long nr, struct iocb *ios[]);

--- a/modules/tests/Makefile
+++ b/modules/tests/Makefile
@@ -193,6 +193,8 @@ endif
 
 tests += testrunner.so
 
+tests += tst-libaio.so
+
 # Tests with special compilation parameters needed...
 $(out)/tests/tst-mmap.so: COMMON += -Wl,-z,now
 $(out)/tests/tst-elf-permissions.so: COMMON += -Wl,-z,relro

--- a/tests/tst-libaio.cc
+++ b/tests/tst-libaio.cc
@@ -1,0 +1,191 @@
+/*
+ * Copyright (C) 2026 Greg Burd
+ *
+ * This work is open source software, licensed under the terms of the
+ * BSD license as described in the LICENSE file in the top-level directory.
+ */
+
+// Exercises the Linux libaio interface (io_setup/io_submit/io_getevents/
+// io_destroy/io_cancel) implemented in core/libaio.cc.  This test targets
+// OSv's <libaio.h> ABI (flat struct iocb with aio_* fields); it is built and
+// run as part of the OSv test image.
+
+#include <libaio.h>
+
+#include <unistd.h>
+#include <fcntl.h>
+#include <string.h>
+#include <stdlib.h>
+#include <errno.h>
+
+#include <cassert>
+#include <cstdint>
+#include <iostream>
+
+// Helpers matching the fields libaio's io_prep_* would set.
+static void prep_pwrite(struct iocb *cb, int fd, void *buf, size_t n, long long off)
+{
+    memset(cb, 0, sizeof(*cb));
+    cb->aio_lio_opcode = IO_CMD_PWRITE;
+    cb->aio_fildes = fd;
+    cb->aio_buf = reinterpret_cast<uint64_t>(buf);
+    cb->aio_nbytes = n;
+    cb->aio_offset = off;
+}
+
+static void prep_pread(struct iocb *cb, int fd, void *buf, size_t n, long long off)
+{
+    memset(cb, 0, sizeof(*cb));
+    cb->aio_lio_opcode = IO_CMD_PREAD;
+    cb->aio_fildes = fd;
+    cb->aio_buf = reinterpret_cast<uint64_t>(buf);
+    cb->aio_nbytes = n;
+    cb->aio_offset = off;
+}
+
+// Collect exactly n events, tolerating short io_getevents returns.
+static void get_n_events(io_context_t ctx, long n, struct io_event *evs)
+{
+    long got = 0;
+    while (got < n) {
+        int r = io_getevents(ctx, 1, n - got, evs + got, nullptr);
+        assert(r > 0);
+        got += r;
+    }
+}
+
+// A write followed by a read back should return the same bytes.
+static void test_write_read_roundtrip()
+{
+    char path[] = "/tmp/tst-libaio-XXXXXX";
+    int fd = mkstemp(path);
+    assert(fd >= 0);
+
+    const size_t N = 8192;
+    char *wbuf = static_cast<char *>(malloc(N));
+    char *rbuf = static_cast<char *>(malloc(N));
+    for (size_t i = 0; i < N; i++) {
+        wbuf[i] = static_cast<char>((i * 13 + 5) & 0xff);
+    }
+    memset(rbuf, 0, N);
+
+    io_context_t ctx = nullptr;
+    assert(io_setup(8, &ctx) == 0);
+
+    // Submit the write.
+    struct iocb cbw;
+    prep_pwrite(&cbw, fd, wbuf, N, 0);
+    cbw.aio_data = 0x1111;
+    struct iocb *pw = &cbw;
+    assert(io_submit(ctx, 1, &pw) == 1);
+
+    struct io_event ev;
+    get_n_events(ctx, 1, &ev);
+    assert(ev.res == (long)N);        // all bytes written
+    assert(ev.data == 0x1111);        // aio_data echoed back
+    assert(ev.obj == reinterpret_cast<uint64_t>(&cbw));
+
+    // Now read it back.
+    struct iocb cbr;
+    prep_pread(&cbr, fd, rbuf, N, 0);
+    cbr.aio_data = 0x2222;
+    struct iocb *pr = &cbr;
+    assert(io_submit(ctx, 1, &pr) == 1);
+    get_n_events(ctx, 1, &ev);
+    assert(ev.res == (long)N);
+    assert(ev.data == 0x2222);
+    assert(memcmp(wbuf, rbuf, N) == 0);
+
+    assert(io_destroy(ctx) == 0);
+    free(wbuf);
+    free(rbuf);
+    close(fd);
+    unlink(path);
+}
+
+// Submit several ops at once and collect all their completions.
+static void test_batch()
+{
+    char path[] = "/tmp/tst-libaio-batch-XXXXXX";
+    int fd = mkstemp(path);
+    assert(fd >= 0);
+
+    io_context_t ctx = nullptr;
+    assert(io_setup(16, &ctx) == 0);
+
+    const int B = 8;
+    const size_t N = 4096;
+    char *bufs[B];
+    struct iocb cbs[B];
+    struct iocb *ps[B];
+    for (int i = 0; i < B; i++) {
+        bufs[i] = static_cast<char *>(malloc(N));
+        memset(bufs[i], 'A' + i, N);
+        prep_pwrite(&cbs[i], fd, bufs[i], N, (long long)i * N);
+        cbs[i].aio_data = 0x100 + i;
+        ps[i] = &cbs[i];
+    }
+    assert(io_submit(ctx, B, ps) == B);
+
+    struct io_event evs[B];
+    get_n_events(ctx, B, evs);
+    long total = 0;
+    for (int i = 0; i < B; i++) {
+        assert(evs[i].res == (long)N);
+        total += evs[i].res;
+    }
+    assert(total == (long)(B * N));
+
+    assert(io_destroy(ctx) == 0);
+    for (int i = 0; i < B; i++) {
+        free(bufs[i]);
+    }
+    close(fd);
+    unlink(path);
+}
+
+// A bad fd must surface as -EBADF in the event's res, not a crash.
+static void test_bad_fd()
+{
+    io_context_t ctx = nullptr;
+    assert(io_setup(4, &ctx) == 0);
+
+    char buf[512];
+    struct iocb cb;
+    prep_pread(&cb, 987654, buf, sizeof(buf), 0);  // fd not open
+    struct iocb *p = &cb;
+    assert(io_submit(ctx, 1, &p) == 1);
+
+    struct io_event ev;
+    get_n_events(ctx, 1, &ev);
+    assert(ev.res == -EBADF);
+
+    assert(io_destroy(ctx) == 0);
+}
+
+// io_getevents with a timeout must return 0 when nothing is pending.
+static void test_getevents_timeout()
+{
+    io_context_t ctx = nullptr;
+    assert(io_setup(4, &ctx) == 0);
+
+    struct io_event ev;
+    struct timespec ts { 0, 50 * 1000 * 1000 };  // 50 ms
+    int r = io_getevents(ctx, 1, 1, &ev, &ts);
+    assert(r == 0);  // timed out with no events
+
+    assert(io_destroy(ctx) == 0);
+}
+
+int main()
+{
+    std::cerr << "Running libaio tests\n";
+
+    test_write_read_roundtrip();
+    test_batch();
+    test_bad_fd();
+    test_getevents_timeout();
+
+    std::cerr << "libaio tests PASSED\n";
+    return 0;
+}


### PR DESCRIPTION
## What

Implements the Linux async I/O interface (libaio), which was a latent crash
hazard. `io_setup()` returned success, but `io_submit()`, `io_getevents()`,
`io_destroy()` and `io_cancel()` were `UNIMPL()` stubs that called `abort()`. A
program that probed libaio, saw `io_setup()` succeed, and then submitted any I/O
would take down the whole unikernel.

## How

OSv has no user/kernel boundary, so "async" I/O is done the same way
`core/io_uring.cc` does it: each submitted iocb runs on a short-lived detached
worker thread that performs the blocking read/write/fsync through the VFS
(`sys_read`/`sys_write`/`sys_fsync`, the same primitives io_uring uses), then
queues an `io_event` and wakes any thread parked in `io_getevents()`.

- `io_setup()`: allocate a real `io_context` capped at `nr_events` in-flight ops.
- `io_submit()`: dispatch each iocb to a detached worker; honor the in-flight cap
  (partial count if some were accepted, otherwise `EAGAIN`, matching Linux).
  Supports `PREAD`, `PWRITE`, `PREADV`, `PWRITEV`, `FSYNC`, `FDSYNC`, `NOOP`;
  unknown opcodes complete with `res == -EINVAL` rather than aborting.
- `io_getevents()`: block until `min_nr` events are available or the optional
  timeout elapses, then copy out up to `nr` events. A bad fd surfaces as
  `res == -EBADF` in the event, not a crash.
- `io_destroy()`: mark the context draining and wait for all in-flight ops to
  retire (detached workers self-reap) before freeing, so no worker can touch a
  freed context.
- `io_cancel()`: return `EINVAL`. Ops run to completion on a worker with no safe
  mid-flight cancellation point; `EINVAL` is a valid Linux response.

Best-effort eventfd notification is delivered when an iocb sets
`IOCB_FLAG_RESFD`.

`include/api/libaio.h` is filled in with the real Linux aio ABI (`struct iocb`,
`struct io_event`, `IO_CMD_*` opcodes, `IOCB_FLAG_*`), which was previously only
forward-declared.

## Testing

`tests/tst-libaio.cc` covers the write/read round-trip (data and `aio_data`
echo), an 8-op batch, bad-fd (`-EBADF`, no abort), and the `io_getevents`
timeout path. It passes on OSv under KVM on both single- and multi-vCPU
configurations.

## Note

This is a self-contained worker-thread-per-iocb design, which is simple and
correct for typical libaio concurrency. If a caller submits very large batches
and thread-creation cost shows up, the worker loop can be swapped for a bounded
pool like the one in `core/io_uring.cc`; that is left as a follow-up.


_(Recreated from #1413, which GitHub auto-closed when its branch was rebased onto current master. Same change, rebased and verified on master 3aba46ca.)_
