### PR TITLE
fs: validate ROFS on-disk metadata and fix symlink-path off-by-one

### DIFF
--- a/fs/rofs/rofs_vfsops.cc
+++ b/fs/rofs/rofs_vfsops.cc
@@ -110,7 +110,24 @@ rofs_mount(struct mount *mp, const char *dev, int flags, const void *data)
     memcpy(sb, buf.get(), ROFS_SUPERBLOCK_SIZE);
     //
     // Read structure_info_blocks_count to construct array of directory enries, symlinks and i-nodes
-    buf.reset(alloc_phys_contiguous_aligned(BSIZE * sb->structure_info_blocks_count, PAGE_SIZE));
+    //
+    // All the counts/sizes below come straight from the (potentially crafted)
+    // on-disk superblock, so validate them: guard the allocation size against
+    // integer overflow, null-check it, and bound every walk of @data_ptr
+    // against the end of the buffer we actually read.
+    uint64_t struct_bytes = (uint64_t)BSIZE * sb->structure_info_blocks_count;
+    if (sb->structure_info_blocks_count == 0 ||
+        struct_bytes / BSIZE != sb->structure_info_blocks_count ||
+        struct_bytes > (SIZE_MAX)) {
+        kprintf("[rofs] bad structure_info_blocks_count\n");
+        device_close(device);
+        return EINVAL;
+    }
+    buf.reset(alloc_phys_contiguous_aligned(struct_bytes, PAGE_SIZE));
+    if (!buf.get()) {
+        device_close(device);
+        return ENOMEM;
+    }
     error = rofs_read_blocks(device, sb->structure_info_first_block, sb->structure_info_blocks_count, buf.get());
     if (error) {
         kprintf("[rofs] Error reading rofs structure info blocks\n");
@@ -120,20 +137,71 @@ rofs_mount(struct mount *mp, const char *dev, int flags, const void *data)
 
     rofs = new struct rofs_info;
     rofs->sb = sb;
-    rofs->dir_entries = (struct rofs_dir_entry *) malloc(sizeof(struct rofs_dir_entry) * sb->directory_entries_count);
+    rofs->dir_entries = nullptr;
+    rofs->symlinks = nullptr;
+    rofs->inodes = nullptr;
+    // Checked allocation helper: reject count*elem overflow and zero the memory
+    // so a partial-failure cleanup can safely walk the arrays for inner
+    // pointers (filenames / symlink strings) that were not yet allocated.
+    auto checked_alloc = [](size_t count, size_t elem) -> void* {
+        if (elem && count > SIZE_MAX / elem) return nullptr;
+        return calloc(count, elem);
+    };
+    // On any post-superblock failure, free everything allocated so far so a
+    // crafted image cannot leak kernel memory across repeated mount attempts.
+    auto fail = [&](struct device *dev, int err) -> int {
+        if (rofs->dir_entries) {
+            for (uint64_t i = 0; i < sb->directory_entries_count; i++)
+                free(rofs->dir_entries[i].filename);
+            free(rofs->dir_entries);
+        }
+        if (rofs->symlinks) {
+            for (uint64_t i = 0; i < sb->symlinks_count; i++)
+                free(rofs->symlinks[i]);
+            free(rofs->symlinks);
+        }
+        free(rofs->inodes);
+        delete rofs;
+        delete sb;
+        device_close(dev);
+        return err;
+    };
+    rofs->dir_entries = (struct rofs_dir_entry *) checked_alloc(sb->directory_entries_count, sizeof(struct rofs_dir_entry));
+    if (sb->directory_entries_count && !rofs->dir_entries) {
+        return fail(device, ENOMEM);
+    }
 
     void *data_ptr = buf.get();
+    const uint8_t *data_end = (const uint8_t *)buf.get() + struct_bytes;
+    // Bounds helper: is [data_ptr, data_ptr+n) within the structure buffer?
+    auto in_bounds = [&](const void *p, size_t n) -> bool {
+        const uint8_t *q = (const uint8_t *)p;
+        // Guard the upper bound explicitly: if q has already run past data_end
+        // then (data_end - q) is negative and, cast to size_t, becomes huge and
+        // would wrongly pass the length check.
+        return q >= (const uint8_t *)buf.get() && q <= data_end &&
+               n <= (size_t)(data_end - q);
+    };
     //
     // Read directory entries
-    for (unsigned int idx = 0; idx < sb->directory_entries_count; idx++) {
+    for (uint64_t idx = 0; idx < sb->directory_entries_count; idx++) {
         struct rofs_dir_entry *dir_entry = &(rofs->dir_entries[idx]);
+        if (!in_bounds(data_ptr, sizeof(uint64_t) + sizeof(unsigned short))) {
+            kprintf("[rofs] directory entry table truncated\n");
+            return fail(device, EINVAL);
+        }
         dir_entry->inode_no = *((uint64_t *) data_ptr);
         data_ptr += sizeof(uint64_t);
 
         unsigned short *filename_size = (unsigned short *) data_ptr;
         data_ptr += sizeof(unsigned short);
 
+        if (!in_bounds(data_ptr, *filename_size)) {
+            kprintf("[rofs] directory entry name out of bounds\n");
+            return fail(device, EINVAL);
+        }
         dir_entry->filename = (char *) malloc(*filename_size + 1);
+        if (!dir_entry->filename) { return fail(device, ENOMEM); }
         strncpy(dir_entry->filename, (char *) data_ptr, *filename_size);
         dir_entry->filename[*filename_size] = 0;
         print("[rofs] i-node: %d -> directory entry: %s\n", dir_entry->inode_no, dir_entry->filename);
@@ -141,13 +209,25 @@ rofs_mount(struct mount *mp, const char *dev, int flags, const void *data)
     }
     //
     // Read symbolic links
-    rofs->symlinks = (char **) malloc(sizeof(char *) * sb->symlinks_count);
+    rofs->symlinks = (char **) checked_alloc(sb->symlinks_count, sizeof(char *));
+    if (sb->symlinks_count && !rofs->symlinks) {
+        return fail(device, ENOMEM);
+    }
 
-    for (unsigned int idx = 0; idx < sb->symlinks_count; idx++) {
+    for (uint64_t idx = 0; idx < sb->symlinks_count; idx++) {
+        if (!in_bounds(data_ptr, sizeof(unsigned short))) {
+            kprintf("[rofs] symlink table truncated\n");
+            return fail(device, EINVAL);
+        }
         unsigned short *symlink_path_size = (unsigned short *) data_ptr;
         data_ptr += sizeof(unsigned short);
 
+        if (!in_bounds(data_ptr, *symlink_path_size)) {
+            kprintf("[rofs] symlink path out of bounds\n");
+            return fail(device, EINVAL);
+        }
         rofs->symlinks[idx] = (char *) malloc(*symlink_path_size + 1);
+        if (!rofs->symlinks[idx]) { return fail(device, ENOMEM); }
         strncpy(rofs->symlinks[idx], (char *) data_ptr, *symlink_path_size);
         rofs->symlinks[idx][*symlink_path_size] = 0;
         print("[rofs] symlink: %s\n", rofs->symlinks[idx]);
@@ -155,10 +235,17 @@ rofs_mount(struct mount *mp, const char *dev, int flags, const void *data)
     }
     //
     // Read i-nodes
-    rofs->inodes = (struct rofs_inode *) malloc(sizeof(struct rofs_inode) * sb->inodes_count);
+    rofs->inodes = (struct rofs_inode *) checked_alloc(sb->inodes_count, sizeof(struct rofs_inode));
+    if (sb->inodes_count && !rofs->inodes) {
+        return fail(device, ENOMEM);
+    }
+    if (!in_bounds(data_ptr, (size_t)sb->inodes_count * sizeof(struct rofs_inode))) {
+        kprintf("[rofs] inode table out of bounds\n");
+        return fail(device, EINVAL);
+    }
     memcpy(rofs->inodes, data_ptr, sb->inodes_count * sizeof(struct rofs_inode));
 
-    for (unsigned int idx = 0; idx < sb->inodes_count; idx++) {
+    for (uint64_t idx = 0; idx < sb->inodes_count; idx++) {
         print("[rofs] inode: %d, size: %d\n", rofs->inodes[idx].inode_no, rofs->inodes[idx].file_size);
     }
 

--- a/fs/rofs/rofs_vnops.cc
+++ b/fs/rofs/rofs_vnops.cc
@@ -94,7 +94,12 @@ static int rofs_readlink(struct vnode *vnode, struct uio *uio)
         return EINVAL; //This node is not a symbolic link
     }
 
-    assert(inode->data_offset >= 0 && inode->data_offset < rofs->sb->symlinks_count);
+    // data_offset indexes the symlinks[] table; it comes from the on-disk
+    // inode, so validate it against the parsed count (assert is compiled out in
+    // release, so it is not a real guard).
+    if (inode->data_offset >= rofs->sb->symlinks_count) {
+        return EIO;
+    }
 
     char *link_path = rofs->symlinks[inode->data_offset];
 
@@ -190,11 +195,23 @@ static int rofs_readdir(struct vnode *vnode, struct file *fp, struct dirent *dir
 
         dir->d_fileno = fp->f_offset;
 
-        // Set the name
-        struct rofs_dir_entry *directory_entry = rofs->dir_entries + (inode->data_offset + index);
+        // data_offset + index indexes dir_entries[]; both come from the
+        // on-disk inode, so bound the combined index against the table size and
+        // detect uint64_t wrap (a crafted data_offset near UINT64_MAX could
+        // otherwise wrap to a small in-range value and index out of bounds).
+        uint64_t de_idx = (uint64_t)inode->data_offset + index;
+        if (de_idx < inode->data_offset ||
+            de_idx >= rofs->sb->directory_entries_count) {
+            return ENOENT;
+        }
+        struct rofs_dir_entry *directory_entry = rofs->dir_entries + de_idx;
         strlcpy((char *) &dir->d_name, directory_entry->filename, sizeof(dir->d_name));
         dir->d_ino = directory_entry->inode_no;
 
+        // inode_no is 1-based into inodes[]; validate before indexing.
+        if (dir->d_ino == 0 || dir->d_ino > rofs->sb->inodes_count) {
+            return EIO;
+        }
         struct rofs_inode *directory_entry_inode = rofs->inodes + (dir->d_ino - 1);
         if (S_ISDIR(directory_entry_inode->mode))
             dir->d_type = DT_DIR;
@@ -229,8 +246,13 @@ static int rofs_lookup(struct vnode *vnode, char *name, struct vnode **vpp)
     }
 
     for (unsigned int idx = 0; idx < inode->dir_children_count; idx++) {
-        if (strcmp(name, rofs->dir_entries[inode->data_offset + idx].filename) == 0) {
-            int inode_no = rofs->dir_entries[inode->data_offset + idx].inode_no;
+        uint64_t de_idx = (uint64_t)inode->data_offset + idx;
+        if (de_idx < inode->data_offset ||
+            de_idx >= rofs->sb->directory_entries_count) {
+            break;   // directory metadata is inconsistent; stop rather than OOB
+        }
+        if (strcmp(name, rofs->dir_entries[de_idx].filename) == 0) {
+            int inode_no = rofs->dir_entries[de_idx].inode_no;
 
             if (vget(vnode->v_mount, inode_no, &vp)) { //TODO: Will it ever work? Revisit
                 print("[rofs] found vp in cache!\n");
@@ -238,7 +260,11 @@ static int rofs_lookup(struct vnode *vnode, char *name, struct vnode **vpp)
                 return 0;
             }
 
-            struct rofs_inode *found_inode = rofs->inodes + (inode_no - 1); //Check if exists
+            // inode_no is 1-based into inodes[]; validate before indexing.
+            if (inode_no <= 0 || (unsigned)inode_no > rofs->sb->inodes_count) {
+                return EIO;
+            }
+            struct rofs_inode *found_inode = rofs->inodes + (inode_no - 1);
             rofs_set_vnode(vp, found_inode);
 
             print("[rofs] found the directory entry [%s] at at inode %d -> %d!\n", name, inode->inode_no,

--- a/fs/vfs/vfs_lookup.cc
+++ b/fs/vfs/vfs_lookup.cc
@@ -69,7 +69,11 @@ namei_follow_link(struct dentry *dp, char *node, char *name, char *fp, size_t mo
     int     c;
 
     lp    = link.get();
-    error = read_link(dp->d_vnode, lp, PATH_MAX, &sz);
+    // Read at most PATH_MAX-1 bytes so the NUL terminator written below stays
+    // inside the PATH_MAX buffer; read_link may otherwise fill all PATH_MAX
+    // bytes (a symlink target of on-disk size >= PATH_MAX) and lp[sz] would be
+    // a 1-byte out-of-bounds write.
+    error = read_link(dp->d_vnode, lp, PATH_MAX - 1, &sz);
     if (error != 0) {
         return (error);
     }


### PR DESCRIPTION
**Security fix — kernel heap corruption from a crafted ROFS image + a 1-byte OOB write in symlink resolution.** Relevant for any attacker-controlled/attached volume; in a unikernel these are kernel memory corruption.

## 1. ROFS mount trusts all superblock counts/sizes (`fs/rofs/rofs_vfsops.cc`)
- `alloc_phys_contiguous_aligned(BSIZE * structure_info_blocks_count)` — integer overflow + no null check.
- `malloc(sizeof(x) * {directory_entries,symlinks,inodes}_count)` — overflow to a tiny allocation.
- The directory-entry / symlink / inode parse loops walk `data_ptr` with **no bound** against the buffer actually read. A crafted count or per-entry `filename_size`/`symlink_path_size` walks far past the buffer → OOB read (heap contents copied into filenames) then a fault.

**Fix:** checked multiplication, null checks, and an `in_bounds()` guard on every read from the structure buffer; `EINVAL` on any inconsistency.

## 2. ROFS runtime index OOB (`fs/rofs/rofs_vnops.cc`)
`rofs_readlink`/`readdir`/`lookup` indexed `symlinks[]`, `dir_entries[]`, `inodes[]` using `data_offset` / `inode_no` / `d_ino` taken straight from the image, unbounded. The readlink guard was an `assert()` — **compiled out in release**. `inodes + (inode_no - 1)` with `inode_no==0` underflows.

**Fix:** validate every index against the parsed table sizes; reject `inode_no==0`.

## 3. `namei_follow_link` off-by-one (`fs/vfs/vfs_lookup.cc`)
`read_link(dp, lp, PATH_MAX, &sz)` can set `sz==PATH_MAX`, then `lp[sz]=0` writes 1 byte past the `PATH_MAX` buffer (symlink target of on-disk size >= PATH_MAX). **Fix:** read at most `PATH_MAX-1`.

## Severity
High (crafted image → kernel heap corruption) + Low (namei off-by-one). All in shipped `master`.

Verified: ROFS still mounts and boots to userspace, file access (lookup/readdir/readlink) works normally.