### PR TITLE
tests: union-merge the tests module Makefile to avoid list conflicts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# The tests module Makefile is an append-only list that many independent
+# feature branches extend (each adds its own test). Union-merge it so those
+# additions never conflict: git keeps both sides instead of raising a conflict
+# that would otherwise need a manual resolution (and an extra merge commit) for
+# every concurrent PR. Pair with one-line "tests += tst-foo.so" additions so the
+# merged result stays valid.
+modules/tests/Makefile merge=union


### PR DESCRIPTION
The tests module Makefile keeps a single append-only `tests` list that many independent feature branches extend, each adding its own test. Because every addition edits the same contiguous region, concurrent PRs conflict on it: as soon as one merges, the others need a manual resolution (and an extra merge commit) for what is really an independent append.

This marks the file `merge=union` in `.gitattributes` so git resolves these additions by keeping both sides instead of raising a conflict.

Combined with one-line `tests += tst-foo.so` additions (rather than splicing into the list literal), concurrent test-adding PRs merge cleanly in any order with no manual work. Verified: three branches each appending a test line merge clean in sequence and `make` still expands `tests` to the full list.

Suggested to merge this first; I will then convert my open test-adding PRs to the one-line `+=` form so they stop conflicting on this file.