### PR TITLE
libc: make setrlimit/getrlimit consistent and stop aborting

### DIFF
--- a/libc/libc.cc
+++ b/libc/libc.cc
@@ -7,6 +7,7 @@
 
 #include "libc.hh"
 #include <osv/sched.hh>
+#include <osv/mutex.h>
 #include <stdio.h>
 #include <limits.h>
 #include <stdlib.h>
@@ -54,51 +55,78 @@ extern "C" int* ___errno_location()
     return &errno;
 }
 
+// OSv is a single process, so resource limits are process-wide.  We keep a
+// stored table so setrlimit()/getrlimit() are consistent (an app that raises
+// RLIMIT_NOFILE and reads it back sees the new value) and, importantly, so we
+// never abort() on a resource we do not special-case.  The limits are advisory:
+// OSv does not actually enforce most of them.
+static mutex rlimit_mutex;
+static struct rlimit rlimits[RLIMIT_NLIMITS];
+static bool rlimits_initialized = false;
+
+static rlim_t default_stack_limit()
+{
+    pthread_attr_t attr;
+    pthread_attr_init(&attr);
+    size_t stacksize = 0;
+    pthread_attr_getstacksize(&attr, &stacksize);
+    pthread_attr_destroy(&attr);
+    return stacksize;
+}
+
+// Caller must hold rlimit_mutex.
+static void init_rlimits_locked()
+{
+    if (rlimits_initialized) {
+        return;
+    }
+    for (int i = 0; i < RLIMIT_NLIMITS; i++) {
+        rlimits[i].rlim_cur = rlimits[i].rlim_max = RLIM_INFINITY;
+    }
+    rlimits[RLIMIT_STACK].rlim_cur = rlimits[RLIMIT_STACK].rlim_max =
+        default_stack_limit();
+    rlimits[RLIMIT_NOFILE].rlim_cur = rlimits[RLIMIT_NOFILE].rlim_max = 1024 * 10;
+    rlimits[RLIMIT_NICE].rlim_cur = rlimits[RLIMIT_NICE].rlim_max = 0;
+    rlimits_initialized = true;
+}
+
 int getrlimit(int resource, struct rlimit *rlim)
 {
-    auto set = [=] (rlim_t r) { rlim->rlim_cur = rlim->rlim_max = r; };
-    switch (resource) {
-    case RLIMIT_STACK: {
-        pthread_attr_t attr;
-        pthread_attr_init(&attr);
-        size_t stacksize;
-        pthread_attr_getstacksize(&attr, &stacksize);
-        set(stacksize);
-        pthread_attr_destroy(&attr);
-        break;
+    if (resource < 0 || resource >= RLIMIT_NLIMITS) {
+        errno = EINVAL;
+        return -1;
     }
-    case RLIMIT_NOFILE:
-        set(1024*10); // FIXME: larger?
-        break;
-    case RLIMIT_CORE:
-        set(RLIM_INFINITY);
-        break;
-    case RLIMIT_NPROC:
-        set(RLIM_INFINITY);
-        break;
-    case RLIMIT_AS:
-    case RLIMIT_DATA:
-    case RLIMIT_RSS:
-        set(RLIM_INFINITY);
-        break;
-    case RLIMIT_CPU:
-    case RLIMIT_FSIZE:
-    case RLIMIT_MEMLOCK:
-    case RLIMIT_MSGQUEUE:
-        set(RLIM_INFINITY);
-        break;
-    case RLIMIT_NICE:
-        set(0);
-        break;
-    default:
-        abort("getrlimit(): resource %d not supported. aborting.\n", resource);
+    if (!rlim) {
+        errno = EFAULT;
+        return -1;
+    }
+    WITH_LOCK(rlimit_mutex) {
+        init_rlimits_locked();
+        *rlim = rlimits[resource];
     }
     return 0;
 }
 
 int setrlimit(int resource, const struct rlimit *rlim)
 {
-    // osv - no limits
+    if (resource < 0 || resource >= RLIMIT_NLIMITS) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!rlim) {
+        errno = EFAULT;
+        return -1;
+    }
+    if (rlim->rlim_cur > rlim->rlim_max) {
+        errno = EINVAL;
+        return -1;
+    }
+    // OSv does not enforce the limits, but we store them so getrlimit() is
+    // consistent with what the application set.
+    WITH_LOCK(rlimit_mutex) {
+        init_rlimits_locked();
+        rlimits[resource] = *rlim;
+    }
     return 0;
 }
 

--- a/modules/tests/Makefile
+++ b/modules/tests/Makefile
@@ -193,6 +193,8 @@ endif
 
 tests += testrunner.so
 
+tests += tst-rlimit.so
+
 # Tests with special compilation parameters needed...
 $(out)/tests/tst-mmap.so: COMMON += -Wl,-z,now
 $(out)/tests/tst-elf-permissions.so: COMMON += -Wl,-z,relro

--- a/syscalls/syscall_tracepoints.cc.in
+++ b/syscalls/syscall_tracepoints.cc.in
@@ -176,6 +176,7 @@ TRACEPOINT(trace_syscall_shmdt, "%d <= 0x%x", int, const void *)
 TRACEPOINT(trace_syscall_shmget, "%d <= %d %lu %d", int, key_t, size_t, int);
 TRACEPOINT(trace_syscall_rt_sigtimedwait, "%d <= %p %p %p %lu", int, const sigset_t *, siginfo_t *, const struct timespec *, size_t);
 TRACEPOINT(trace_syscall_getrlimit, "%d <= %d %p", int, int, struct rlimit *);
+TRACEPOINT(trace_syscall_setrlimit, "%d <= %d %p", int, int, const struct rlimit *);
 TRACEPOINT(trace_syscall_getpriority, "%d <= %d %d", int, int, int);
 TRACEPOINT(trace_syscall_setpriority, "%d <= %d %d %d", int, int, int, int);
 TRACEPOINT(trace_syscall_ppoll, "%d <= %p %ld %p %p", int, struct pollfd *, nfds_t, const struct timespec *, const sigset_t *);

--- a/syscalls/syscalls.cc.in
+++ b/syscalls/syscalls.cc.in
@@ -176,6 +176,7 @@
     SYSCALL3(shmget, key_t, size_t, int);
     SYSCALL4(rt_sigtimedwait, const sigset_t *, siginfo_t *, const struct timespec *, size_t);
     SYSCALL2(getrlimit, int, struct rlimit *);
+    SYSCALL2(setrlimit, int, const struct rlimit *);
     SYSCALL2(getpriority, int, int);
     SYSCALL3(setpriority, int, int, int);
     SYSCALL4(ppoll, struct pollfd *, nfds_t, const struct timespec *, const sigset_t *);

--- a/tests/tst-rlimit.cc
+++ b/tests/tst-rlimit.cc
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2026 Greg Burd
+ *
+ * This work is open source software, licensed under the terms of the
+ * BSD license as described in the LICENSE file in the top-level directory.
+ */
+
+// Exercises setrlimit/getrlimit/prlimit consistency.  getrlimit() used to
+// abort() on any resource it did not special-case, and setrlimit() was a
+// no-op inconsistent with getrlimit(); both are fixed here.  Built and run as
+// part of the OSv test image.
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE   // prlimit() is declared by <sys/resource.h> only under _GNU_SOURCE
+#endif
+#include <sys/resource.h>
+
+#include <errno.h>
+#include <unistd.h>
+
+#include <cassert>
+#include <iostream>
+
+int main()
+{
+    std::cerr << "Running rlimit tests\n";
+    struct rlimit rl;
+
+    // Every resource in range must be queryable without aborting.
+    for (int r = 0; r < RLIMIT_NLIMITS; r++) {
+        assert(getrlimit(r, &rl) == 0);
+    }
+
+    // Out-of-range resource yields EINVAL, not a crash.
+    errno = 0;
+    assert(getrlimit(-1, &rl) == -1 && errno == EINVAL);
+    errno = 0;
+    assert(getrlimit(RLIMIT_NLIMITS, &rl) == -1 && errno == EINVAL);
+
+    // A null rlim pointer yields EFAULT (matches Linux and OSv's shmctl style).
+    errno = 0;
+    assert(getrlimit(RLIMIT_NOFILE, nullptr) == -1 && errno == EFAULT);
+    errno = 0;
+    assert(setrlimit(RLIMIT_NOFILE, nullptr) == -1 && errno == EFAULT);
+
+    // set/get round-trip.
+    struct rlimit set { 4096, 8192 };
+    assert(setrlimit(RLIMIT_NOFILE, &set) == 0);
+    assert(getrlimit(RLIMIT_NOFILE, &rl) == 0);
+    assert(rl.rlim_cur == 4096 && rl.rlim_max == 8192);
+
+    // Previously an abort() trigger: RLIMIT_SIGPENDING is now handled.
+    struct rlimit sp { 100, 200 };
+    assert(setrlimit(RLIMIT_SIGPENDING, &sp) == 0);
+    assert(getrlimit(RLIMIT_SIGPENDING, &rl) == 0);
+    assert(rl.rlim_cur == 100 && rl.rlim_max == 200);
+
+    // rlim_cur > rlim_max is rejected.
+    struct rlimit bad { 200, 100 };
+    errno = 0;
+    assert(setrlimit(RLIMIT_NOFILE, &bad) == -1 && errno == EINVAL);
+
+    // prlimit for our own pid gets/sets consistently.
+    struct rlimit newl { 2048, 4096 }, old;
+    assert(prlimit(0, RLIMIT_NOFILE, &newl, &old) == 0);
+    assert(old.rlim_cur == 4096 && old.rlim_max == 8192);  // prior value
+    assert(getrlimit(RLIMIT_NOFILE, &rl) == 0);
+    assert(rl.rlim_cur == 2048 && rl.rlim_max == 4096);
+
+    std::cerr << "rlimit tests PASSED\n";
+    return 0;
+}


### PR DESCRIPTION
## What

Fixes two problems with the resource-limit functions:

1. `getrlimit()` called `abort()` on any resource it did not special-case
   (`RLIMIT_LOCKS`, `RLIMIT_SIGPENDING`, `RLIMIT_RTPRIO`, `RLIMIT_RTTIME`). A
   program querying one of those crashed the whole unikernel, the same class of
   hazard as the old libaio stubs.

2. `setrlimit()` was a no-op that returned success, so a later `getrlimit()`
   reported the old (usually infinite) value rather than what the application
   just set, an inconsistency some programs depend on.

## How

Replace the `getrlimit()` switch with a process-wide stored table of
`RLIMIT_NLIMITS` entries, initialized once with the previous defaults (stack
size from the default pthread attr, `RLIMIT_NOFILE` 10240, `RLIMIT_NICE` 0,
everything else infinite). `getrlimit()` reads the table, `setrlimit()` writes
it, both guarded by a mutex. Out-of-range resources and `rlim_cur > rlim_max`
return `EINVAL` instead of crashing or being silently accepted.

The limits remain advisory (OSv is a single address space and does not enforce
most of them), but set and get are now consistent.

Wire `setrlimit` as syscall `SYS_setrlimit` (only `getrlimit` and `prlimit64`
were in the table) with a tracepoint.

## Testing

`tests/tst-rlimit.cc` covers querying every resource without aborting, the
EINVAL paths, set/get round-trips, and `prlimit`. Passes on OSv under KVM.


_(Recreated from #1415, which GitHub auto-closed when its branch was rebased onto current master. Same change, rebased and verified on master 3aba46ca.)_
