### PR TITLE
virtio-blk: do not hold the per-queue lock while draining completions

### DIFF
--- a/drivers/virtio-blk.cc
+++ b/drivers/virtio-blk.cc
@@ -362,11 +362,25 @@ void blk::req_done()
         trace_virtio_blk_wake();
 
         for (int q = 0; q < _num_queues; q++) {
-            WITH_LOCK(_queue_locks[q]) {
-                auto* q_ring = get_virt_queue(q);
-                drain_queue(q_ring);
-                q_ring->wakeup_waiter();
-            }
+            // Do NOT take _queue_locks[q] here.  make_request() holds that lock
+            // across vring::add_buf_wait(), which SLEEPS when the ring is full
+            // waiting for this completion thread to advance _used_ring_host_head
+            // (via get_buf_finalize) so the producer can GC descriptors and make
+            // room.  If we grabbed the same lock we would block on the sleeping
+            // producer while it waits on us -> permanent deadlock (seen ~1-in-3
+            // under heavy ZFS checkpoint write load at -smp1: z_wr_iss stuck in
+            // add_buf_wait holding the queue lock, virtio-blk req_done stuck on
+            // that lock, disk progress = 0 forever).  The
+            // completion drain is a single-consumer path (only this one req_done
+            // thread runs it) and races the producer's get_buf_gc only on the
+            // u16 _used_ring_host_head counter -- the same lock-free
+            // producer/consumer split the original single-queue driver used
+            // before per-queue submission locks were added.  The per-queue lock
+            // still serialises concurrent make_request producers; it must not
+            // gate completions.
+            auto* q_ring = get_virt_queue(q);
+            drain_queue(q_ring);
+            q_ring->wakeup_waiter();
         }
     }
 }


### PR DESCRIPTION
## Problem

The multiqueue support in `blk::req_done()` drains the used ring under `WITH_LOCK(_queue_locks[q])`. But `make_request()` holds that **same** per-queue lock across `vring::add_buf_wait()`, which sleeps when the ring is full, waiting for the completion thread to advance `_used_ring_host_head` so the producer can garbage-collect descriptors and make room.

The completion thread then blocks forever trying to acquire the lock the sleeping producer holds: a permanent deadlock. Under heavy sustained write load (e.g. a ZFS checkpoint storm) with a full ring, I/O progress stops with no recovery.

I hit this running PostgreSQL on ZFS: under a checkpoint write storm the guest wedged (disk progress 0 forever, the box otherwise responsive) roughly 1 in 3 heavy runs. gdb showed a `z_wr_iss` thread asleep in `add_buf_wait()` holding `_queue_locks[q]`, and the `req_done` completion thread spinning to acquire that same lock.

## Fix

Restore the pre-multiqueue behaviour: drain the used ring and wake the full-ring waiter **without** the per-queue submission lock. The completion drain is single-consumer (one `req_done` thread) and races producers only on the u16 `_used_ring_host_head` counter, exactly as the original single-queue driver did. The per-queue lock still serialises concurrent `make_request` producers; it must not gate completions.

Single-file change to `drivers/virtio-blk.cc` (+19/-5, mostly the explanatory comment).

## Validation

Built `image=native-example` and `image=tests` (EXIT 0), boots on virtio-blk. Stress-tested the exact producer/consumer path with unthrottled concurrent async writes to a virtio-blk disk (`misc-bdev-write`), which floods the ring so `add_buf_wait()` sleeps and relies on `req_done` to wake it:

| config | throughput |
|---|---|
| queues=4, 32-page bufs | 2877 Mb/s |
| queues=4, 1-page bufs (ring-full path) | 2353 Mb/s |
| queues=8 | 2052 Mb/s |
| single-queue baseline | 2144 Mb/s |

All clean, forward progress, no hang. Four consecutive multiqueue-heavy runs (including queues=8) on the lock-free completion drain, where the bug previously reproduced ~1 in 3.