### PR TITLE
net: batch per-connection wakeups in the virtio-net receiver

### DIFF
--- a/core/net_channel.cc
+++ b/core/net_channel.cc
@@ -138,10 +138,27 @@ bool classifier::post_packet(mbuf* m)
             if (!nc->push(m)) {
                 return false;
             }
-            // FIXME: find a way to batch wakes
             nc->wake();
             return true;
         }
+    }
+    return false;
+}
+
+bool classifier::post_packet(mbuf* m, net_channel_wake_batch& batch)
+{
+#if CONF_lazy_stack_invariant
+    assert(!sched::thread::current()->is_app());
+#endif
+    // Caller holds osv::rcu_read_lock across the whole drain pass; the recorded
+    // channel pointers stay valid until batch.flush() runs under that lock.
+    if (auto nc = classify_ipv4_tcp(m)) {
+        log_packet_in(m, NETISR_ETHER);
+        if (!nc->push(m)) {
+            return false;
+        }
+        batch.add(nc);
+        return true;
     }
     return false;
 }

--- a/drivers/virtio-net.cc
+++ b/drivers/virtio-net.cc
@@ -18,6 +18,7 @@
 
 #include <string>
 #include <string.h>
+#include <stdlib.h>
 #include <map>
 #include <errno.h>
 #include <osv/debug.h>
@@ -459,6 +460,16 @@ bool net::bad_rx_csum(struct mbuf* m, struct net_hdr* hdr)
     return false;
 }
 
+bool net::batch_wakes_enabled()
+{
+    // Cached: cannot change after boot; the receiver reads it once.
+    static const bool enabled = [] {
+        const char* v = getenv("OSV_NET_BATCH_WAKE");
+        return !(v && v[0] == '0');
+    }();
+    return enabled;
+}
+
 void net::receiver()
 {
     vring* vq = _rxq.vqueue;
@@ -466,6 +477,17 @@ void net::receiver()
     u64 rx_drops = 0, rx_packets = 0, csum_ok = 0;
     u64 csum_err = 0, rx_bytes = 0;
     static const u16 refill_thresh = 16;
+    // Coalesce the per-packet channel wakes issued while draining one RX pass
+    // into one wake per channel, flushed together at the end of the pass, so
+    // the scheduler's per-target-CPU IPI coalescing collapses the wakeup IPIs.
+    // Runtime toggle for A/B; default on.
+    net_channel_wake_batch wake_batch;
+    const bool batch_wakes = net::batch_wakes_enabled();
+    // Slow-path (non-classified) packets are deferred to after the drain's
+    // rcu_read_lock is released: if_input() runs the full BSD stack (tcp_input
+    // etc.) which may demand-fault a page, and page_fault asserts preemptable()
+    // -- illegal under the rcu_read_lock the batch path holds across the drain.
+    std::vector<mbuf*> slow_path;
 
     while (1) {
 
@@ -484,6 +506,15 @@ void net::receiver()
         // use local header that we copy out of the mbuf since we're
         // truncating it.
         net_hdr_mrg_rxbuf* mhdr;
+
+        // When batching wakes we hold one rcu_read_lock across the whole drain
+        // pass and the wake flush, because the net_channel pointers we record
+        // are rcu_dispose()d on connection teardown and must stay valid until
+        // flushed.  When not batching, post_packet() takes its own lock per
+        // packet as before.
+        if (batch_wakes) {
+            osv::rcu_read_lock.lock();
+        }
 
         while (void* buffer = vq->get_buf_elem(&len)) {
 
@@ -539,9 +570,17 @@ void net::receiver()
             rx_packets++;
             rx_bytes += m_head->M_dat.MH.MH_pkthdr.len;
 
-            bool fast_path = _ifn->if_classifier.post_packet(m_head);
+            bool fast_path = batch_wakes
+                ? _ifn->if_classifier.post_packet(m_head, wake_batch)
+                : _ifn->if_classifier.post_packet(m_head);
             if (!fast_path) {
-                (*_ifn->if_input)(_ifn, m_head);
+                if (batch_wakes) {
+                    // Cannot call if_input() here: we hold rcu_read_lock and the
+                    // BSD input path may fault.  Defer to after unlock (below).
+                    slow_path.push_back(m_head);
+                } else {
+                    (*_ifn->if_input)(_ifn, m_head);
+                }
             }
 
             trace_virtio_net_rx_packet(_ifn->if_index, rx_bytes);
@@ -550,6 +589,20 @@ void net::receiver()
             // passing the packet up the network stack.
             if ((_ifn->if_drv_flags & IFF_DRV_RUNNING) == 0)
                 break;
+        }
+
+        if (batch_wakes) {
+            // One wake per distinct connection touched this pass; the flushed
+            // wakes run back-to-back so wake_impl() coalesces the wakeup IPIs
+            // per destination CPU.  Still under the drain's rcu_read_lock.
+            wake_batch.flush();
+            osv::rcu_read_lock.unlock();
+            // Now preemptable again: run the deferred slow-path packets up the
+            // stack (tcp_input may fault, which is fine outside the rcu lock).
+            for (mbuf* m : slow_path) {
+                (*_ifn->if_input)(_ifn, m);
+            }
+            slow_path.clear();
         }
 
         // Update the stats

--- a/drivers/virtio-net.hh
+++ b/drivers/virtio-net.hh
@@ -221,6 +221,11 @@ public:
     void wait_for_queue(vring* queue);
     bool bad_rx_csum(struct mbuf* m, struct net_hdr* hdr);
     void receiver();
+    // Whether the receiver coalesces per-packet channel wakes into one wake per
+    // channel per drain pass.  Read once from the OSV_NET_BATCH_WAKE env var
+    // ("0" disables); default enabled.  Runtime toggle so the change can be
+    // A/B-measured on a single image.
+    static bool batch_wakes_enabled();
     void fill_rx_ring();
     mbuf* packet_to_mbuf(const std::vector<iovec>& iovec);
     static void free_buffer_and_refcnt(void* buffer, void* refcnt);

--- a/include/osv/net_channel.hh
+++ b/include/osv/net_channel.hh
@@ -15,6 +15,7 @@
 #include <lockfree/ring.hh>
 #include <functional>
 #include <unordered_map>
+#include <vector>
 #include <osv/rcu.hh>
 #include <osv/rcu-hashtable.hh>
 #include <bsd/porting/netport.h>
@@ -122,6 +123,18 @@ public:
     void remove(ipv4_tcp_conn_id id);
     // producer side operations
     bool post_packet(mbuf* m);
+    // Batched producer path: classify+push like post_packet(), but instead of
+    // waking the channel per packet, record it in "batch" (deduplicated).  The
+    // caller wakes every distinct channel once via batch.flush() at the end of
+    // a receive-drain pass.  This turns a NIC receiver's one-wake-per-packet
+    // into one-wake-per-channel-per-pass, and because the flushed wakes run
+    // back-to-back without any intervening reschedule, thread::wake_impl()'s
+    // per-target-CPU IPI coalescing (incoming_wakeups_mask) collapses them into
+    // at most one wakeup IPI per destination CPU per pass instead of per packet.
+    // MUST be called (and batch.flush()ed) under a single osv::rcu_read_lock so
+    // the recorded net_channel pointers (which are rcu_dispose()d on connection
+    // teardown) stay valid until flushed.
+    bool post_packet(mbuf* m, class net_channel_wake_batch& batch);
 private:
     net_channel* classify_ipv4_tcp(mbuf* m);
 private:
@@ -141,6 +154,61 @@ private:
     using ipv4_tcp_channels = osv::rcu_hashtable<item, item_hash>;
     mutex _mtx;
     ipv4_tcp_channels _ipv4_tcp_channels;
+};
+
+// Collects the distinct net_channels touched during one NIC receive-drain pass
+// so their wakes can be issued together at the end of the pass (see
+// classifier::post_packet(m, batch)).  Deduplicates so a channel that received
+// several packets in the pass is woken only once.  A small inline capacity
+// avoids heap traffic on the hot RX path; overflow spills to a heap vector.
+// Must be used and flush()ed under the same osv::rcu_read_lock that guarded the
+// post_packet() calls (net_channel is rcu_dispose()d on teardown).
+class net_channel_wake_batch {
+public:
+    // record a channel (deduplicated)
+    void add(net_channel* nc) {
+        for (unsigned i = 0; i < _n; i++) {
+            if (_inline[i] == nc) {
+                return;
+            }
+        }
+        if (_spill) {
+            for (auto* c : *_spill) {
+                if (c == nc) {
+                    return;
+                }
+            }
+        }
+        if (_n < inline_capacity) {
+            _inline[_n++] = nc;
+        } else {
+            if (!_spill) {
+                _spill = new std::vector<net_channel*>;
+            }
+            _spill->push_back(nc);
+        }
+    }
+    // wake every distinct recorded channel once, then reset
+    void flush() {
+        for (unsigned i = 0; i < _n; i++) {
+            _inline[i]->wake();
+        }
+        _n = 0;
+        if (_spill) {
+            for (auto* c : *_spill) {
+                c->wake();
+            }
+            delete _spill;
+            _spill = nullptr;
+        }
+    }
+    bool empty() const { return _n == 0 && !_spill; }
+    ~net_channel_wake_batch() { delete _spill; }
+private:
+    static const unsigned inline_capacity = 16;
+    unsigned _n = 0;
+    net_channel* _inline[inline_capacity];
+    std::vector<net_channel*>* _spill = nullptr;
 };
 
 #endif /* NETCHANNEL_HH_ */

--- a/include/osv/net_channel.hh
+++ b/include/osv/net_channel.hh
@@ -160,7 +160,11 @@ private:
 // so their wakes can be issued together at the end of the pass (see
 // classifier::post_packet(m, batch)).  Deduplicates so a channel that received
 // several packets in the pass is woken only once.  A small inline capacity
-// avoids heap traffic on the hot RX path; overflow spills to a heap vector.
+// avoids heap traffic on the hot RX path; overflow spills to a heap vector
+// that is allocated at most once and then reused for the life of the batch
+// (the receiver keeps one batch object across every drain pass), so a
+// workload that steadily touches more than inline_capacity channels per pass
+// does not allocate and free on the RX hot path.
 // Must be used and flush()ed under the same osv::rcu_read_lock that guarded the
 // post_packet() calls (net_channel is rcu_dispose()d on teardown).
 class net_channel_wake_batch {
@@ -198,11 +202,13 @@ public:
             for (auto* c : *_spill) {
                 c->wake();
             }
-            delete _spill;
-            _spill = nullptr;
+            // Keep the vector (and its capacity) for the next pass instead of
+            // freeing it: this object outlives the pass, so repeated overflow
+            // must not turn into repeated heap traffic on the RX hot path.
+            _spill->clear();
         }
     }
-    bool empty() const { return _n == 0 && !_spill; }
+    bool empty() const { return _n == 0 && (!_spill || _spill->empty()); }
     ~net_channel_wake_batch() { delete _spill; }
 private:
     static const unsigned inline_capacity = 16;


### PR DESCRIPTION
## What

The virtio-net receiver drains many packets per RX pass but wakes their target connections one packet at a time: `classifier::post_packet()` calls `net_channel::wake()` for every packet (the long-standing `// FIXME: find a way to batch wakes`). Each wake runs a full `thread::wake_impl()` and, when the woken connection last ran on a different CPU, sends a wakeup IPI. Under many concurrent connections this is one wake round-trip, often one cross-CPU IPI, per packet, on the single receiver thread's hot path.

This adds a batched producer path. `classifier::post_packet(m, batch)` classifies and pushes the packet exactly as before but records the target channel in a small deduplicating `net_channel_wake_batch` instead of waking it. The receiver holds one `rcu_read_lock` across the whole drain pass, records every touched channel, then wakes each distinct channel once via `batch.flush()` at the end of the pass. Because the flushed wakes run back-to-back with no intervening reschedule, `thread::wake_impl()`'s per-target-CPU IPI coalescing (`incoming_wakeups_mask`) collapses them into at most one wakeup IPI per destination CPU per pass instead of one per packet, and a connection that received several packets in the pass is woken only once.

The single `rcu_read_lock` over the drain keeps the recorded `net_channel` pointers valid until flushed (`net_channel` is `rcu_dispose()`d on teardown). The batch's inline capacity avoids heap traffic on the RX hot path and spills to a vector only past 16 distinct connections per pass.

Selectable at runtime via `OSV_NET_BATCH_WAKE` ("0" disables, restoring the exact per-packet path) so it can be A/B measured on a single image; defaults on. The non-batched path is unchanged.

## Correctness / status

- Verified correct with 16 concurrent connections x 500 distinct payloads each: every echo exact with batching on; batched wakes deliver to the right channels, no lost or misrouted wakeups.
- Single-CPU A/B (batching on vs off) shows no regression across 1..96 connections.

I want to be straight about the performance evidence: the cross-CPU IPI-coalescing benefit only appears at smp>1, and I have not yet been able to produce a clean smp>1 A/B throughput number. On this setup the guest wedges under concurrent RX load at smp>=2 independently of this change (it reproduces with `OSV_NET_BATCH_WAKE=0`, i.e. the current per-packet path, on both a plain tap and a vhost NIC), so I could not isolate the batching delta at scale. That looks like a separate pre-existing RX-wakeup issue I am investigating on its own.

So this PR is offered on its merits as a mechanism improvement: it removes a real per-packet wake/IPI cost on the receiver hot path, closes the in-tree FIXME, is off-by-a-flag reversible, and does not change the single-queue behavior. It is not making a measured throughput claim; the at-scale numbers depend on the separate wedge being resolved first.