### PR TITLE
virtio-balloon: reword a stray internal comment tag

### DIFF
--- a/drivers/virtio-balloon.cc
+++ b/drivers/virtio-balloon.cc
@@ -219,9 +219,9 @@ void balloon::worker()
     // target on a modest interval instead: ballooning is not latency-critical,
     // and a sub-second reaction to memory pressure is fine.
     //
-    // ponytail: polling because config-change IRQ is unwired in virtio core;
-    // drop the timer and wake purely on the config-change vector once that is
-    // plumbed (VIRTIO_MSI_CONFIG_VECTOR).
+    // TODO: polling because the config-change IRQ is unwired in the virtio
+    // core; drop the timer and wake purely on the config-change vector once
+    // that is plumbed (VIRTIO_MSI_CONFIG_VECTOR).
     using namespace std::chrono;
     WITH_LOCK(_mtx) {
         while (!_shutdown) {


### PR DESCRIPTION
A comment in the balloon config-change polling loop carried a stray internal shorthand tag that slipped through review. This rewords it as a plain `TODO:` with the same technical content, no functional change.

The note still says what it should: the loop polls because the config-change IRQ is unwired in the virtio core, and the intended follow-up is to wake on the config-change vector (VIRTIO_MSI_CONFIG_VECTOR) once that is plumbed.