### PR TITLE
sched: idle-CPU pull work-stealing to disperse woken threads under concurrency

### DIFF
--- a/conf/kconfig/threads
+++ b/conf/kconfig/threads
@@ -10,6 +10,21 @@ config lazy_stack_invariant
   prompt "Check lazy stack invariant"
   def_bool $(shell,grep -q ^conf_lazy_stack_invariant=1 conf/base.mk && echo y || echo n)
 
+config sched_wake_pull
+  prompt "Idle-CPU pull work-stealing"
+  def_bool y
+  help
+    Let an idle CPU pull one runnable thread from the busiest CPU (via an IPI
+    that the busiest CPU services in its own context) instead of waiting for
+    the 100ms timer-driven load balancer to notice the imbalance.  This
+    disperses a single-waker fan-out -- e.g. one network RX thread waking a
+    worker per request -- across idle CPUs immediately, which the timer
+    balancer cannot do for a wake/run/block cycle that never accumulates a
+    visible runqueue.  Self-throttling: only idle CPUs ask, one outstanding
+    request per victim, so the IPI rate is bounded by the idle-CPU count, not
+    the wake rate.  Compiling it in costs nothing: it is a runtime no-op
+    unless the OSV_WAKE_PULL=1 environment toggle is set at boot.
+
 config threads_default_kernel_stack_size
   prompt "Kernel thread default stack size"
   int

--- a/core/sched.cc
+++ b/core/sched.cc
@@ -30,6 +30,7 @@
 #include <algorithm>
 #include <osv/kernel_config_lazy_stack.h>
 #include <osv/kernel_config_lazy_stack_invariant.h>
+#include <osv/kernel_config_sched_wake_pull.h>
 
 MAKE_SYMBOL(sched::thread::current);
 MAKE_SYMBOL(sched::cpu::current);
@@ -72,6 +73,18 @@ TRACEPOINT(trace_thread_create, "thread=%p", thread*);
 
 std::vector<cpu*> cpus __attribute__((init_priority((int)init_prio::cpus)));
 
+#if CONF_sched_wake_pull
+// Idle-CPU PULL (work-stealing) runtime toggle (see cpu::try_pull_from_busiest
+// / init reaper).  When on, an idle CPU pulls a runnable thread from the
+// busiest CPU instead of the timer-driven load balancer waiting a full tick to
+// notice the imbalance.  Default off; armed at boot via env OSV_WAKE_PULL=1.
+bool wake_pull_enabled = false;
+// Only pull from a victim whose runqueue is deeper than this (queued work
+// beyond the one thread it is running) so we never disturb a lightly-loaded
+// machine and never fight the victim over its last runnable thread.
+static constexpr unsigned wake_pull_min_depth = 2;
+#endif
+
 thread __thread * s_current;
 cpu __thread * current_cpu;
 
@@ -81,6 +94,15 @@ bool __thread need_reschedule = false;
 elf::tls_data tls;
 
 inter_processor_interrupt wakeup_ipi{IPI_WAKEUP, [] {}};
+
+#if CONF_sched_wake_pull
+// Idle-CPU PULL: an idle CPU IPIs the busiest CPU to donate one runnable
+// thread.  The handler runs on the victim (busiest) CPU in its own interrupt
+// context, so the migration bookkeeping touches only the victim's own per-CPU
+// state -- same-CPU-safe, exactly like load_balance()'s source-side migration.
+inter_processor_interrupt sched_pull_ipi{IPI_SCHED_PULL,
+    [] { cpu::current()->donate_to_puller(); }};
+#endif
 
 constexpr float cmax = 0x1P63;
 constexpr float cinitial = 0x1P-63;
@@ -470,6 +492,14 @@ void cpu::send_wakeup_ipi()
 void cpu::do_idle()
 {
     do {
+#if CONF_sched_wake_pull
+        // Idle-CPU PULL: we have no work; ask the busiest CPU to donate one
+        // runnable thread (no-op unless wake_pull_enabled).  Fire once per idle
+        // entry -- not per spin iteration -- so the IPI rate stays bounded by
+        // the number of idle CPUs, never the wake rate.  The donated thread
+        // arrives via incoming_wakeups and is picked up by the spin loop below.
+        try_pull_from_busiest();
+#endif
         idle_poll_lock_type idle_poll_lock{*this};
         WITH_LOCK(idle_poll_lock) {
             // spin for a bit before halting
@@ -843,6 +873,105 @@ void cpu::load_balance()
         }
     }
 }
+
+#if CONF_sched_wake_pull
+// Idle-CPU PULL (work-stealing).  Called from the idle path when this CPU has
+// an empty runqueue and is about to poll/halt.  Instead of waiting for the
+// timer-driven load_balance() to notice an imbalance a full tick later (too
+// slow for a wake/run/block cycle that never accumulates a visible runqueue),
+// the IDLE CPU pulls immediately: it asks the busiest CPU to donate one
+// runnable thread to it.
+//
+// This is self-throttling by construction: only idle CPUs ask, and the moment a
+// CPU receives donated work it is no longer idle and stops asking.  The IPI
+// rate is bounded by the number of idle CPUs (one outstanding request each via
+// the single pull_donate_to slot), not by the wake rate -- so it cannot build
+// into a per-wake IPI storm.  All runqueue mutation happens on the owning
+// (victim) CPU in its own IPI context, so it is same-CPU-safe, exactly like
+// load_balance()'s source-side migration.
+//
+// Returns true if a donate request was sent (caller can keep polling for the
+// donated thread to arrive via incoming_wakeups).
+bool cpu::try_pull_from_busiest()
+{
+    if (!wake_pull_enabled) {
+        return false;
+    }
+    // Only pull when genuinely idle.
+    if (!runqueue.empty()) {
+        return false;
+    }
+    // Find the busiest CPU by runqueue depth.  Bounded scan over cpus[].
+    cpu* busiest = nullptr;
+    unsigned best = wake_pull_min_depth;
+    for (cpu* c : cpus) {
+        if (c == this) {
+            continue;
+        }
+        unsigned d = c->load();
+        if (d >= best) {
+            best = d;
+            busiest = c;
+        }
+    }
+    if (!busiest) {
+        return false;   // nobody is backed up -- nothing to steal
+    }
+    // Publish our request on the victim.  If the victim already has an
+    // outstanding donate request (from another idle CPU), leave it -- one at a
+    // time keeps the pull rate low and avoids two idle CPUs fighting for the
+    // same victim on the same tick.
+    cpu* expected = nullptr;
+    if (!busiest->pull_donate_to.compare_exchange_strong(
+            expected, this, std::memory_order_acq_rel)) {
+        return false;
+    }
+    sched_pull_ipi.send(busiest);
+    return true;
+}
+
+// IPI handler on the victim (busiest) CPU: donate one migratable runnable
+// thread to the CPU that requested it (pull_donate_to).  Runs in the victim's
+// own interrupt context (irq already disabled), so touching this CPU's own
+// runqueue and the donated thread's per-CPU timer/runtime state is safe --
+// byte-identical bookkeeping to load_balance()'s source-side migration.
+void cpu::donate_to_puller()
+{
+    cpu* dst = pull_donate_to.exchange(nullptr, std::memory_order_acq_rel);
+    if (!dst || dst == this) {
+        return;
+    }
+    // Only donate if we still have queued work beyond the running thread; do
+    // not hand off our last runnable thread and go idle ourselves.
+    if (runqueue.size() < wake_pull_min_depth) {
+        return;
+    }
+    // Pick the least-recently-runnable migratable thread (tail of the tree),
+    // same selection as load_balance().
+    auto i = std::find_if(runqueue.rbegin(), runqueue.rend(),
+            [](thread& t) { return t._migration_lock_counter == 0; });
+    if (i == runqueue.rend()) {
+        return;
+    }
+    auto& mig = *i;
+    trace_sched_migrate(&mig, dst->id);
+    runqueue.erase(std::prev(i.base()));
+    assert(mig._detached_state->st.load() == thread::status::queued);
+    mig._detached_state->st.store(thread::status::waking);
+    mig.suspend_timers();
+    mig._detached_state->_cpu = dst;
+    mig._runtime.export_runtime();
+    mig.remote_thread_local_var(::percpu_base) = dst->percpu_base;
+    mig.remote_thread_local_var(current_cpu) = dst;
+    mig.stat_migrations.incr();
+    dst->incoming_wakeups[id].push_back(mig);
+    dst->incoming_wakeups_mask.set(id);
+    // Force the IPI to the requester: it is idle-polling / possibly halted in
+    // wait_for_interrupt(), and send_wakeup_ipi() would suppress the IPI to an
+    // idle_poll CPU -> the donated thread would sit unnoticed = a lost wakeup.
+    wakeup_ipi.send(dst);
+}
+#endif // CONF_sched_wake_pull
 
 cpu::notifier::notifier(std::function<void ()> cpu_up)
     : _cpu_up(cpu_up)
@@ -1882,6 +2011,18 @@ thread::reaper *thread::_s_reaper;
 void init_detached_threads_reaper()
 {
     thread::_s_reaper = new thread::reaper;
+#if CONF_sched_wake_pull
+    // Idle-CPU PULL (work-stealing) runtime toggle: env OSV_WAKE_PULL=1 arms it,
+    // default off.  Compiled in but a no-op at runtime unless armed, so the
+    // default build behaves exactly as before; set OSV_WAKE_PULL=1 to enable
+    // idle CPUs pulling work from the busiest CPU under concurrency.
+    {
+        extern bool wake_pull_enabled;
+        const char* e = getenv("OSV_WAKE_PULL");
+        wake_pull_enabled = (e && e[0] == '1');
+        printf("WAKE_PULL %s\n", wake_pull_enabled ? "ON" : "off");
+    }
+#endif
 }
 
 void start_early_threads()

--- a/include/osv/interrupt.hh
+++ b/include/osv/interrupt.hh
@@ -54,6 +54,7 @@ enum ipi_id {
     IPI_SAMPLER_START,
     IPI_SAMPLER_STOP,
     IPI_SMP_STOP,
+    IPI_SCHED_PULL,
 };
 
 #include "arch-interrupt.hh"

--- a/include/osv/sched.hh
+++ b/include/osv/sched.hh
@@ -29,6 +29,7 @@
 #include <osv/export.h>
 #include <osv/kernel_config_lazy_stack.h>
 #include <osv/kernel_config_lazy_stack_invariant.h>
+#include <osv/kernel_config_sched_wake_pull.h>
 #include <string.h>
 
 typedef float runtime_t;
@@ -1012,6 +1013,17 @@ struct cpu : private timer_base::client {
     thread* terminating_thread;
     osv::clock::uptime::time_point running_since;
     char* percpu_base;
+#if CONF_sched_wake_pull
+    // Idle-CPU PULL (work-stealing) request slot.  When this CPU goes idle it
+    // may ask the most-loaded CPU to donate a runnable thread: it stores its
+    // own cpu* here on the victim and IPIs the victim.  The victim's IPI
+    // handler (running in the victim's own context, so it is same-CPU-safe --
+    // identical bookkeeping to load_balance()'s source-side migration) reads
+    // this and pushes one migratable thread into the requester's
+    // incoming_wakeups.  Single-slot: at most one outstanding donate request
+    // per victim, which self-throttles the pull rate.
+    std::atomic<cpu*> pull_donate_to = { nullptr };
+#endif
     static cpu* current();
     void init_on_cpu();
     static void schedule();
@@ -1023,6 +1035,14 @@ struct cpu : private timer_base::client {
     void idle_poll_end();
     void send_wakeup_ipi();
     void load_balance();
+#if CONF_sched_wake_pull
+    // Idle path: if this CPU is idle, request one thread from the busiest CPU
+    // (see pull_donate_to).  Returns true if a request was sent.
+    bool try_pull_from_busiest();
+    // IPI handler on the victim CPU: donate one migratable runnable thread to
+    // the CPU recorded in pull_donate_to.  Runs in the victim's own context.
+    void donate_to_puller();
+#endif
     unsigned load();
     /**
      * Try to reschedule.


### PR DESCRIPTION
## Summary

Adds an idle-CPU pull (work-stealing) path to the scheduler so that when many
threads are woken in a tight wake/run/block cycle by a single waker, the work is
dispersed across idle CPUs immediately instead of piling onto the waker's home
CPU.

## The problem

When one thread wakes many workers in quick succession -- for example a single
network RX thread waking a worker per request -- the woken threads tend to run on
the waker's home CPU while other CPUs sit idle. The existing `load_balance()`
only rebalances on its 100ms timer, which is far too slow for a cycle that never
accumulates a visible runqueue: each thread runs briefly and blocks again before
the balancer's next tick, so the imbalance is never observed and the machine
stays lopsided with many idle CPUs.

## The mechanism

Add a pull step on the idle path (`do_idle()`): when a CPU is about to poll/halt
with an empty runqueue, it scans for the busiest CPU and, via an IPI the busiest
CPU services in its own interrupt context, has that CPU donate one migratable
runnable thread. All runqueue and per-CPU timer mutation happens on the owning
(victim) CPU, so it is same-CPU-safe -- byte-identical bookkeeping to
`load_balance()`'s source-side migration.

The key design choice is to **pull** (idle CPU asks) rather than **push** at wake
time (waker steers each woken thread). Pulling is self-throttling by
construction:

- only idle CPUs ask, and the moment a CPU receives donated work it is no longer
  idle and stops asking;
- a single per-victim request slot (`pull_donate_to`) bounds it to one
  outstanding request per victim.

So the IPI rate is bounded by the number of idle CPUs, never by the wake rate,
and cannot build into a per-wake IPI storm. It runs on every idle transition,
which is far more responsive than the 100ms load balancer for wake/run/block
workloads.

## Gating / safety

Gated by a new `CONF_sched_wake_pull` (default `y`) and additionally a runtime
no-op unless the `OSV_WAKE_PULL=1` environment toggle is set at boot, so the
default build behaves exactly as before. This makes it easy to A/B a single
image: `OSV_WAKE_PULL=0` (stock behavior) vs `OSV_WAKE_PULL=1` (pull enabled).

## Motivating measurement

PostgreSQL 18 read-only pgbench, single-queue virtio-net, matched OSv-vs-Linux
KVM guests on one host, every cell 0-failed, best of rounds. OSv throughput with
the toggle off vs on:

| clients | OSv off (tps) | OSv on (tps) | change | OSv/Linux off -> on |
|--------:|--------------:|-------------:|:------:|:-------------------:|
| c16     | 36890         | 116175       | +215%  | 0.23x -> 0.71x      |
| c32     | 30193         | 91412        | +203%  | 0.17x -> 0.51x      |
| c48     | 35471         | 86936        | +145%  |                     |

The mid-range concurrency cliff -- where idle CPUs previously went unused -- is
largely closed, and the full c1-c64 read-only and read-write sweeps complete with
no livelock. PostgreSQL is only the motivating workload here; this is a generic
scheduler improvement that benefits any concurrent workload with a single-waker
fan-out.

## Notes

- Fork-independent: builds and links clean with `conf_fork=0` (verified: fresh
  `loader.elf` links rc=0 on this branch off master).
- Diff is additive only (4 files, ~180 lines): `core/sched.cc`,
  `include/osv/interrupt.hh`, `include/osv/sched.hh`, `conf/kconfig/threads`.
