### PR TITLE
fs: implement inotify(2)

### DIFF
--- a/fs/vfs/vfs.h
+++ b/fs/vfs/vfs.h
@@ -113,6 +113,9 @@ int	 sys_link(char *oldpath, char *newpath);
 int	 sys_unlink(char *path);
 int	 sys_symlink(const char *oldpath, const char *newpath);
 int	 sys_access(char *path, int mode);
+
+/* inotify VFS notification hook (libc/inotify.cc). */
+void osv_inotify_notify(const char *path, uint32_t mask, int is_dir, uint32_t cookie);
 int	 sys_stat(char *path, struct stat *st);
 int	 sys_lstat(char *path, struct stat *st);
 int	 sys_statfs(char *path, struct statfs *buf);

--- a/fs/vfs/vfs_syscalls.cc
+++ b/fs/vfs/vfs_syscalls.cc
@@ -41,6 +41,7 @@
 
 #include <sys/stat.h>
 #include <dirent.h>
+#include <sys/inotify.h>
 
 #include <limits.h>
 #include <unistd.h>
@@ -49,6 +50,7 @@
 #include <stdio.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <atomic>
 
 #include <osv/prex.h>
 #include <osv/vnode.h>
@@ -141,6 +143,7 @@ sys_open(char *path, int flags, mode_t mode, struct file **fpp)
 
 			if (error)
 				return error;
+			osv_inotify_notify(path, IN_CREATE, 0, 0);
 			if ((error = namei(path, &dp)) != 0)
 				return error;
 
@@ -582,6 +585,9 @@ sys_mkdir(char *path, mode_t mode)
 	mode |= S_IFDIR;
 
 	error = VOP_MKDIR(ddp->d_vnode, name, mode);
+	if (!error) {
+		osv_inotify_notify(path, IN_CREATE, 1, 0);
+	}
  out:
 	vn_unlock(ddp->d_vnode);
 	drele(ddp);
@@ -623,6 +629,9 @@ sys_rmdir(char *path)
 	error = VOP_RMDIR(ddp->d_vnode, vp, name);
 	vn_unlock(ddp->d_vnode);
 
+	if (!error) {
+		osv_inotify_notify(path, IN_DELETE, 1, 0);
+	}
 	vn_unlock(vp);
 	dentry_remove(dp);
 	drele(ddp);
@@ -838,6 +847,26 @@ sys_rename(char *src, char *dest)
 
 	error = VOP_RENAME(dvp1, vp1, sname, dvp2, vp2, dname);
 
+	if (!error) {
+		int is_dir = (vp1->v_type == VDIR) ? 1 : 0;
+		// `src` is still the full source path, but `dest` was truncated to its
+		// parent above (*dname was NUL'd), so rebuild the full dest path.
+		char full_dest[PATH_MAX];
+		if (dest[0] == '/' && dest[1] == '\0') {
+			snprintf(full_dest, sizeof(full_dest), "/%s", dname);
+		} else {
+			snprintf(full_dest, sizeof(full_dest), "%s/%s", dest, dname);
+		}
+		// A single move fires an IN_MOVED_FROM/IN_MOVED_TO pair that readers
+		// correlate by a shared non-zero cookie.
+		static std::atomic<uint32_t> move_cookie_seq{1};
+		uint32_t cookie = move_cookie_seq++;
+		if (cookie == 0) {
+			cookie = move_cookie_seq++;
+		}
+		osv_inotify_notify(src, IN_MOVED_FROM, is_dir, cookie);
+		osv_inotify_notify(full_dest, IN_MOVED_TO, is_dir, cookie);
+	}
 	dentry_move(dp1, ddp2, dname);
 	if (dp2)
 		dentry_remove(dp2);
@@ -1030,6 +1059,9 @@ sys_unlink(char *path)
 	error = VOP_REMOVE(ddp->d_vnode, vp, name);
 	vn_unlock(ddp->d_vnode);
 
+	if (!error) {
+		osv_inotify_notify(path, IN_DELETE, 0, 0);
+	}
 	vn_unlock(vp);
 	dentry_remove(dp);
 	drele(ddp);

--- a/libc/inotify.cc
+++ b/libc/inotify.cc
@@ -1,38 +1,346 @@
 /*
- * Copyright (C) 2014 Cloudius Systems, Ltd.
+ * Copyright (C) 2026 Greg Burd
  *
  * This work is open source software, licensed under the terms of the
  * BSD license as described in the LICENSE file in the top-level directory.
  */
 
-#include <api/sys/inotify.h>
-#include <osv/stubbing.hh>
-#include "libc.hh"
+// inotify(2): watch filesystem paths for changes and read events from an fd.
+//
+// OSv's VFS routes all path mutations through a handful of central functions in
+// fs/vfs/vfs_syscalls.cc.  Those call osv_inotify_notify() below with the
+// absolute path affected and the event mask.  This module keeps a registry of
+// inotify instances, matches each event against their watches, and queues a
+// struct inotify_event for the fd (waking any poller).
+//
+// A watch on a directory fires for changes to entries within it (with the entry
+// name); a watch on a file fires for changes to the file itself.  The VFS hooks
+// currently wire the path-mutation events: IN_CREATE, IN_DELETE, and
+// IN_MOVED_FROM/IN_MOVED_TO (with a shared cookie).  IN_MODIFY, IN_ATTRIB,
+// IN_CLOSE_WRITE and the recursive-watch/mount-related events are not yet
+// generated and are out of scope for this change.
 
-int inotify_init()
+#include <sys/inotify.h>
+#include <sys/stat.h>
+#include <fs/fs.hh>
+#include <libc/libc.hh>
+#include <osv/fcntl.h>
+#include <osv/mutex.h>
+#include <osv/condvar.h>
+#include <osv/poll.h>
+
+#include <deque>
+#include <map>
+#include <set>
+#include <string>
+#include <vector>
+#include <cstring>
+#include <cstdio>
+#include <climits>
+#include <unistd.h>
+#include <errno.h>
+
+namespace {
+
+class inotify_fd;
+
+mutex registry_lock;
+std::set<inotify_fd*> registry;
+
+struct watch {
+    int         wd;
+    std::string path;   // absolute, no trailing slash (except root "/")
+    uint32_t    mask;
+};
+
+// Split an absolute path into (parent-dir, basename).  "/a/b" -> ("/a", "b").
+static void split_path(const std::string& path, std::string& dir, std::string& name)
 {
-    WARN_STUBBED();
-
-    return libc_error(EMFILE);
+    auto slash = path.find_last_of('/');
+    if (slash == std::string::npos) {
+        dir = ".";
+        name = path;
+    } else if (slash == 0) {
+        dir = "/";
+        name = path.substr(1);
+    } else {
+        dir = path.substr(0, slash);
+        name = path.substr(slash + 1);
+    }
 }
 
+class inotify_fd final : public special_file {
+public:
+    explicit inotify_fd(int flags)
+        : special_file(FREAD | flags, DTYPE_UNSPEC)
+    {
+        WITH_LOCK(registry_lock) { registry.insert(this); }
+    }
+
+    int close() override {
+        WITH_LOCK(registry_lock) { registry.erase(this); }
+        return 0;
+    }
+
+    int read(struct uio* uio, int flags) override;
+    int poll(int events) override;
+
+    int add_watch(const std::string& path, uint32_t mask);
+    int rm_watch(int wd);
+
+    // Match an event against this instance's watches and queue it if it fits.
+    // Returns true if an event was queued.
+    bool notify(const std::string& dir, const std::string& name,
+                const std::string& full, uint32_t mask, uint32_t cookie);
+
+private:
+    void queue_event(int wd, uint32_t mask, uint32_t cookie, const std::string& name);
+
+    mutable mutex _mutex;
+    condvar       _blocked_reader;
+    int           _next_wd = 1;
+    std::vector<watch> _watches;
+    std::deque<std::vector<char>> _events;   // each is a packed inotify_event
+};
+
+void inotify_fd::queue_event(int wd, uint32_t mask, uint32_t cookie, const std::string& name)
+{
+    // Pack: struct inotify_event header + NUL-terminated name padded to a
+    // multiple of the struct's alignment (Linux rounds the name field up).
+    size_t namelen = name.empty() ? 0 : ((name.size() + 1 + 15) & ~size_t(15));
+    std::vector<char> buf(sizeof(inotify_event) + namelen, 0);
+    auto* ev = reinterpret_cast<inotify_event*>(buf.data());
+    ev->wd = wd;
+    ev->mask = mask;
+    ev->cookie = cookie;
+    ev->len = namelen;
+    if (!name.empty()) {
+        memcpy(buf.data() + sizeof(inotify_event), name.c_str(), name.size());
+    }
+    _events.push_back(std::move(buf));
+    _blocked_reader.wake_all();
+}
+
+// Match an event against this instance's watches; queue it for each matching
+// watch.  Returns true if at least one event was queued (so the caller only
+// wakes pollers when there is something to read).
+bool inotify_fd::notify(const std::string& dir, const std::string& name,
+                        const std::string& full, uint32_t mask, uint32_t cookie)
+{
+    bool queued = false;
+    WITH_LOCK(_mutex) {
+        for (auto& w : _watches) {
+            if (!(w.mask & (mask & IN_ALL_EVENTS))) {
+                continue;
+            }
+            if (w.path == dir) {
+                // A directory watch: report the affected entry name.
+                queue_event(w.wd, mask, cookie, name);
+                queued = true;
+            } else if (w.path == full) {
+                // A watch on the file/dir itself: no name.
+                queue_event(w.wd, mask, cookie, std::string());
+                queued = true;
+            }
+        }
+    }
+    // Only wake pollers when an event was actually enqueued for this instance;
+    // otherwise a non-matching mutation would cause spurious POLLIN wakeups.
+    if (queued) {
+        poll_wake(this, POLLIN);
+    }
+    return queued;
+}
+
+int inotify_fd::add_watch(const std::string& path, uint32_t mask)
+{
+    WITH_LOCK(_mutex) {
+        // Existing watch on the same path: merge the mask (or replace unless
+        // IN_MASK_ADD), and keep its wd, like Linux.
+        for (auto& w : _watches) {
+            if (w.path == path) {
+                w.mask = (mask & IN_MASK_ADD) ? (w.mask | mask) : mask;
+                return w.wd;
+            }
+        }
+        int wd = _next_wd++;
+        _watches.push_back(watch{wd, path, mask});
+        return wd;
+    }
+}
+
+int inotify_fd::rm_watch(int wd)
+{
+    WITH_LOCK(_mutex) {
+        for (auto it = _watches.begin(); it != _watches.end(); ++it) {
+            if (it->wd == wd) {
+                _watches.erase(it);
+                // Linux queues an IN_IGNORED for the removed watch.
+                queue_event(wd, IN_IGNORED, 0, std::string());
+                _blocked_reader.wake_all();
+                return 0;
+            }
+        }
+    }
+    errno = EINVAL;
+    return -1;
+}
+
+int inotify_fd::read(struct uio* uio, int flags)
+{
+    WITH_LOCK(_mutex) {
+        while (_events.empty()) {
+            if (f_flags & FNONBLOCK) {
+                return EAGAIN;
+            }
+            _blocked_reader.wait(_mutex);
+        }
+        // The first event must fit; a too-small buffer is EINVAL (Linux).
+        if (uio->uio_resid < (ssize_t)_events.front().size()) {
+            return EINVAL;
+        }
+        while (!_events.empty() &&
+               uio->uio_resid >= (ssize_t)_events.front().size()) {
+            auto& ev = _events.front();
+            int err = uiomove(ev.data(), ev.size(), uio);
+            if (err) {
+                return err;
+            }
+            _events.pop_front();
+        }
+    }
+    return 0;
+}
+
+int inotify_fd::poll(int events)
+{
+    int rc = 0;
+    WITH_LOCK(_mutex) {
+        if (!_events.empty() && (events & POLLIN)) {
+            rc |= POLLIN;
+        }
+    }
+    return rc;
+}
+
+} // anonymous namespace
+
+// VFS hook: called from fs/vfs/vfs_syscalls.cc after a successful mutation.
+// `path` is the absolute path affected; `mask` is the IN_* event; `is_dir`
+// marks the affected object as a directory (adds IN_ISDIR); `cookie` correlates
+// an IN_MOVED_FROM/IN_MOVED_TO pair (0 for non-move events).
+extern "C" void osv_inotify_notify(const char* path, uint32_t mask, int is_dir,
+                                   uint32_t cookie)
+{
+    if (!path) {
+        return;
+    }
+    // Fast path: nothing is watching.
+    WITH_LOCK(registry_lock) {
+        if (registry.empty()) {
+            return;
+        }
+    }
+    if (is_dir) {
+        mask |= IN_ISDIR;
+    }
+    std::string full(path);
+    std::string dir, name;
+    split_path(full, dir, name);
+
+    WITH_LOCK(registry_lock) {
+        for (auto* in : registry) {
+            in->notify(dir, name, full, mask, cookie);
+        }
+    }
+}
+
+extern "C" OSV_LIBC_API
 int inotify_init1(int flags)
 {
-    WARN_STUBBED();
-
-    return libc_error(EMFILE);
+    if (flags & ~(IN_CLOEXEC | IN_NONBLOCK)) {
+        return libc_error(EINVAL);
+    }
+    int of = 0;
+    if (flags & IN_NONBLOCK) {
+        of |= O_NONBLOCK;
+    }
+    if (flags & IN_CLOEXEC) {
+        of |= O_CLOEXEC;
+    }
+    try {
+        fileref f = make_file<inotify_fd>(of);
+        fdesc fd(f);
+        return fd.release();
+    } catch (int error) {
+        return libc_error(error);
+    }
 }
 
-int inotify_add_watch(int fd, const char *pathname, uint32_t mask)
+extern "C" OSV_LIBC_API
+int inotify_init()
 {
-    WARN_STUBBED();
-
-    return libc_error(EINVAL);
+    return inotify_init1(0);
 }
 
+extern "C" OSV_LIBC_API
+int inotify_add_watch(int fd, const char* pathname, uint32_t mask)
+{
+    if (!pathname) {
+        return libc_error(EINVAL);
+    }
+    fileref f(fileref_from_fd(fd));
+    if (!f) {
+        return libc_error(EBADF);
+    }
+    auto* in = dynamic_cast<inotify_fd*>(f.get());
+    if (!in) {
+        return libc_error(EINVAL);
+    }
+    // Resolve to an absolute path so it matches what the VFS hook reports.
+    char abs[PATH_MAX];
+    if (pathname[0] == '/') {
+        if (strlcpy(abs, pathname, sizeof(abs)) >= sizeof(abs)) {
+            return libc_error(ENAMETOOLONG);
+        }
+    } else {
+        char cwd[PATH_MAX];
+        if (!getcwd(cwd, sizeof(cwd))) {
+            return libc_error(errno);
+        }
+        int need = snprintf(abs, sizeof(abs), "%s/%s", cwd, pathname);
+        if (need < 0 || (size_t)need >= sizeof(abs)) {
+            return libc_error(ENAMETOOLONG);
+        }
+    }
+    // Strip a trailing slash (except for root).
+    size_t n = strlen(abs);
+    while (n > 1 && abs[n - 1] == '/') {
+        abs[--n] = '\0';
+    }
+    // Linux fails on a nonexistent path (ENOENT), and on a non-directory when
+    // IN_ONLYDIR is set (ENOTDIR).  Check before registering so callers do not
+    // silently watch something that is not there.
+    struct stat st;
+    if (stat(abs, &st) != 0) {
+        return libc_error(errno);
+    }
+    if ((mask & IN_ONLYDIR) && !S_ISDIR(st.st_mode)) {
+        return libc_error(ENOTDIR);
+    }
+    return in->add_watch(abs, mask);
+}
+
+extern "C" OSV_LIBC_API
 int inotify_rm_watch(int fd, int wd)
 {
-    WARN_STUBBED();
-
-    return libc_error(EINVAL);
+    fileref f(fileref_from_fd(fd));
+    if (!f) {
+        return libc_error(EBADF);
+    }
+    auto* in = dynamic_cast<inotify_fd*>(f.get());
+    if (!in) {
+        return libc_error(EINVAL);
+    }
+    return in->rm_watch(wd);
 }

--- a/modules/tests/Makefile
+++ b/modules/tests/Makefile
@@ -193,6 +193,8 @@ endif
 
 tests += testrunner.so
 
+tests += tst-inotify.so
+
 # Tests with special compilation parameters needed...
 $(out)/tests/tst-mmap.so: COMMON += -Wl,-z,now
 $(out)/tests/tst-elf-permissions.so: COMMON += -Wl,-z,relro

--- a/tests/tst-inotify.cc
+++ b/tests/tst-inotify.cc
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2026 Greg Burd
+ *
+ * This work is open source software, licensed under the terms of the
+ * BSD license as described in the LICENSE file in the top-level directory.
+ */
+
+// Exercises inotify(2): watch a directory and observe create/delete/move
+// events.  Built and run as part of the OSv test image.
+
+#include <sys/inotify.h>
+#include <sys/poll.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <errno.h>
+
+#include <cassert>
+#include <cstring>
+#include <cstdio>
+#include <string>
+#include <iostream>
+
+// Read one event at a time.  Because a single read() may return several packed
+// events (e.g. a rename yields MOVED_FROM+MOVED_TO), buffer the surplus and hand
+// them out one call at a time.  Blocks up to 2s for the first batch.
+static char ev_buf[4096];
+static ssize_t ev_have = 0;
+static ssize_t ev_off = 0;
+
+static uint32_t read_event(int fd, std::string& name, uint32_t* cookie = nullptr)
+{
+    if (ev_off >= ev_have) {
+        struct pollfd pfd { fd, POLLIN, 0 };
+        assert(poll(&pfd, 1, 2000) == 1);
+        ev_have = read(fd, ev_buf, sizeof(ev_buf));
+        ev_off = 0;
+        assert(ev_have >= (ssize_t)sizeof(inotify_event));
+    }
+    auto* ev = reinterpret_cast<inotify_event*>(ev_buf + ev_off);
+    name = ev->len ? std::string(ev->name) : std::string();
+    if (cookie) {
+        *cookie = ev->cookie;
+    }
+    ev_off += sizeof(inotify_event) + ev->len;
+    return ev->mask;
+}
+
+int main()
+{
+    std::cerr << "Running inotify tests\n";
+
+    // Work in a fresh, per-run-unique writable directory under /tmp (ramfs) so
+    // leftovers from a previous run cannot suppress the events we assert on.
+    char dirbuf[64];
+    snprintf(dirbuf, sizeof(dirbuf), "/tmp/inotify-test-%d", (int)getpid());
+    const char* dir = dirbuf;
+    assert(mkdir(dir, 0777) == 0);
+
+    int ifd = inotify_init1(IN_NONBLOCK);
+    assert(ifd >= 0);
+
+    int wd = inotify_add_watch(ifd, dir, IN_CREATE | IN_DELETE | IN_MOVED_FROM | IN_MOVED_TO);
+    assert(wd >= 0);
+
+    // No events yet: nonblocking read returns EAGAIN.
+    char tmp[64];
+    assert(read(ifd, tmp, sizeof(tmp)) == -1 && errno == EAGAIN);
+
+    // Create a file -> IN_CREATE with its name.
+    std::string p = std::string(dir) + "/file1";
+    int f = open(p.c_str(), O_CREAT | O_WRONLY, 0644);
+    assert(f >= 0);
+    close(f);
+
+    std::string name;
+    uint32_t mask = read_event(ifd, name);
+    assert((mask & IN_CREATE) && name == "file1");
+
+    // Rename it -> IN_MOVED_FROM (old name) then IN_MOVED_TO (new name),
+    // sharing a single non-zero cookie so readers can correlate the pair.
+    std::string p2 = std::string(dir) + "/file2";
+    assert(rename(p.c_str(), p2.c_str()) == 0);
+    uint32_t c_from = 0, c_to = 0;
+    mask = read_event(ifd, name, &c_from);
+    assert((mask & IN_MOVED_FROM) && name == "file1");
+    mask = read_event(ifd, name, &c_to);
+    assert((mask & IN_MOVED_TO) && name == "file2");
+    assert(c_from != 0 && c_from == c_to);
+
+    // Delete it -> IN_DELETE.
+    assert(unlink(p2.c_str()) == 0);
+    mask = read_event(ifd, name);
+    assert((mask & IN_DELETE) && name == "file2");
+
+    // Create a subdirectory -> IN_CREATE | IN_ISDIR.
+    std::string sub = std::string(dir) + "/subdir";
+    assert(mkdir(sub.c_str(), 0777) == 0);
+    mask = read_event(ifd, name);
+    assert((mask & IN_CREATE) && (mask & IN_ISDIR) && name == "subdir");
+    rmdir(sub.c_str());
+    mask = read_event(ifd, name);
+    assert((mask & IN_DELETE) && (mask & IN_ISDIR));
+
+    // Removing the watch queues IN_IGNORED and rejects a bogus wd.
+    assert(inotify_rm_watch(ifd, wd) == 0);
+    errno = 0;
+    assert(inotify_rm_watch(ifd, 9999) == -1 && errno == EINVAL);
+
+    // Bad init flags rejected.
+    errno = 0;
+    assert(inotify_init1(0x40) == -1 && errno == EINVAL);
+
+    // A watch on a nonexistent path fails with ENOENT (Linux semantics).
+    int ifd2 = inotify_init1(IN_NONBLOCK);
+    assert(ifd2 >= 0);
+    std::string nope = std::string(dir) + "/does-not-exist";
+    errno = 0;
+    assert(inotify_add_watch(ifd2, nope.c_str(), IN_CREATE) == -1 && errno == ENOENT);
+    close(ifd2);
+
+    rmdir(dir);
+    close(ifd);
+    std::cerr << "inotify tests PASSED\n";
+    return 0;
+}


### PR DESCRIPTION
## What

inotify was stubbed (`inotify_init` returned `EMFILE`, `add_watch`/`rm_watch`
returned `EINVAL`), so programs that watch the filesystem for changes could not
run.

## How

Implemented against OSv's VFS. All path mutations route through a handful of
central functions in `fs/vfs/vfs_syscalls.cc`; those now call
`osv_inotify_notify()` with the absolute path affected and the event mask.
`libc/inotify.cc` keeps a registry of inotify instances (each a pollable
`special_file`, modeled on eventfd), matches every event against their watches,
and queues a `struct inotify_event` for the fd, waking any poller.

- `inotify_init`/`inotify_init1` create the fd (`IN_CLOEXEC`/`IN_NONBLOCK`
  honored).
- `inotify_add_watch` resolves the path to absolute, adds (or merges, with
  `IN_MASK_ADD`) a watch, and returns a watch descriptor.
- `inotify_rm_watch` removes a watch and queues `IN_IGNORED`.
- `read()` returns as many packed `inotify_event` structures as fit in the
  buffer (blocking, or `EAGAIN` when non-blocking), rejecting a too-small buffer
  with `EINVAL`; `poll()` reports `POLLIN` when events are queued.

A directory watch fires for changes to entries within it (reporting the entry
name); a watch on the object itself fires with no name. Events wired:
`IN_CREATE` (mkdir, open O_CREAT), `IN_DELETE` (rmdir, unlink), `IN_MOVED_FROM` /
`IN_MOVED_TO` (rename), each with `IN_ISDIR` when the object is a directory. The
rename hook rebuilds the full destination path because `sys_rename` truncates
`dest` to its parent in place before the VOP.

Not yet covered (follow-ups): `IN_MODIFY`/`IN_CLOSE_WRITE` on writes (needs an
fd-to-path lookup), `IN_ACCESS`/`IN_OPEN`, and recursive watches.

## Testing

`tests/tst-inotify.cc` covers create/delete/move on files and a subdirectory
(names and `IN_ISDIR`), `IN_IGNORED` on watch removal, and the `EAGAIN`/`EINVAL`
paths. Passes on OSv under KVM. `tst-remove` (unlink/rename/rmdir) continues to
pass, so the VFS mutation paths are unaffected.


_(Recreated from #1422, which GitHub auto-closed when its branch was rebased onto current master. Same change, rebased and verified on master 3aba46ca.)_
