### PR TITLE
mm: implement the membarrier(2) syscall

### DIFF
--- a/exported_symbols/osv_ld-musl.so.1.symbols
+++ b/exported_symbols/osv_ld-musl.so.1.symbols
@@ -631,6 +631,7 @@ mbsrtowcs
 mbstowcs
 mbtowc
 memalign
+membarrier
 memccpy
 memchr
 memcmp

--- a/exported_symbols/osv_libc.so.6.symbols
+++ b/exported_symbols/osv_libc.so.6.symbols
@@ -521,6 +521,7 @@ mbstowcs
 mbtowc
 memalign
 __memalign_hook
+membarrier
 memccpy
 memchr
 memcmp

--- a/include/api/sys/membarrier.h
+++ b/include/api/sys/membarrier.h
@@ -1,0 +1,33 @@
+#ifndef _SYS_MEMBARRIER_H
+#define _SYS_MEMBARRIER_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Commands for the membarrier(2) system call (see linux/membarrier.h). */
+enum membarrier_cmd {
+	MEMBARRIER_CMD_QUERY				= 0,
+	MEMBARRIER_CMD_GLOBAL				= (1 << 0),
+	MEMBARRIER_CMD_GLOBAL_EXPEDITED			= (1 << 1),
+	MEMBARRIER_CMD_REGISTER_GLOBAL_EXPEDITED	= (1 << 2),
+	MEMBARRIER_CMD_PRIVATE_EXPEDITED		= (1 << 3),
+	MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED	= (1 << 4),
+	MEMBARRIER_CMD_PRIVATE_EXPEDITED_SYNC_CORE	= (1 << 5),
+	MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED_SYNC_CORE = (1 << 6),
+	MEMBARRIER_CMD_PRIVATE_EXPEDITED_RSEQ		= (1 << 7),
+	MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED_RSEQ	= (1 << 8),
+	MEMBARRIER_CMD_SHARED				= MEMBARRIER_CMD_GLOBAL,
+};
+
+enum membarrier_cmd_flag {
+	MEMBARRIER_CMD_FLAG_CPU		= (1 << 0),
+};
+
+int membarrier(int cmd, unsigned int flags, int cpu_id);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _SYS_MEMBARRIER_H */

--- a/include/api/x64/bits/syscall.h
+++ b/include/api/x64/bits/syscall.h
@@ -313,6 +313,7 @@
 #define __NR_kcmp				312
 #define __NR_finit_module			313
 #define __NR_getrandom				318
+#define __NR_membarrier				324
 #define __NR_statx				332
 
 #undef __NR_fstatat
@@ -643,6 +644,7 @@
 #define SYS_process_vm_writev			311
 #define SYS_kcmp				312
 #define SYS_finit_module			313
+#define SYS_membarrier				324
 #define SYS_statx				332
 #define SYS_io_uring_setup			425
 #define SYS_io_uring_enter			426

--- a/linux.cc
+++ b/linux.cc
@@ -70,6 +70,7 @@ extern "C" int eventfd2(unsigned int, int);
 extern "C" int osv_sigtimedwait(const sigset_t *, siginfo_t *, const struct timespec *);
 extern "C" int epoll_pwait2(int epfd, struct epoll_event *events, int maxevents,
             const struct timespec *timeout, const sigset_t *sigmask);
+extern "C" int membarrier(int cmd, unsigned int flags, int cpu_id);
 
 extern "C" OSV_LIBC_API long gettid()
 {

--- a/modules/tests/Makefile
+++ b/modules/tests/Makefile
@@ -126,6 +126,7 @@ tests := tst-pthread.so misc-ramdisk.so tst-vblk.so tst-mq-smoke.so tst-bsd-evh.
 	tst-epoll-pwait2.so \
 	tst-prctl.so \
 	tst-mmap-file-cow.so \
+	tst-membarrier.so \
 	tst-elf-permissions.so misc-mutex.so misc-sockets.so tst-condvar.so \
 	tst-queue-mpsc.so tst-af-local.so tst-pipe.so tst-yield.so \
 	misc-ctxsw.so tst-read.so tst-symlink.so tst-openat.so \

--- a/runtime.cc
+++ b/runtime.cc
@@ -43,6 +43,8 @@
 #include <osv/power.hh>
 #include <sys/time.h>
 #include <osv/mmu.hh>
+#include <atomic>
+#include <sys/membarrier.h>
 #include "libc/libc.hh"
 #include <api/sys/times.h>
 #include <map>
@@ -257,6 +259,54 @@ int munlock(const void*, size_t)
 {
     WARN_STUBBED();
     return 0;
+}
+
+// membarrier(2).  OSv is a single process whose threads share one address
+// space, so a "global" and a "private" barrier are equivalent here.  We
+// implement the expedited barrier by forcing every other CPU through an IPI
+// (mmu::flush_tlb_all() broadcasts an IPI and waits for each CPU to run its
+// handler; taking and returning from an interrupt is a context-synchronizing,
+// full-barrier event on that CPU on both x86-64 and aarch64) plus a local
+// seq_cst fence.  This is a correct superset of what membarrier promises (it
+// also flushes TLBs, which is harmless).  Non-expedited GLOBAL degrades to the
+// same.
+//
+// Note: reuses the proven, arch-portable flush_tlb_all() broadcast rather than
+// adding a dedicated membarrier IPI (which would be per-arch, x64
+// inter_processor_interrupt vs aarch64 sgi_interrupt).  Add a lighter dedicated
+// IPI only if membarrier ever shows up hot in a profile.
+OSV_LIBC_API
+int membarrier(int cmd, unsigned int flags, int cpu_id)
+{
+    // We do not implement the SYNC_CORE / RSEQ / CPU-flag variants.  flags and
+    // cpu_id must be 0: cpu_id is only meaningful with MEMBARRIER_CMD_FLAG_CPU
+    // (a flag we reject), so a nonzero cpu_id here is an invalid request.
+    if (flags != 0 || cpu_id != 0) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    switch (cmd) {
+    case MEMBARRIER_CMD_QUERY:
+        // Report the commands we support.
+        return MEMBARRIER_CMD_GLOBAL | MEMBARRIER_CMD_GLOBAL_EXPEDITED |
+               MEMBARRIER_CMD_REGISTER_GLOBAL_EXPEDITED |
+               MEMBARRIER_CMD_PRIVATE_EXPEDITED |
+               MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED;
+    case MEMBARRIER_CMD_REGISTER_GLOBAL_EXPEDITED:
+    case MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED:
+        // Registration is a no-op: any thread may issue the barrier.
+        return 0;
+    case MEMBARRIER_CMD_GLOBAL:
+    case MEMBARRIER_CMD_GLOBAL_EXPEDITED:
+    case MEMBARRIER_CMD_PRIVATE_EXPEDITED:
+        std::atomic_thread_fence(std::memory_order_seq_cst);
+        mmu::flush_tlb_all();
+        return 0;
+    default:
+        errno = EINVAL;
+        return -1;
+    }
 }
 
 NO_SYS(OSV_LIBC_API int mkfifo(const char*, mode_t));

--- a/syscalls/syscall_tracepoints.cc.in
+++ b/syscalls/syscall_tracepoints.cc.in
@@ -72,6 +72,7 @@ TRACEPOINT(trace_syscall_epoll_pwait, "%d <= %d %p %d %d %p", int, int, struct e
 TRACEPOINT(trace_syscall_epoll_pwait2, "%d <= %d %p %d %p %p", int, int, struct epoll_event *, int, const struct timespec *, const sigset_t*);
 #endif
 TRACEPOINT(trace_syscall_getrandom, "%lu <= 0x%x %lu %u", ssize_t, char *, size_t, unsigned int);
+TRACEPOINT(trace_syscall_membarrier, "%d <= %d %u %d", int, int, unsigned int, int);
 TRACEPOINT(trace_syscall_nanosleep, "%d <= %p %p", int, const struct timespec*, struct timespec *);
 TRACEPOINT(trace_syscall_fstatat, "%d <= %d \"%s\" %p 0%0o", int, int, const char *, struct stat *, int);
 TRACEPOINT(trace_syscall_sys_exit_group, "%d <= %d", int, int);

--- a/syscalls/syscalls.cc.in
+++ b/syscalls/syscalls.cc.in
@@ -72,6 +72,7 @@
     SYSCALL5(epoll_pwait2, int, struct epoll_event *, int, const struct timespec *, const sigset_t*);
 #endif
     SYSCALL3(getrandom, char *, size_t, unsigned int);
+    SYSCALL3(membarrier, int, unsigned int, int);
     SYSCALL2(nanosleep, const struct timespec*, struct timespec *);
     SYSCALL4(fstatat, int, const char *, struct stat *, int);
     SYSCALL1(sys_exit_group, int);

--- a/tests/tst-membarrier.cc
+++ b/tests/tst-membarrier.cc
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2026 Greg Burd
+ *
+ * This work is open source software, licensed under the terms of the
+ * BSD license as described in the LICENSE file in the top-level directory.
+ */
+
+// Exercises the membarrier(2) syscall implemented in runtime.cc.
+// Built and run as part of the OSv test image.
+
+#include <sys/membarrier.h>
+
+#include <errno.h>
+
+#include <cassert>
+#include <iostream>
+
+static void test_membarrier()
+{
+    // QUERY reports a nonzero mask of supported commands.
+    int supported = membarrier(MEMBARRIER_CMD_QUERY, 0, 0);
+    assert(supported > 0);
+    assert(supported & MEMBARRIER_CMD_GLOBAL);
+    assert(supported & MEMBARRIER_CMD_PRIVATE_EXPEDITED);
+
+    // Registration is accepted.
+    assert(membarrier(MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED, 0, 0) == 0);
+    assert(membarrier(MEMBARRIER_CMD_REGISTER_GLOBAL_EXPEDITED, 0, 0) == 0);
+
+    // The actual barriers succeed (these broadcast an IPI to all other CPUs).
+    assert(membarrier(MEMBARRIER_CMD_GLOBAL, 0, 0) == 0);
+    assert(membarrier(MEMBARRIER_CMD_GLOBAL_EXPEDITED, 0, 0) == 0);
+    assert(membarrier(MEMBARRIER_CMD_PRIVATE_EXPEDITED, 0, 0) == 0);
+
+    // Unknown command and nonzero flags are rejected with EINVAL.
+    errno = 0;
+    assert(membarrier(0x40000000, 0, 0) == -1 && errno == EINVAL);
+    errno = 0;
+    assert(membarrier(MEMBARRIER_CMD_GLOBAL, 0x1, 0) == -1 && errno == EINVAL);
+    // A nonzero cpu_id is only valid with the (unsupported) CPU flag -> EINVAL.
+    errno = 0;
+    assert(membarrier(MEMBARRIER_CMD_GLOBAL, 0, 1) == -1 && errno == EINVAL);
+}
+
+int main()
+{
+    std::cerr << "Running membarrier tests\n";
+    test_membarrier();
+    std::cerr << "membarrier tests PASSED\n";
+    return 0;
+}


### PR DESCRIPTION
## What

Implements the `membarrier(2)` syscall, which was missing entirely (not in the
syscall table, no libc entry, no prototype). Runtimes that use it for cheap
asymmetric synchronization (Go, .NET, some JVMs, RCU-style user libraries) could
not use it on OSv.

## How

OSv is a single process whose threads all share one address space, so a "global"
and a "private" membarrier are equivalent here. The expedited barrier forces
every other CPU through an IPI: `mmu::flush_tlb_all()` already broadcasts an IPI
and waits for each CPU to run its handler (a full memory barrier on that CPU),
and we add a local `seq_cst` fence. This is a correct superset of what
membarrier promises (it also flushes TLBs, which is harmless), and reuses a
proven, arch-portable primitive rather than adding a dedicated per-arch IPI (x64
`inter_processor_interrupt` vs aarch64 `sgi_interrupt`). A lighter dedicated IPI
can replace it if membarrier ever shows up hot in a profile.

- `MEMBARRIER_CMD_QUERY` returns the supported command mask.
- `REGISTER_{GLOBAL,PRIVATE}_EXPEDITED` are accepted as no-ops (any thread may
  issue the barrier).
- `{GLOBAL, GLOBAL_EXPEDITED, PRIVATE_EXPEDITED}` run the barrier.
- `SYNC_CORE` / `RSEQ` / CPU-flag variants and unknown commands return `EINVAL`,
  as does a nonzero `flags` argument.

Wired as syscall `SYS_membarrier` (adding `__NR_membarrier` / `SYS_membarrier`
for x86-64) with a tracepoint, plus the `sys/membarrier.h` header with the
command enum and prototype, and the symbol exported from `libc.so.6` and
`ld-musl.so.1`.

## Testing

`tests/tst-membarrier.cc` covers QUERY, register, the three barrier commands,
and the EINVAL paths. Passes on OSv under KVM with 1, 2 and 4 vCPUs (exercising
the cross-CPU IPI broadcast).


_(Recreated from #1414, which GitHub auto-closed when its branch was rebased onto current master. Same change, rebased and verified on master 3aba46ca.)_
