### PR TITLE
virtio-blk: handle completions on the queue's dedicated thread

### DIFF
--- a/documentation/block-multiqueue.md
+++ b/documentation/block-multiqueue.md
@@ -3,13 +3,13 @@
 ## Overview
 
 The virtio-blk driver can negotiate `VIRTIO_BLK_F_MQ` with the host and
-operate multiple virtqueues, one selected per submitting CPU.  This lets
+operate multiple virtqueues, one selected per submitting CPU. This lets
 several vCPUs submit block I/O in parallel against independent rings
 instead of serialising on a single queue lock.
 
 The implementation lives entirely in `drivers/virtio-blk.cc` and
 `drivers/virtio-blk.hh`; there is no separate generic block-multiqueue
-framework.  Each queue is an ordinary virtio virtqueue guarded by its own
+framework. Each queue is an ordinary virtio virtqueue guarded by its own
 mutex.
 
 ## Queue assignment
@@ -28,13 +28,13 @@ on the common path.
 
 When the host offers `VIRTIO_BLK_F_MQ`, the driver reads `num_queues`
 from the device config and `probe_virt_queues()` sets up that many
-virtqueues.  The probed count is authoritative: a per-queue lock vector
-(`_queue_locks`) is sized to match, and a single completion thread services
-all of them.
+virtqueues. The probed count is authoritative: a per-queue lock vector
+(`_queue_locks`) is sized to match, and each queue is serviced by its
+dedicated completion thread.
 
 ```c
 probe_virt_queues();
-_num_queues = virtio_driver::_num_queues;
+_num_queues = std::min(virtio_driver::_num_queues, sched::cpus.size());
 ...
 _queue_locks = std::vector<mutex>(_num_queues);
 ```
@@ -59,42 +59,34 @@ mapped to the same queue (more vCPUs than queues) share that queue's lock.
 
 With MSI-X the transport assigns one interrupt vector per virtqueue
 (`setup_queue()` maps queue index i to MSI-X entry i), so a completion on any
-queue raises that queue's own vector.  We register a per-queue ISR for every
-vector; each ISR disables its own queue's interrupts and wakes a single shared
-completion thread.  That thread sleeps until any queue's used ring has pending
-completions (re-arming interrupts on every queue and re-checking before it
+queue raises that queue's own vector. We register a per-queue ISR for every
+vector; each ISR disables its own queue's interrupts and wakes its dedicated
+completion thread. That thread sleeps until its queue's used ring has pending
+completions (re-arming interrupts on thus queue and re-checking before it
 sleeps, so a completion arriving during the check is never missed), and when
-woken it drains every queue, taking each queue's lock so it cannot race with
-that queue's owner:
+woken it drains this queue, without having to take the queue's lock because
+it races only on a lock-less `_used_ring_host_head` counter:
 
 ```c
-for (int q = 0; q < _num_queues; q++) {
-    WITH_LOCK(_queue_locks[q]) {
-        drain_queue(get_virt_queue(q));
-        get_virt_queue(q)->wakeup_waiter();
+void blk::req_done(int qid)
+{
+    auto* queue = get_virt_queue(qid);
+    blk_req* req;
+
+    while (1) {
+        virtio_driver::wait_for_queue(queue, &vring::used_ring_not_empty);
+
+        ..
+        // wake up the requesting thread in case the ring was full before
+        queue->wakeup_waiter();
     }
 }
 ```
 
-So all queues (vrings) and their MSI-X vectors are fully used; the single
-consumer thread is only the *completion-side* fan-in, not a per-queue
-bottleneck (submission is lock-per-queue and runs on the owning CPU).  On the
-non-MSI-X / MMIO path a single shared IRQ line fans into the same all-queue
-drain.
-
-The wake predicate checks every queue's used ring and re-arms interrupts on
-all queues when none have work, so a completion landing on any queue wakes
-the single thread.
-
-### Known limitation
-
-Because only one MSI/legacy interrupt vector is wired, completions for all
-queues are processed from the CPU that takes the interrupt (typically
-CPU 0), which then reaches across queues on the owners' behalf.  A future
-change can register a per-queue interrupt (as the NVMe driver does via
-`driver::register_io_interrupt()`), so each queue's completions land on
-its owning CPU and the cross-queue drain loop can be dropped.  The
-submission path already scales; only completion handling is centralised.
+So all queues (vrings) and their MSI-X vectors are fully used; each queue
+is serviced by its dedicated consumer thread, submission is lock-per-queue
+and runs on the owning CPU). On the non-MSI-X / MMIO path a single shared
+IRQ line fans into the same single-queue drain.
 
 ## Configuration
 
@@ -111,7 +103,7 @@ qemu-system-x86_64 \
 
 `scripts/run.py` exposes this through the `--virtio-blk-queues` option so
 test images can request multiple queues without hand-editing the QEMU
-command line.  With one vCPU or one queue the driver behaves exactly as the
+command line. With one vCPU or one queue the driver behaves exactly as the
 original single-queue path.
 
 ## Testing

--- a/drivers/virtio-blk.cc
+++ b/drivers/virtio-blk.cc
@@ -132,48 +132,64 @@ blk::blk(virtio_device& virtio_dev)
 
     // read_config() recorded the device's advertised num_queues, but
     // probe_virt_queues() determines how many virtqueues actually exist and
-    // stores that in the base class _num_queues.  Use the probed count as the
+    // stores that in the base class _num_queues.
+    // Use the minimum of probed count and number of cpus as the
     // authoritative value so make_request()/req_done() never index a queue the
-    // base class did not set up.
-    _num_queues = virtio_driver::_num_queues;
+    // base class did not set up. Also, there is no point of creating more queues
+    // than number of cpus, as make_request() would never submit requests there.
+    _num_queues = std::min<u32>(virtio_driver::_num_queues, sched::cpus.size());
 
-    // Resize per-queue lock vector now that _num_queues is known.
+    // Resize per-queue lock vector and create as many threads
+    // now that _num_queues is known.
     _queue_locks = std::vector<mutex>(_num_queues);
+    auto threads = std::vector<sched::thread*>(_num_queues);
 
     // Enable indirect descriptors on every queue so large multi-segment
     // requests use a single descriptor entry on whichever queue
     // make_request() selects.
+    bool multi_queue = _num_queues > 1;
     for (int qid = 0; qid < _num_queues; qid++) {
         get_virt_queue(qid)->set_use_indirect(true);
+        auto *t = sched::thread::make(
+           [this,qid] { this->req_done(qid); },
+           sched::thread::attr().name("virtio-blk" + (_num_queues > 1 ? std::to_string(qid) : "") + "_req_done"));
+        t->start();
+        // It only makes sense and is actuall necessary to pin the consumer
+        // threads when there are more than one queue so that each is serviced
+        // on different cpu to make it thread-safe
+        if (multi_queue) {
+           auto cpu = sched::cpus[qid % sched::cpus.size()];
+           sched::thread::pin(t, cpu);
+        }
+        threads[qid] = t;
     }
-
-    // One completion thread services all virtqueues: it wakes when any queue's
-    // MSI-X vector fires, then drains every queue.
-    sched::thread* t = sched::thread::make(
-        [this] { this->req_done(); },
-        sched::thread::attr().name("virtio-blk"));
-    t->start();
+    //
+    // Use 1st thread when only single queue is available
+    auto single_thread = threads[0];
 
     // With VIRTIO_BLK_F_MQ, setup_queue() maps queue index i -> MSI-X entry i
     // (1:1), so a completion on queue i raises entry i's interrupt, not queue
     // 0's; register an ISR for every queue's vector or completions on queues
-    // 1..N-1 are never serviced and I/O steered there hangs.  Each ISR disables
-    // its own queue's interrupts and wakes the single completion thread, which
-    // then drains all queues.  (The config-change MSI-X vector is left at
+    // 1..N-1 are never serviced and I/O steered there hangs. Each ISR disables
+    // its own queue's interrupts and wakes its dedicated completion thread, which
+    // then drains the queue. (The config-change MSI-X vector is left at
     // VIRTIO_MSI_NO_VECTOR, as it is for all OSv virtio devices - virtio-blk
     // reads capacity via the config space, not a config-change interrupt.)
     interrupt_factory int_factory;
 #if CONF_drivers_pci
-    int_factory.register_msi_bindings = [this, t](interrupt_manager &msi) {
+    int_factory.register_msi_bindings = [this, threads](interrupt_manager &msi) {
         std::vector<msix_binding> bindings;
         bindings.reserve(_num_queues);
         for (int qid = 0; qid < _num_queues; qid++) {
+            // Use a dedicated thread to be woken up when
+            // an interrupt for the relevant queue is delivered
             auto* q = get_virt_queue(qid);
-            bindings.push_back({ (unsigned)qid, [q] { q->disable_interrupts(); }, t });
+            auto* t = threads[qid];
+            bindings.push_back({ (unsigned)qid, [q,t] { q->disable_interrupts(); }, t });
         }
         // easy_register() needs one MSI-X vector per binding; if the device
         // advertised more queues than it has MSI-X entries it returns false
-        // having registered NONE, which would silently hang all I/O.  Fail
+        // having registered NONE, which would silently hang all I/O. Fail
         // loudly at probe instead - a device that negotiates F_MQ is expected
         // to expose at least num_queues (+1 config) vectors.
         if (!msi.easy_register(bindings)) {
@@ -183,28 +199,28 @@ blk::blk(virtio_device& virtio_dev)
         }
     };
 
-    int_factory.create_pci_interrupt = [this,t](pci::device &pci_dev) {
+    int_factory.create_pci_interrupt = [this,single_thread](pci::device &pci_dev) {
         return new pci_interrupt(
             pci_dev,
             [=] { return this->ack_irq(); },
-            [=] { t->wake_with_irq_disabled(); });
+            [=] { single_thread->wake_with_irq_disabled(); });
     };
 #endif
 
 #if CONF_drivers_mmio
 #ifdef __aarch64__
-    int_factory.create_spi_edge_interrupt = [this,t]() {
+    int_factory.create_spi_edge_interrupt = [this,single_thread]() {
         return new spi_interrupt(
             gic::irq_type::IRQ_TYPE_EDGE,
             _dev.get_irq(),
             [=] { return this->ack_irq(); },
-            [=] { t->wake_with_irq_disabled(); });
+            [=] { single_thread->wake_with_irq_disabled(); });
     };
 #else
-    int_factory.create_gsi_edge_interrupt = [this,t]() {
+    int_factory.create_gsi_edge_interrupt = [this,single_thread]() {
         return new gsi_edge_interrupt(
             _dev.get_irq(),
-            [=] { if (this->ack_irq()) t->wake_with_irq_disabled(); });
+            [=] { if (this->ack_irq()) single_thread->wake_with_irq_disabled(); });
     };
 #endif
 #endif
@@ -225,7 +241,8 @@ blk::blk(virtio_device& virtio_dev)
     dev->max_io_size = _config.seg_max ? (_config.seg_max - 1) * mmu::page_size : UINT_MAX;
     read_partition_table(dev);
 
-    debugf("virtio-blk: Add blk device instances %d as %s, devsize=%lld\n", _id, dev_name.c_str(), dev->size);
+    debugf("virtio-blk: Add blk device instances %d as %s with %d queue%s, devsize=%lld\n",
+        _id, dev_name.c_str(), _num_queues, (_num_queues > 1 ? "s" : ""), dev->size);
 }
 
 blk::~blk()
@@ -285,103 +302,50 @@ void blk::read_config()
 }
 
 /*
- * drain_queue() — pull all completed requests off one virtqueue ring.
- * Returns the number of completions processed.
+ * req_done() — completion thread for single virtqueue.
+ *
+ * virtio-blk uses one interrupt per queue, so a completion landing on that queue
+ * wakes its thread. It sleeps until this queue's used ring is non-empty,
+ * then drains it. No lock needs to be held while the queue is drained,
+ * as the req_done() for each queue is handled on different cpu, and also
+ * is thread-safe when interacting with producer threads calling make_request()
+ * because it races only on the lock-free _used_ring_host_head counter.
  */
-int blk::drain_queue(vring* queue)
+void blk::req_done(int qid)
 {
-    int n = 0;
-    u32 len;
+    auto* queue = get_virt_queue(qid);
     blk_req* req;
 
-    while ((req = static_cast<blk_req*>(queue->get_buf_elem(&len))) != nullptr) {
-        if (req->bio) {
-            switch (req->res.status) {
-            case VIRTIO_BLK_S_OK:
-                trace_virtio_blk_req_ok(req->bio, req->hdr.sector,
-                                        req->bio->bio_bcount, req->hdr.type);
-                biodone(req->bio, true);
-                break;
-            case VIRTIO_BLK_S_UNSUPP:
-                trace_virtio_blk_req_unsupp(req->bio, req->hdr.sector,
-                                            req->bio->bio_bcount, req->hdr.type);
-                biodone(req->bio, false);
-                break;
-            default:
-                trace_virtio_blk_req_err(req->bio, req->hdr.sector,
-                                         req->bio->bio_bcount, req->hdr.type);
-                biodone(req->bio, false);
-                break;
-            }
-        }
-        delete req;
-        queue->get_buf_finalize();
-        n++;
-    }
-    return n;
-}
-
-/*
- * req_done() — single completion thread for all virtqueues.
- *
- * virtio-blk uses one shared interrupt, so a completion landing on any queue
- * wakes this thread.  It sleeps until at least one queue's used ring is
- * non-empty, then drains every queue.  Each queue's lock is held only while
- * that queue is drained, so make_request() on other CPUs/queues can proceed
- * concurrently.
- */
-bool blk::any_queue_not_empty()
-{
-    for (int q = 0; q < _num_queues; q++) {
-        auto* ring = get_virt_queue(q);
-        if (ring->used_ring_not_empty()) {
-            ring->disable_interrupts();
-            return true;
-        }
-    }
-    // Nothing pending: re-arm interrupts on every queue, then re-check to
-    // close the race where a completion arrives between the loop above and
-    // enabling interrupts here.
-    for (int q = 0; q < _num_queues; q++) {
-        get_virt_queue(q)->enable_interrupts();
-    }
-    for (int q = 0; q < _num_queues; q++) {
-        auto* ring = get_virt_queue(q);
-        if (ring->used_ring_not_empty()) {
-            ring->disable_interrupts();
-            return true;
-        }
-    }
-    return false;
-}
-
-void blk::req_done()
-{
     while (1) {
-        sched::thread::wait_until([this] { return this->any_queue_not_empty(); });
+
+        virtio_driver::wait_for_queue(queue, &vring::used_ring_not_empty);
         trace_virtio_blk_wake();
 
-        for (int q = 0; q < _num_queues; q++) {
-            // Do NOT take _queue_locks[q] here.  make_request() holds that lock
-            // across vring::add_buf_wait(), which SLEEPS when the ring is full
-            // waiting for this completion thread to advance _used_ring_host_head
-            // (via get_buf_finalize) so the producer can GC descriptors and make
-            // room.  If we grabbed the same lock we would block on the sleeping
-            // producer while it waits on us -> permanent deadlock (seen ~1-in-3
-            // under heavy ZFS checkpoint write load at -smp1: z_wr_iss stuck in
-            // add_buf_wait holding the queue lock, virtio-blk req_done stuck on
-            // that lock, disk progress = 0 forever).  The
-            // completion drain is a single-consumer path (only this one req_done
-            // thread runs it) and races the producer's get_buf_gc only on the
-            // u16 _used_ring_host_head counter -- the same lock-free
-            // producer/consumer split the original single-queue driver used
-            // before per-queue submission locks were added.  The per-queue lock
-            // still serialises concurrent make_request producers; it must not
-            // gate completions.
-            auto* q_ring = get_virt_queue(q);
-            drain_queue(q_ring);
-            q_ring->wakeup_waiter();
+        u32 len;
+        while((req = static_cast<blk_req*>(queue->get_buf_elem(&len))) != nullptr) {
+            if (req->bio) {
+                switch (req->res.status) {
+                case VIRTIO_BLK_S_OK:
+                    trace_virtio_blk_req_ok(req->bio, req->hdr.sector, req->bio->bio_bcount, req->hdr.type);
+                    biodone(req->bio, true);
+                    break;
+                case VIRTIO_BLK_S_UNSUPP:
+                    trace_virtio_blk_req_unsupp(req->bio, req->hdr.sector, req->bio->bio_bcount, req->hdr.type);
+                    biodone(req->bio, false);
+                    break;
+                default:
+                    trace_virtio_blk_req_err(req->bio, req->hdr.sector, req->bio->bio_bcount, req->hdr.type);
+                    biodone(req->bio, false);
+                    break;
+               }
+            }
+
+            delete req;
+            queue->get_buf_finalize();
         }
+
+        // wake up the requesting thread in case the ring was full before
+        queue->wakeup_waiter();
     }
 }
 

--- a/drivers/virtio-blk.hh
+++ b/drivers/virtio-blk.hh
@@ -150,7 +150,7 @@ public:
 
     int make_request(struct bio*);
 
-    void req_done();
+    void req_done(int qid);
     int64_t size();
 
     void set_readonly() {_ro = true;}
@@ -159,14 +159,7 @@ public:
     bool ack_irq();
 
     static hw_driver* probe(hw_device* dev);
-
-    /* Pull all completed requests off one virtqueue ring. */
-    static int drain_queue(vring* queue);
 private:
-
-    /* Wake predicate for the completion thread: true if any queue's used
-     * ring has completions pending. */
-    bool any_queue_not_empty();
 
     struct blk_req {
         blk_req(struct bio* b) :bio(b) {};

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -699,11 +699,8 @@ if __name__ == "__main__":
     else:
         cmdargs.virtio_device_suffix = ""
 
-    # Add multiqueue support for virtio-blk if specified
-    if cmdargs.virtio_blk_queues > 1:
-        cmdargs.virtio_blk_queue_suffix = ",num-queues=%d" % cmdargs.virtio_blk_queues
-    else:
-        cmdargs.virtio_blk_queue_suffix = ""
+    # Add multiqueue support for virtio-blk
+    cmdargs.virtio_blk_queue_suffix = ",num-queues=%d" % cmdargs.virtio_blk_queues
 
     if cmdargs.networking and cmdargs.tap and (cmdargs.execute == None or '--ip=' not in cmdargs.execute):
         process = subprocess.run(["ip", "address", "show", cmdargs.tap], stdout=subprocess.PIPE)


### PR DESCRIPTION
This changes virtio-blk driver to create as many completion threads as there are virt queues. So if there are more than a single queue, interrupts delivered are serviced by its own dedicated queue instead of a single shared one. The idea is to minimize the number of IPIs because hopefully a submission thread would be woken by a completion thread running on the same cpu.

This also reverts some of the changes made to have a single completion thread handle all queues.

Finally, this modifies `run.py` to explicitly set the number of virt queues to 1 as advertised instead of defaulting to the number of cpus. 

It turns out that multiple queues (>1) do not really lead to higher throughput, as these results demonstrate:
```
./scripts/build fs=rofs image=fio

./scripts/run.py -e '/fio --thread --name=fiotest --filename=/dev/vblk1 --numjobs=4 --rw=read --size=128M --cpus_allowed_policy=split --cpus_allowed=0-3' --second-disk=./disk2.img //Read test, run 3 times

./scripts/run.py -e '/fio --thread --name=fiotest --filename=/dev/vblk1 --numjobs=4 --rw=write --size=128M --cpus_allowed_policy=split --cpus_allowed=0-3' --second-disk=./disk2.img //Write test, run 3 times

### Before introducing multiple queues - single queue, single completion thread
READ: bw=577MiB/s (605MB/s), 144MiB/s-145MiB/s (151MB/s-153MB/s), io=512MiB (537MB), run=880-887msec
READ: bw=576MiB/s (604MB/s), 144MiB/s-145MiB/s (151MB/s-153MB/s), io=512MiB (537MB), run=880-889msec
READ: bw=547MiB/s (574MB/s), 137MiB/s-139MiB/s (143MB/s-146MB/s), io=512MiB (537MB), run=922-936msec

WRITE: bw=511MiB/s (536MB/s), 128MiB/s-128MiB/s (134MB/s-134MB/s), io=512MiB (537MB), run=1002-1002msec
WRITE: bw=491MiB/s (515MB/s), 123MiB/s-123MiB/s (129MB/s-129MB/s), io=512MiB (537MB), run=1043-1043msec
WRITE: bw=511MiB/s (536MB/s), 128MiB/s-128MiB/s (134MB/s-134MB/s), io=512MiB (537MB), run=1002-1002msec

### As of master before this PR - 4 queues, single completion thread, no lock in `req_done()`
READ: bw=459MiB/s (481MB/s), 115MiB/s-116MiB/s (120MB/s-121MB/s), io=512MiB (537MB), run=1106-1116msec
READ: bw=459MiB/s (481MB/s), 115MiB/s-116MiB/s (120MB/s-122MB/s), io=512MiB (537MB), run=1101-1115msec
READ: bw=463MiB/s (485MB/s), 116MiB/s-116MiB/s (121MB/s-122MB/s), io=512MiB (537MB), run=1100-1107msec

WRITE: bw=454MiB/s (476MB/s), 114MiB/s-114MiB/s (119MB/s-120MB/s), io=512MiB (537MB), run=1119-1127msec
WRITE: bw=457MiB/s (479MB/s), 114MiB/s-116MiB/s (120MB/s-122MB/s), io=512MiB (537MB), run=1100-1121msec
WRITE: bw=444MiB/s (465MB/s), 111MiB/s-113MiB/s (116MB/s-119MB/s), io=512MiB (537MB), run=1129-1154msec

### With this patch - by default (see `run.py` change), single queue, single completion queue
READ: bw=560MiB/s (587MB/s), 140MiB/s-142MiB/s (147MB/s-149MB/s), io=512MiB (537MB), run=902-915msec
READ: bw=539MiB/s (565MB/s), 135MiB/s-136MiB/s (141MB/s-142MB/s), io=512MiB (537MB), run=942-950msec
READ: bw=558MiB/s (585MB/s), 140MiB/s-142MiB/s (146MB/s-148MB/s), io=512MiB (537MB), run=904-917msec

WRITE: bw=494MiB/s (518MB/s), 123MiB/s-124MiB/s (129MB/s-130MB/s), io=512MiB (537MB), run=1035-1037msec
WRITE: bw=514MiB/s (538MB/s), 128MiB/s-129MiB/s (135MB/s-135MB/s), io=512MiB (537MB), run=996-997msec
WRITE: bw=501MiB/s (526MB/s), 125MiB/s-126MiB/s (131MB/s-132MB/s), io=512MiB (537MB), run=1016-1021msec

### With this patch - 4 queues, 4 dedicated completion queues
READ: bw=464MiB/s (487MB/s), 116MiB/s-126MiB/s (122MB/s-132MB/s), io=512MiB (537MB), run=1017-1103msec
READ: bw=468MiB/s (490MB/s), 117MiB/s-123MiB/s (123MB/s-129MB/s), io=512MiB (537MB), run=1038-1095msec
READ: bw=441MiB/s (462MB/s), 110MiB/s-125MiB/s (116MB/s-131MB/s), io=512MiB (537MB), run=1022-1162msec

WRITE: bw=343MiB/s (359MB/s), 85.7MiB/s-126MiB/s (89.8MB/s-132MB/s), io=512MiB (537MB), run=1014-1494msec
WRITE: bw=505MiB/s (529MB/s), 126MiB/s-138MiB/s (132MB/s-145MB/s), io=512MiB (537MB), run=925-1014msec
WRITE: bw=365MiB/s (383MB/s), 91.2MiB/s-127MiB/s (95.7MB/s-133MB/s), io=512MiB (537MB), run=1007-1403msec
```