### PR TITLE
fs: implement close_range(2)

### DIFF
--- a/exported_symbols/osv_ld-musl.so.1.symbols
+++ b/exported_symbols/osv_ld-musl.so.1.symbols
@@ -78,6 +78,7 @@ clock_getres
 clock_gettime
 clock_nanosleep
 close
+close_range
 closedir
 closelog
 confstr

--- a/exported_symbols/osv_libc.so.6.symbols
+++ b/exported_symbols/osv_libc.so.6.symbols
@@ -56,6 +56,7 @@ clock_getres
 clock_gettime
 clock_nanosleep
 close
+close_range
 closedir
 closelog
 confstr

--- a/fs/vfs/main.cc
+++ b/fs/vfs/main.cc
@@ -299,6 +299,46 @@ int close(int fd)
     return -1;
 }
 
+// close_range(2): close (or set close-on-exec on) every open fd in the inclusive
+// range [first, last].  CLOSE_RANGE_UNSHARE is a no-op in a single-process
+// unikernel (there is nothing to unshare).  CLOSE_RANGE_CLOEXEC sets O_CLOEXEC
+// instead of closing.
+#ifndef CLOSE_RANGE_UNSHARE
+#define CLOSE_RANGE_UNSHARE (1U << 1)
+#endif
+#ifndef CLOSE_RANGE_CLOEXEC
+#define CLOSE_RANGE_CLOEXEC (1U << 2)
+#endif
+extern "C" OSV_LIBC_API
+int close_range(unsigned int first, unsigned int last, unsigned int flags)
+{
+    if (first > last || (flags & ~(CLOSE_RANGE_UNSHARE | CLOSE_RANGE_CLOEXEC))) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    unsigned int end = last;
+    if (end >= (unsigned int)FDMAX) {
+        end = FDMAX - 1;
+    }
+    for (unsigned int fd = first; fd <= end; fd++) {
+        if (flags & CLOSE_RANGE_CLOEXEC) {
+            // Set close-on-exec on the open fds in the range, leave them open.
+            struct file *fp;
+            if (fget(fd, &fp) == 0) {
+                FD_LOCK(fp);
+                fp->f_flags |= O_CLOEXEC;
+                FD_UNLOCK(fp);
+                fdrop(fp);
+            }
+        } else {
+            // Close each fd, ignoring ones that are not open (as Linux does).
+            fdclose(fd);
+        }
+    }
+    return 0;
+}
+
 TRACEPOINT(trace_vfs_mknod, "\"%s\" 0%0o 0x%x", const char*, mode_t, dev_t);
 TRACEPOINT(trace_vfs_mknod_ret, "");
 TRACEPOINT(trace_vfs_mknod_err, "%d", int);

--- a/include/api/aarch64/bits/syscall.h
+++ b/include/api/aarch64/bits/syscall.h
@@ -282,6 +282,7 @@
 #define __NR_io_uring_enter 426
 #define __NR_io_uring_register 427
 #define __NR_epoll_pwait2 441
+#define __NR_close_range 436
 #define __NR_sys_io_uring_setup __NR_io_uring_setup
 #define __NR_sys_io_uring_enter __NR_io_uring_enter
 #define __NR_sys_io_uring_register __NR_io_uring_register
@@ -586,6 +587,7 @@
 #define SYS_io_uring_enter 426
 #define SYS_io_uring_register 427
 #define SYS_epoll_pwait2 441
+#define SYS_close_range 436
 #define SYS_open_tree		428
 #define SYS_move_mount		429
 #define SYS_fsopen		430

--- a/include/api/unistd.h
+++ b/include/api/unistd.h
@@ -190,6 +190,7 @@ int getresuid(uid_t *, uid_t *, uid_t *);
 int getresgid(gid_t *, gid_t *, gid_t *);
 char *get_current_dir_name(void);
 int syncfs(int);
+int close_range(unsigned int, unsigned int, unsigned int);
 #endif
 
 #if defined(_LARGEFILE64_SOURCE) || defined(_GNU_SOURCE)

--- a/include/api/x64/bits/syscall.h
+++ b/include/api/x64/bits/syscall.h
@@ -656,6 +656,7 @@
 #define SYS_io_uring_enter			426
 #define SYS_io_uring_register			427
 #define SYS_epoll_pwait2			441
+#define SYS_close_range				436
 
 #undef SYS_fstatat
 #undef SYS_pread
@@ -671,6 +672,7 @@
 #define __NR_io_uring_enter 426
 #define __NR_io_uring_register 427
 #define __NR_epoll_pwait2 441
+#define __NR_close_range 436
 #define __NR_sys_io_uring_setup __NR_io_uring_setup
 #define __NR_sys_io_uring_enter __NR_io_uring_enter
 #define __NR_sys_io_uring_register __NR_io_uring_register

--- a/linux.cc
+++ b/linux.cc
@@ -74,6 +74,7 @@ extern "C" int membarrier(int cmd, unsigned int flags, int cpu_id);
 extern "C" int renameat2(int, const char *, int, const char *, unsigned int);
 extern "C" ssize_t preadv2(int, const struct iovec *, int, off_t, int);
 extern "C" ssize_t pwritev2(int, const struct iovec *, int, off_t, int);
+extern "C" int close_range(unsigned int first, unsigned int last, unsigned int flags);
 
 extern "C" OSV_LIBC_API long gettid()
 {

--- a/modules/tests/Makefile
+++ b/modules/tests/Makefile
@@ -193,6 +193,8 @@ endif
 
 tests += testrunner.so
 
+tests += tst-close-range.so
+
 # Tests with special compilation parameters needed...
 $(out)/tests/tst-mmap.so: COMMON += -Wl,-z,now
 $(out)/tests/tst-elf-permissions.so: COMMON += -Wl,-z,relro

--- a/syscalls/syscall_tracepoints.cc.in
+++ b/syscalls/syscall_tracepoints.cc.in
@@ -8,6 +8,7 @@ TRACEPOINT(trace_syscall_gettid, "%d <=", pid_t);
 TRACEPOINT(trace_syscall_clock_gettime, "%d <= %d %p", int, clockid_t, struct timespec *);
 TRACEPOINT(trace_syscall_clock_getres, "%d <= %d %p", int, clockid_t, struct timespec *);
 TRACEPOINT(trace_syscall_close, "%d <= %d", int, int);
+TRACEPOINT(trace_syscall_close_range, "%d <= %u %u %u", int, unsigned int, unsigned int, unsigned int);
 TRACEPOINT(trace_syscall_pipe2, "%d <= %p 0%0o", int, int *, int);
 #if CONF_core_epoll
 TRACEPOINT(trace_syscall_epoll_create1, "%d <= 0%0o", int, int);

--- a/syscalls/syscalls.cc.in
+++ b/syscalls/syscalls.cc.in
@@ -8,6 +8,7 @@
     SYSCALL2(clock_gettime, clockid_t, struct timespec *);
     SYSCALL2(clock_getres, clockid_t, struct timespec *);
     SYSCALL1(close, int);
+    SYSCALL3(close_range, unsigned int, unsigned int, unsigned int);
     SYSCALL2(pipe2, int *, int);
 #if CONF_core_epoll
     SYSCALL1(epoll_create1, int);

--- a/tests/tst-close-range.cc
+++ b/tests/tst-close-range.cc
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2026 Greg Burd
+ *
+ * This work is open source software, licensed under the terms of the
+ * BSD license as described in the LICENSE file in the top-level directory.
+ */
+
+// Exercises close_range(2).  Built and run as part of the OSv test image.
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+#include <unistd.h>
+#include <fcntl.h>
+
+#include <errno.h>
+
+#include <cassert>
+#include <iostream>
+
+#ifndef CLOSE_RANGE_CLOEXEC
+#define CLOSE_RANGE_CLOEXEC (1U << 2)
+#endif
+
+// Open n fds pointing at /dev/null and return the lowest one; they are
+// contiguous because the fd table hands out the lowest free slots.
+static int open_run(int n, int *fds)
+{
+    for (int i = 0; i < n; i++) {
+        fds[i] = open("/dev/null", O_RDONLY);
+        assert(fds[i] >= 0);
+    }
+    return fds[0];
+}
+
+int main()
+{
+    std::cerr << "Running close_range tests\n";
+
+    // Close a contiguous run of fds.
+    int fds[5];
+    open_run(5, fds);
+    assert(close_range(fds[0], fds[4], 0) == 0);
+    // All of them are now closed: fcntl must report EBADF.
+    for (int i = 0; i < 5; i++) {
+        errno = 0;
+        assert(fcntl(fds[i], F_GETFD) == -1 && errno == EBADF);
+    }
+
+    // A range that includes not-open fds is fine (Linux ignores them).
+    int a = open("/dev/null", O_RDONLY);
+    assert(a >= 0);
+    assert(close_range(a, a + 100, 0) == 0);
+    errno = 0;
+    assert(fcntl(a, F_GETFD) == -1 && errno == EBADF);
+
+    // CLOSE_RANGE_CLOEXEC sets close-on-exec instead of closing.
+    int b = open("/dev/null", O_RDONLY);
+    assert(b >= 0);
+    int flags = fcntl(b, F_GETFD);
+    assert(flags != -1 && (flags & FD_CLOEXEC) == 0); // not set yet
+    assert(close_range(b, b, CLOSE_RANGE_CLOEXEC) == 0);
+    flags = fcntl(b, F_GETFD);
+    assert(flags != -1);                             // still open
+    assert(flags & FD_CLOEXEC);                      // now set
+    close(b);
+
+    // first > last is rejected; an unknown flag is rejected.
+    errno = 0;
+    assert(close_range(10, 5, 0) == -1 && errno == EINVAL);
+    errno = 0;
+    assert(close_range(0, 3, 0x40) == -1 && errno == EINVAL);
+
+    std::cerr << "close_range tests PASSED\n";
+    return 0;
+}


### PR DESCRIPTION
## What

`close_range(2)` was missing entirely. It is the standard way to close a range
of file descriptors in one call (commonly used to clean up inherited fds and by
some language runtimes), so programs that call it failed.

## How

Implemented over the existing fd table: close (or, with `CLOSE_RANGE_CLOEXEC`,
set `O_CLOEXEC` on) every open fd in the inclusive range `[first, last]`,
clamping `last` to the fd-table size and ignoring fds that are not open, as Linux
does. `CLOSE_RANGE_UNSHARE` is a no-op in a single-process unikernel (there is
nothing to unshare). `first > last` and unknown flags return `EINVAL`.

Wired as syscall `SYS_close_range` (adding `__NR_close_range` /
`SYS_close_range` for x86-64 and aarch64) with a tracepoint, declared in
`unistd.h` under `_GNU_SOURCE`, and the symbol exported from `libc.so.6` and
`ld-musl.so.1`.

## Testing

`tests/tst-close-range.cc` covers closing a contiguous run, a range that spans
not-open fds, the `CLOSE_RANGE_CLOEXEC` variant, and the `EINVAL` paths. Passes
on OSv under KVM.


_(Recreated from #1417, which GitHub auto-closed when its branch was rebased onto current master. Same change, rebased and verified on master 3aba46ca.)_
