### PR TITLE
vfs: reject oversized iovcnt in sys_read/sys_write (fix app-triggerable kernel panic)

### DIFF
--- a/fs/vfs/vfs_syscalls.cc
+++ b/fs/vfs/vfs_syscalls.cc
@@ -250,6 +250,16 @@ sys_read(struct file *fp, const struct iovec *iov, size_t niov,
     if ((fp->f_flags & FREAD) == 0)
         return EBADF;
 
+    // Reject an out-of-range iovec count with EINVAL *before* touching iov: a
+    // caller-controlled niov > UIO_MAXIOV would otherwise (a) walk iov[] for
+    // up to niov entries in the summation loop below (OOB read) and (b) hit
+    // the assert() further down, which in a _KERNEL build is compiled in and
+    // calls abort() -> whole-VM panic.  It also caps the VLA below to a sane
+    // size.  (niov is size_t; guard both the >MAXIOV and, defensively, the
+    // count itself.)
+    if (niov > UIO_MAXIOV)
+        return EINVAL;
+
     size_t bytes = 0;
     auto iovp = iov;
     for (unsigned i = 0; i < niov; i++) {
@@ -288,6 +298,10 @@ sys_write(struct file *fp, const struct iovec *iov, size_t niov,
 {
     if ((fp->f_flags & FWRITE) == 0)
         return EBADF;
+
+    // See sys_read: reject niov > UIO_MAXIOV up front (OOB-read + abort() DoS).
+    if (niov > UIO_MAXIOV)
+        return EINVAL;
 
     size_t bytes = 0;
     auto iovp = iov;

--- a/modules/tests/Makefile
+++ b/modules/tests/Makefile
@@ -115,7 +115,7 @@ ext-only-tests := tst-readdir.so tst-concurrent-read.so tst-fs-link.so
 
 specific-fs-tests := $($(fs_type)-only-tests)
 
-tests := tst-pthread.so misc-ramdisk.so tst-vblk.so tst-mq-smoke.so tst-bsd-evh.so \
+tests := tst-iovcnt-guard.so tst-pthread.so misc-ramdisk.so tst-vblk.so tst-mq-smoke.so tst-bsd-evh.so \
 	misc-bsd-callout.so tst-bsd-kthread.so tst-bsd-taskqueue.so \
 	tst-fpu.so tst-preempt.so tst-tracepoint.so tst-hub.so \
 	misc-console.so misc-leak.so misc-readbench.so misc-mmap-anon-perf.so \

--- a/tests/tst-iovcnt-guard.cc
+++ b/tests/tst-iovcnt-guard.cc
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2026 Greg Burd
+ *
+ * This work is open source software, licensed under the terms of the
+ * BSD license as described in the LICENSE file in the top-level directory.
+ */
+
+// Regression: a huge iovcnt to readv/writev must return -1/EINVAL, not panic
+// the kernel (previously an assert(niov <= UIO_MAXIOV) -> abort()).
+#include <sys/uio.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+
+int main()
+{
+    int fd = open("/tmp/iovcnt-test", O_RDWR | O_CREAT | O_TRUNC, 0644);
+    if (fd < 0) { perror("open"); return 1; }
+    // A normal small write to give the file content.
+    struct iovec one = { (void*)"hi", 2 };
+    if (writev(fd, &one, 1) != 2) { perror("writev(1)"); return 1; }
+    lseek(fd, 0, SEEK_SET);
+
+    // Oversized iovcnt: must be rejected with EINVAL, not abort the VM.
+    struct iovec v = { 0, 0 };
+    errno = 0;
+    ssize_t r = readv(fd, &v, 0x40000000);
+    if (!(r == -1 && errno == EINVAL)) {
+        fprintf(stderr, "FAIL: readv(huge iovcnt) returned %zd errno=%d (want -1/EINVAL)\n", r, errno);
+        return 1;
+    }
+    errno = 0;
+    r = writev(fd, &v, 0x40000000);
+    if (!(r == -1 && errno == EINVAL)) {
+        fprintf(stderr, "FAIL: writev(huge iovcnt) returned %zd errno=%d (want -1/EINVAL)\n", r, errno);
+        return 1;
+    }
+    close(fd);
+    unlink("/tmp/iovcnt-test");
+    fprintf(stderr, "iovcnt-guard test PASSED\n");
+    return 0;
+}


### PR DESCRIPTION
**Security fix — local DoS (any unprivileged app can panic the kernel).**

`sys_read()`/`sys_write()` (fs/vfs/vfs_syscalls.cc) summed `iov_len` over `niov` entries and only *then* did `assert(niov <= UIO_MAXIOV)` before a `struct iovec copy_iov[niov]` VLA. `niov` is caller-controlled and reaches here unvalidated from `readv/writev/preadv/pwritev/preadv2/pwritev2`, io_uring `READV/WRITEV(_FIXED)`, and libaio `PREADV/PWRITEV`.

Three problems:
1. OSv keeps `assert()` **live in `_KERNEL` builds** (`include/api/assert.h`: `#if defined NDEBUG && !defined _KERNEL`), so `niov > UIO_MAXIOV` → `__assert_fail` → `abort()` = **whole-VM panic**. In a unikernel an app-triggerable panic is a full-system DoS.
2. The summation loop dereferences `iov[i]` for up to `niov` entries *before* the assert → out-of-bounds read.
3. `copy_iov[niov]` is a VLA sized by the unvalidated count (kernel-stack blowout).

### PoC
```c
struct iovec v = {0,0};
readv(open("/f", O_RDONLY), &v, 0x40000000);   // -> assert -> abort() -> VM panic (before this fix)
```
Also reachable by submitting an `IORING_OP_READV` SQE with `len = 0x40000000`.

### Fix
Reject `niov > UIO_MAXIOV` with `EINVAL` at function entry (before touching `iov`), matching Linux's `EINVAL` for an out-of-range `iovcnt`. Fixes all three issues.

### Severity
High (CVSS ~7.1, AV:L/AC:L/PR:L/UI:N/A:H) — trivially reachable kernel panic.

Verified with `tst-iovcnt-guard` (new): `readv`/`writev` with a huge `iovcnt` now return `-1/EINVAL` instead of aborting.