### PR TITLE
libext: fix heap overflow in ext_readlink and ext_readdir from a crafted ext4 image

### DIFF
--- a/modules/libext/ext_vnops.cc
+++ b/modules/libext/ext_vnops.cc
@@ -635,6 +635,13 @@ ext_readdir(struct vnode *dvp, struct file *fp, struct dirent *dir)
         if (ext4_dir_en_get_inode(it.curr) != 0) {
             memset(dir->d_name, 0, sizeof(dir->d_name));
             uint16_t name_length = ext4_dir_en_get_name_len(&fs->sb, it.curr);
+            // On an old-rev (rev0, minor<5) image ext4_dir_en_get_name_len can
+            // fold in name_length_high and return up to block_size-8 (~4 KiB),
+            // while d_name is only sizeof(dir->d_name) (256).  Clamp so a
+            // crafted directory entry cannot overflow the fixed d_name buffer.
+            if (name_length >= sizeof(dir->d_name)) {
+                name_length = sizeof(dir->d_name) - 1;
+            }
             memcpy(dir->d_name, it.curr->name, name_length);
             ext_debug("readdir directory with i-node=%ld at offset:%ld => entry name:%s\n", dvp->v_ino, file_offset(fp), dir->d_name);
 
@@ -1341,7 +1348,24 @@ ext_readlink(vnode_t *vp, uio_t *uio)
         return uiomove(content, fsize, uio);
     } else {
         uint32_t block_size = ext4_sb_get_block_size(&fs->sb);
+        // A symlink target is stored in at most one block (and is bounded by
+        // PATH_MAX); a slow symlink never spans more.  The inode size is read
+        // straight off disk and is fully attacker-controlled for a crafted
+        // image, so clamp it to block_size before reading into the block_size
+        // buffer -- otherwise ext_internal_read() would write @fsize bytes
+        // (up to 2^64-1) into a block_size heap allocation (heap overflow).
+        if (fsize > block_size) {
+            return EINVAL;   // malformed symlink inode
+        }
+        // Also guard the read start: ext_internal_read subtracts offset from
+        // fsize, so an offset past EOF would underflow the read length.
+        if ((uint64_t)uio->uio_offset >= fsize) {
+            return 0;
+        }
         void *buf = malloc(block_size);
+        if (!buf) {
+            return ENOMEM;
+        }
         size_t read_count = 0;
         int ret = ext_internal_read(fs, &inode_ref._ref, uio->uio_offset, buf, fsize, &read_count);
         if (ret) {

--- a/modules/tests/Makefile
+++ b/modules/tests/Makefile
@@ -115,7 +115,7 @@ ext-only-tests := tst-readdir.so tst-concurrent-read.so tst-fs-link.so
 
 specific-fs-tests := $($(fs_type)-only-tests)
 
-tests := tst-pthread.so misc-ramdisk.so tst-vblk.so tst-mq-smoke.so tst-bsd-evh.so \
+tests := tst-ext-readlink.so tst-pthread.so misc-ramdisk.so tst-vblk.so tst-mq-smoke.so tst-bsd-evh.so \
 	misc-bsd-callout.so tst-bsd-kthread.so tst-bsd-taskqueue.so \
 	tst-fpu.so tst-preempt.so tst-tracepoint.so tst-hub.so \
 	misc-console.so misc-leak.so misc-readbench.so misc-mmap-anon-perf.so \

--- a/modules/tests/Makefile
+++ b/modules/tests/Makefile
@@ -193,6 +193,8 @@ endif
 
 tests += testrunner.so
 
+tests += tst-ext-readlink.so
+
 # Tests with special compilation parameters needed...
 $(out)/tests/tst-mmap.so: COMMON += -Wl,-z,now
 $(out)/tests/tst-elf-permissions.so: COMMON += -Wl,-z,relro

--- a/modules/tests/Makefile
+++ b/modules/tests/Makefile
@@ -112,6 +112,7 @@ zfs-only-tests := tst-readdir.so tst-fallocate.so tst-fs-link.so \
 	tst-concurrent-read.so tst-solaris-taskq.so
 
 ext-only-tests := tst-readdir.so tst-concurrent-read.so tst-fs-link.so
+ext-only-tests += tst-ext-readlink.so
 
 specific-fs-tests := $($(fs_type)-only-tests)
 
@@ -192,8 +193,6 @@ tests += tst-mmx-fpu.so tst-tls-desc.so tst-tls-pie-desc.so libtls_desc.so
 endif
 
 tests += testrunner.so
-
-tests += tst-ext-readlink.so
 
 # Tests with special compilation parameters needed...
 $(out)/tests/tst-mmap.so: COMMON += -Wl,-z,now

--- a/tests/tst-ext-readlink.cc
+++ b/tests/tst-ext-readlink.cc
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2026 Greg Burd
+ *
+ * This work is open source software, licensed under the terms of the
+ * BSD license as described in the LICENSE file in the top-level directory.
+ */
+
+// Regression test for the ext_readlink hardening: a normal symlink must still
+// read back correctly (fast + slow), and the bounds guards must not break it.
+#include <unistd.h>
+#include <string.h>
+#include <stdio.h>
+#include <errno.h>
+
+int main(int argc, char** argv)
+{
+    const char* link = (argc > 1) ? argv[1] : "/data/mylink";
+    char buf[256];
+    memset(buf, 0, sizeof(buf));
+    ssize_t n = readlink(link, buf, sizeof(buf) - 1);
+    if (n < 0) {
+        fprintf(stderr, "readlink(%s) FAILED: %s\n", link, strerror(errno));
+        return 1;
+    }
+    buf[n] = 0;
+    fprintf(stderr, "readlink(%s) = '%s' (%zd bytes)\n", link, buf, n);
+    if (strcmp(buf, "realfile") != 0) {
+        fprintf(stderr, "READLINK MISMATCH: expected 'realfile'\n");
+        return 1;
+    }
+    fprintf(stderr, "ext-readlink regression PASSED\n");
+    return 0;
+}

--- a/tests/tst-ext-readlink.cc
+++ b/tests/tst-ext-readlink.cc
@@ -5,29 +5,137 @@
  * BSD license as described in the LICENSE file in the top-level directory.
  */
 
-// Regression test for the ext_readlink hardening: a normal symlink must still
-// read back correctly (fast + slow), and the bounds guards must not break it.
+// Regression test for the ext_readlink()/ext_readdir() bounds hardening.
+//
+// ext-specific: it creates its own symlinks on a writable ext root, so build and
+// run it with ext as the root filesystem:
+//
+//   scripts/build image=tests fs=ext
+//   scripts/test.py
+//
+// The case that matters is the *slow* symlink. ext_readlink() serves any target
+// shorter than sizeof(inode->blocks) (60 bytes) from the inline i_block fast
+// path, which the hardening does not touch:
+//
+//   if (fsize < sizeof(inode_ref._ref.inode->blocks) && !blocks_count) {
+//       return uiomove((char *)inode_ref._ref.inode->blocks, fsize, uio);
+//   } else {
+//       // malloc(block_size) + ext_internal_read(..., fsize, ...) <- guarded here
+//   }
+//
+// So a target of 60 bytes or more is required to reach the guarded branch at
+// all. An inline symlink additionally has i_blocks == 0, i.e. no data blocks,
+// so it can never be served by the block path even in principle. A test using a
+// short target therefore passes identically with and without the fix.
+//
+// Crafting the actual overflow (an inode whose i_size exceeds block_size) needs
+// debugfs to build the image and cannot be done from inside the guest, so this
+// test covers the legitimate side of the guards: every symlink length a guest
+// can create must still round-trip exactly, including the longest one a single
+// block can hold, which is the boundary the fsize <= block_size guard turns on.
+
 #include <unistd.h>
 #include <string.h>
 #include <stdio.h>
 #include <errno.h>
+#include <dirent.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <sys/stat.h>
 
-int main(int argc, char** argv)
+#include <cassert>
+#include <string>
+
+// Create a symlink at @path pointing at @target, read it back, and require an
+// exact round-trip.
+static void check_symlink(const std::string& path, const std::string& target,
+                          const char *what)
 {
-    const char* link = (argc > 1) ? argv[1] : "/data/mylink";
-    char buf[256];
+    unlink(path.c_str());
+    if (symlink(target.c_str(), path.c_str()) != 0) {
+        fprintf(stderr, "symlink(%s -> %zu bytes) FAILED: %s\n",
+                path.c_str(), target.size(), strerror(errno));
+        assert(false);
+    }
+
+    char buf[PATH_MAX];
     memset(buf, 0, sizeof(buf));
-    ssize_t n = readlink(link, buf, sizeof(buf) - 1);
+    ssize_t n = readlink(path.c_str(), buf, sizeof(buf) - 1);
     if (n < 0) {
-        fprintf(stderr, "readlink(%s) FAILED: %s\n", link, strerror(errno));
-        return 1;
+        fprintf(stderr, "readlink(%s) FAILED: %s\n",
+                path.c_str(), strerror(errno));
+        assert(false);
     }
     buf[n] = 0;
-    fprintf(stderr, "readlink(%s) = '%s' (%zd bytes)\n", link, buf, n);
-    if (strcmp(buf, "realfile") != 0) {
-        fprintf(stderr, "READLINK MISMATCH: expected 'realfile'\n");
-        return 1;
+    fprintf(stderr, "  %-28s target %4zu bytes, readlink returned %4zd\n",
+            what, target.size(), n);
+    assert(n == (ssize_t)target.size());
+    assert(target == buf);
+
+    unlink(path.c_str());
+}
+
+int main(int argc, char **argv)
+{
+    fprintf(stderr, "Running ext-readlink tests\n");
+
+    // Default to the (writable) ext root; an optional argument points the same
+    // binary at another directory, e.g. a separately mounted ext image.
+    const std::string base = (argc > 1) ? argv[1] : "";
+
+    // Fast path: target < 60 bytes, stored inline in the inode. Included so
+    // both branches of ext_readlink() stay covered.
+    check_symlink(base + "/tst-ext-link-inline", "/realfile", "inline (fast path)");
+
+    // Slow path: >= 60 bytes, so the target is stored in a data block and read
+    // back through the guarded malloc(block_size) + ext_internal_read() branch.
+    check_symlink(base + "/tst-ext-link-slow", std::string(64, 'a'),
+                  "slow, just over inline");
+
+    // A longer slow target, still one block on any supported block size.
+    check_symlink(base + "/tst-ext-link-slow2", "/" + std::string(299, 'b'),
+                  "slow, 300 bytes");
+
+    // The largest target a single 1 KiB block can hold: exactly the boundary the
+    // fsize <= block_size guard tests, so this fails if the guard is off by one
+    // or rejects a legitimate long symlink.
+    check_symlink(base + "/tst-ext-link-max", "/" + std::string(1022, 'c'),
+                  "slow, 1 KiB block max");
+
+    // ext_readdir() name clamp: a legitimate 255-byte name (EXT4's maximum) must
+    // still be returned intact, i.e. the clamp to sizeof(d_name)-1 = 255 does
+    // not truncate any name a well-formed image can contain.
+    {
+        const std::string longest(255, 'd');
+        const std::string dir = base + "/tst-ext-rd";
+        const std::string path = dir + "/" + longest;
+        rmdir(dir.c_str());
+        assert(mkdir(dir.c_str(), 0755) == 0);
+        int fd = creat(path.c_str(), 0644);
+        assert(fd >= 0);
+        close(fd);
+
+        DIR *d = opendir(dir.c_str());
+        assert(d != nullptr);
+        bool found = false;
+        struct dirent *de;
+        while ((de = readdir(d)) != nullptr) {
+            // Whatever the entry, the clamp must leave d_name NUL-terminated
+            // inside its 256 bytes.
+            assert(strlen(de->d_name) < sizeof(de->d_name));
+            if (longest == de->d_name) {
+                found = true;
+            }
+        }
+        closedir(d);
+        fprintf(stderr, "  %-28s 255-byte entry found: %s\n",
+                "readdir max name", found ? "yes" : "no");
+        assert(found);
+
+        unlink(path.c_str());
+        assert(rmdir(dir.c_str()) == 0);
     }
-    fprintf(stderr, "ext-readlink regression PASSED\n");
+
+    fprintf(stderr, "ext-readlink tests PASSED\n");
     return 0;
 }


### PR DESCRIPTION
**Security fix -- Critical: kernel heap overflow from mounting a crafted ext4 image** (a realistic threat for attached volumes / multi-tenant hosts; in a unikernel this is kernel heap corruption -> potential RCE).

## 1. `ext_readlink()` heap buffer overflow (Critical)
For a slow symlink, `modules/libext/ext_vnops.cc` did:
```c
uint32_t block_size = ext4_sb_get_block_size(&fs->sb);
void *buf = malloc(block_size);                              // e.g. 4096 bytes
ext_internal_read(fs, &inode_ref._ref, uio->uio_offset, buf, fsize, &read_count);
//                                                          ^^^^^ up to 2^64-1
```
`fsize = ext4_inode_get_size()` is the raw 64-bit inode size read straight off disk -- fully attacker-controlled and **not clamped** to `block_size`. `ext_internal_read` then writes ~`fsize` bytes into the `block_size` heap buffer.

**PoC (verified with debugfs):** craft an ext4 image with a symlink inode whose `i_size = 0x100000` (1 MiB) and `i_blocks != 0` (so the slow-symlink `else` branch is taken). `readlink()`, or any path traversal through the link, reaches `malloc(4096)` then a ~1 MiB write into it -> **heap corruption**. Also `uio_offset > fsize` underflows `fsize - offset` inside `ext_internal_read`.

**Fix:** a symlink target is at most one block (bounded by PATH_MAX); reject `fsize > block_size`, guard `uio_offset >= fsize`, check `malloc`.

## 2. `ext_readdir()` `d_name[256]` overflow (High, old-rev image)
```c
uint16_t name_length = ext4_dir_en_get_name_len(&fs->sb, it.curr);
memcpy(dir->d_name, it.curr->name, name_length);   // d_name is 256 bytes
```
On a rev-0 (minor<5) image, `ext4_dir_en_get_name_len` folds in `name_length_high` and can return up to `block_size-8` (~4088) -> ~4 KB memcpy into the 256-byte `d_name`. **Fix:** clamp to `sizeof(d_name)-1`.

## Verification
With debugfs-crafted images: a normal symlink still reads back correctly (new `tst-ext-readlink` regression), and a symlink inode with `i_size=1MiB` now returns `EINVAL` instead of overflowing the heap.

## Severity
#1 Critical (CVSS ~8.4, AV:L/needs mounted crafted image/C:H/I:H/A:H -- RCE-class). #2 High.

Both bugs are in shipped `master` (the OSv ext/lwext4 glue), not new code.