### PR TITLE
loader: recognize the ld-musl soname so musl-gcc PIEs load

### DIFF
--- a/core/elf.cc
+++ b/core/elf.cc
@@ -1390,6 +1390,7 @@ program::program(void* addr)
           "libm.so.6",
 #ifdef __x86_64__
           "libc.musl-x86_64.so.1",
+          "ld-musl-x86_64.so.1",
           // As noted in issue #1040 Boost version 1.69.0 and above is
           // compiled with hidden visibility, so even if the kernel uses
           // this library, it will not be visible for the application and


### PR DESCRIPTION
## Problem

A position-independent executable built against musl with `musl-gcc`
declares its interpreter/needed soname as `ld-musl-x86_64.so.1`. OSv's
built-in musl libc, however, was only advertised to applications under the
`libc.musl-x86_64.so.1` name in the kernel's `supplied_modules` list.

When such a binary is launched, OSv cannot match its own libc to the
interpreter the executable asks for, so the dynamic-linking path fails and
the run aborts with:

```
Failed to load object ... Powering off.
```

This affects any musl-linked application whose toolchain emits the
`ld-musl-x86_64.so.1` interp soname (the default for a number of distro
`musl-gcc` packages), independent of what the application does.

## Fix

Add `ld-musl-x86_64.so.1` as an alias in the kernel-supplied module list,
next to the existing `libc.musl-x86_64.so.1` entry, inside the
`#ifdef __x86_64__` block in `core/elf.cc`. A `musl-gcc`-built PIE then finds
the kernel's libc under the soname it actually requests.

Binaries that already reference the `libc.musl-x86_64.so.1` name are
unaffected: this only adds a second recognized name for the same built-in
module.

## Scope

One line, additive. No behavior change for existing binaries.
