### PR TITLE
sched: env-tunable idle spin-before-halt (OSV_IDLE_SPIN)

### DIFF
--- a/core/sched.cc
+++ b/core/sched.cc
@@ -467,13 +467,35 @@ void cpu::send_wakeup_ipi()
     }
 }
 
+// Idle spin-before-halt count.  A CPU with no runnable thread spins polling
+// incoming_wakeups before halting via arch::wait_for_interrupt (a VM-exit under
+// KVM).  For a request/reply server (e.g. one OS process per connection) each
+// blocked worker is, on average, re-woken by the next request a short time
+// later; if the spin is long enough to catch that wake, the halt and its
+// wake-IPI round-trip -- several VM-exits per request -- are avoided entirely,
+// which raises throughput at the guest's exit-rate ceiling.  A longer spin,
+// however, burns cycles on a genuinely idle system, so this is opt-in: the
+// default preserves the historical 10000-iteration behavior byte-for-byte and
+// a server image raises it via the OSV_IDLE_SPIN environment variable.
+static unsigned idle_spin_count()
+{
+    static unsigned n = []{
+        const char* e = getenv("OSV_IDLE_SPIN");
+        unsigned v = e ? (unsigned)strtoul(e, nullptr, 10) : 10000;
+        return v ? v : 10000;
+    }();
+    return n;
+}
+
 void cpu::do_idle()
 {
+    unsigned spin_count = idle_spin_count();
     do {
         idle_poll_lock_type idle_poll_lock{*this};
         WITH_LOCK(idle_poll_lock) {
-            // spin for a bit before halting
-            for (unsigned ctr = 0; ctr < 10000; ++ctr) {
+            // spin for a bit before halting; catching a wake here avoids the
+            // halt/wake VM-exit round-trip (see idle_spin_count above).
+            for (unsigned ctr = 0; ctr < spin_count; ++ctr) {
                 // FIXME: can we pull threads from loaded cpus?
                 handle_incoming_wakeups();
                 if (!runqueue.empty()) {


### PR DESCRIPTION
## sched: env-tunable idle spin-before-halt (`OSV_IDLE_SPIN`)

An idle CPU with no runnable thread spins polling `incoming_wakeups` a fixed
10000 iterations before halting via `arch::wait_for_interrupt`, which under a
hypervisor is a VM-exit. For a request/reply server that runs one blocking
worker per connection, each worker is typically re-woken by its next request a
short time after it blocks. When the spin is too short to catch that wake, the
halt and the subsequent wake-IPI cost a round-trip of several VM-exits per
request. At high connection counts this halt/wake round-trip becomes the
throughput ceiling: the guest saturates its VM-exit rate while most exits are
halts and their wakes, and the CPUs are otherwise idle.

This makes the spin-before-halt count tunable via the `OSV_IDLE_SPIN`
environment variable so a busy server can spin slightly longer before halting
an idle CPU and thereby avoid the halt/wake round-trip per request.

### Behavior

- **Default unchanged.** With `OSV_IDLE_SPIN` unset the count is 10000, so the
  idle path is byte-for-byte the historical behavior. A zero or unparseable
  value also falls back to 10000.
- **Opt-in.** A workload that benefits from trading idle CPU cycles for fewer
  halt/wake round-trips raises it (for example `OSV_IDLE_SPIN=100000`). A longer
  spin burns cycles on a genuinely idle system, which is why it is opt-in rather
  than a new default.

### Effect

This is an efficiency and tunability change, not a throughput-uplift claim. The
mechanism is real and was measured directly; the end-to-end throughput payoff is
host-conditional, so the honest statement is below rather than a headline number.

**Measured mechanism.** On a qemu 8.1.3 KVM host (smp16, one blocking worker per
connection), raising the spin from 10000 to 100000 collapsed guest halt VM-exits at
32 connections:

    halt_exits/s   48975  ->  434     (99% reduction)

So the guest-side spin genuinely catches an imminent wake and skips the halt.

**But it is redundant with host-side halt-polling, and then it does nothing.** On a
later qemu with a wider adaptive `halt_poll_ns` window, the same A/B (10000 ->
200000 -> 5000000) produced no change at all:

    halt_exits/s   57692  ->  58084   (unchanged)
    throughput                        (unchanged across all three values)

with `halt_poll_ok` already accounting for roughly 46k of ~58k halts. KVM was
already catching those wakes, so a longer guest spin had nothing left to collapse
and only burned guest cycles.

Both runs are internally consistent: throughput moved if and only if halts
collapsed. Two mechanisms race to catch the imminent request, the guest's idle spin
and the host's KVM halt-poll, and whichever fires first wins.

**Therefore:** this knob reduces per-request halt VM-exits on hosts whose hypervisor
halt-polling does not already catch those wakes, and is a no-op (pure CPU burn) on
hosts where it does. Where it does fire, the throughput effect was modest and
concentrated in write-heavy and deep-tail cases, where workers block longest. It is
not a uniform win, and I am not claiming one. An earlier revision of this
description asserted that it "collapses the per-request halt/wake round-trip" with
"no low-concurrency regression" and implied a general throughput gain; that was
unsupported by a single stable number and is corrected here.

Retaining it as an opt-in tunable rather than a default follows the existing
precedent for this class of knob: the useful setting is workload and
host-dependent, so the decision belongs to the operator.

### Scope

One file (`core/sched.cc`), +24/-2. Generic base scheduler code; does not depend
on any other change and is independently reviewable. Applies directly on
`master`.

