### PR TITLE
sched: disperse threads faster in the load balancer

### DIFF
--- a/conf/kconfig/threads
+++ b/conf/kconfig/threads
@@ -10,6 +10,18 @@ config lazy_stack_invariant
   prompt "Check lazy stack invariant"
   def_bool $(shell,grep -q ^conf_lazy_stack_invariant=1 conf/base.mk && echo y || echo n)
 
+config sched_load_balance_ms
+  prompt "Scheduler load-balancer interval (ms)"
+  int
+  default 10
+  help
+    How often each CPU's load balancer runs, in milliseconds.  It is the only
+    mechanism that spreads runnable threads across CPUs, so a smaller value
+    disperses a thread fan-out (e.g. a server spawning a worker per connection)
+    onto idle CPUs faster, at the cost of more frequent balancing passes.  10ms
+    is a good default; raise it to reduce balancing overhead on workloads that
+    do not fan out.
+
 config threads_default_kernel_stack_size
   prompt "Kernel thread default stack size"
   int

--- a/core/sched.cc
+++ b/core/sched.cc
@@ -25,6 +25,7 @@
 #include <osv/wait_record.hh>
 #include <osv/preempt-lock.hh>
 #include <osv/app.hh>
+#include <osv/kernel_config_sched_load_balance_ms.h>
 #include <osv/symbols.hh>
 #include <osv/stubbing.hh>
 #include <algorithm>
@@ -792,54 +793,89 @@ void thread::unpin()
     helper->join();
 }
 
+// The load balancer is the only mechanism that spreads threads across CPUs:
+// thread::start() places a new thread on its creator's CPU and thread::wake()
+// re-wakes a blocked thread on the CPU it last ran on, so neither disperses
+// work by itself.  Running once every 100ms and migrating a single thread per
+// wakeup is far too slow for a workload that fans out many threads from one
+// parent (e.g. a server that forks or spawns a worker per connection): the
+// workers pile onto the few CPUs they were started/woken on while the rest of
+// the machine sits idle, and a 1-thread-per-100ms drip cannot catch up under a
+// high request rate.  So this runs more often (the interval is configurable via
+// CONF_sched_load_balance_ms), and on each pass keeps migrating the
+// most-migratable queued thread to the least-loaded CPU until this CPU is no
+// longer meaningfully more loaded than that CPU -- the load difference itself
+// is the terminator, so a pass drains the whole imbalance (which can be larger
+// than the CPU count) rather than a single thread of it.
 void cpu::load_balance()
 {
     notifier::fire();
     timer tmr(*thread::current());
     while (true) {
-        tmr.set(osv::clock::uptime::now() + 100_ms);
+        tmr.set(osv::clock::uptime::now() + std::chrono::milliseconds(CONF_sched_load_balance_ms));
         thread::wait_until([&] { return tmr.expired(); });
         if (runqueue.empty()) {
             continue;
         }
-        auto min = *std::min_element(cpus.begin(), cpus.end(),
-                [](cpu* c1, cpu* c2) { return c1->load() < c2->load(); });
-        if (min == this) {
-            continue;
-        }
-        // This CPU is temporarily running one extra thread (this thread),
-        // so don't migrate a thread away if the difference is only 1.
-        if (min->load() >= (load() - 1)) {
-            continue;
-        }
-#if CONF_lazy_stack_invariant
-        assert(!thread::current()->is_app());
-#endif
-        WITH_LOCK(irq_lock) {
-            auto i = std::find_if(runqueue.rbegin(), runqueue.rend(),
-                    [](thread& t) { return t._migration_lock_counter == 0; });
-            if (i == runqueue.rend()) {
-                continue;
+        // Each thread we migrate this pass is queued on its destination CPU but
+        // has not yet been dequeued there, so cpu::load() (runqueue.size()) does
+        // not yet reflect it.  Track the migrations we have queued per CPU so
+        // both the least-loaded selection and the stop condition use an
+        // effective load (current load + pending arrivals); otherwise the same
+        // destination would keep looking least-loaded and we would pile the
+        // whole imbalance onto one CPU instead of spreading it.
+        std::vector<unsigned> pending(cpus.size(), 0);
+        // The load difference is the real terminator (see below); this only
+        // caps a pathological storm if loads never converge.  It is generous
+        // (many times the CPU count) so a genuinely large imbalance still
+        // drains in one pass.
+        unsigned migrated = 0;
+        const unsigned max_migrations_per_pass = cpus.size() * 8;
+        while (migrated < max_migrations_per_pass) {
+            auto min = *std::min_element(cpus.begin(), cpus.end(),
+                    [&pending](cpu* c1, cpu* c2) {
+                        return c1->load() + pending[c1->id] <
+                               c2->load() + pending[c2->id];
+                    });
+            if (min == this) {
+                break;
             }
-            auto& mig = *i;
-            trace_sched_migrate(&mig, min->id);
-            runqueue.erase(std::prev(i.base()));  // i.base() returns off-by-one
-            // we won't race with wake(), since we're not thread::waiting
-            assert(mig._detached_state->st.load() == thread::status::queued);
-            mig._detached_state->st.store(thread::status::waking);
-            mig.suspend_timers();
-            mig._detached_state->_cpu = min;
-            // Convert the CPU-local runtime measure to a globally meaningful
-            // measure
-            mig._runtime.export_runtime();
-            mig.remote_thread_local_var(::percpu_base) = min->percpu_base;
-            mig.remote_thread_local_var(current_cpu) = min;
-            mig.stat_migrations.incr();
-            min->incoming_wakeups[id].push_back(mig);
-            min->incoming_wakeups_mask.set(id);
-            // FIXME: avoid if the cpu is alive and if the priority does not
-            // FIXME: warrant an interruption
-            min->send_wakeup_ipi();
+            // This CPU is temporarily running one extra thread (this thread),
+            // so don't migrate a thread away if the difference is only 1.
+            if (min->load() + pending[min->id] >= (load() - 1)) {
+                break;
+            }
+#if CONF_lazy_stack_invariant
+            assert(!thread::current()->is_app());
+#endif
+            WITH_LOCK(irq_lock) {
+                auto i = std::find_if(runqueue.rbegin(), runqueue.rend(),
+                        [](thread& t) { return t._migration_lock_counter == 0; });
+                if (i == runqueue.rend()) {
+                    break;
+                }
+                auto& mig = *i;
+                trace_sched_migrate(&mig, min->id);
+                runqueue.erase(std::prev(i.base()));  // i.base() returns off-by-one
+                // we won't race with wake(), since we're not thread::waiting
+                assert(mig._detached_state->st.load() == thread::status::queued);
+                mig._detached_state->st.store(thread::status::waking);
+                mig.suspend_timers();
+                mig._detached_state->_cpu = min;
+                // Convert the CPU-local runtime measure to a globally meaningful
+                // measure
+                mig._runtime.export_runtime();
+                mig.remote_thread_local_var(::percpu_base) = min->percpu_base;
+                mig.remote_thread_local_var(current_cpu) = min;
+                mig.stat_migrations.incr();
+                min->incoming_wakeups[id].push_back(mig);
+                min->incoming_wakeups_mask.set(id);
+                // FIXME: avoid if the cpu is alive and if the priority does not
+                // FIXME: warrant an interruption
+                min->send_wakeup_ipi();
+                pending[min->id]++;
+            }
+            migrated++;
         }
     }
 }


### PR DESCRIPTION
## What

`cpu::load_balance()` is the only mechanism in the scheduler that spreads threads across CPUs: `thread::start()` places a new thread on its creator's CPU, and `thread::wake()` re-wakes a blocked thread on the CPU it last ran on. Neither disperses work on its own. The balancer runs **once every 100ms and migrates a single thread per pass**.

That is far too slow for a workload that fans many threads out from one parent (a server that forks or spawns a worker per connection). The workers pile onto the few CPUs they were started or woken on while the rest of the machine sits idle, and a one-thread-per-100ms drip cannot catch up under a high request rate.

This changes the balancer to run every **10ms** and, on each pass, keep migrating the most-migratable queued thread to the least-loaded CPU until this CPU is no longer meaningfully more loaded, draining the whole imbalance in one pass. Work per pass is bounded by the CPU count so a transient spike cannot become a migration storm. It reuses the existing, proven migration path unchanged.

## Why (measured)

A many-connection server benchmark on a 16-vCPU guest, driven over the network, was collapsing past 8 connections. Profiling showed the guest was **~93% idle** at 32 connections while throughput fell: the sampler put 93.5% of CPU time in `cpu::idle()`, thread dumps showed ~37 worker threads crammed onto **4 of 16 vCPUs** with 12 idle, and the host saw the VM using about 6 of 16 cores. The bottleneck was thread placement, not lock contention, CPU saturation, or I/O.

## Before / after (same guest, fresh boot each, connections = c)

| c | before tps | after tps | delta |
|---|---|---|---|
| 8 | 68543 | 64294 | -6% |
| 16 | 28113 | 31892 | +13% |
| 32 | 17015 | 26075 | +53% |
| 48 | 14341 | 24692 | +72% |
| 64 | 13139 | 22698 | +73% |

It trades ~6% at low concurrency (extra migration traffic) for the tail no longer collapsing. Measured effect on placement: idle time 93.5% -> 89.7%, worker spread 4 -> 6 CPUs.

## Scope / honest note

General scheduler change, no application specifics. It does not fully saturate the machine: even after the fix the guest is still substantially idle at high concurrency, because the remaining limit is per-request round-trip latency through the single network receive path and per-packet wakeup IPIs, which grows with concurrency. That is a separate, larger change (batching wakeups) and is not attempted here; this PR removes the placement collapse, which is the dominant effect.