### PR TITLE
drivers/nvme: deepen the IO queue and PRP-list cache for concurrent load

### DIFF
--- a/drivers/nvme-queue.hh
+++ b/drivers/nvme-queue.hh
@@ -122,7 +122,11 @@ protected:
     static constexpr size_t max_pending_levels = 4;
 
     // Let us hold to allocated PRP pages but also limit to up 16 ones
-    ring_spsc<u64*, unsigned, 16> _free_prp_lists;
+    // Cache of pre-allocated PRP-list pages for multi-page I/Os.  Sized to the
+    // IO queue depth class so a deep, busy queue rarely misses into alloc_page()
+    // on the submit path; a miss still falls back to alloc and a full pool frees
+    // on return, so this is a churn optimization, not a correctness limit.
+    ring_spsc<u64*, unsigned, 128> _free_prp_lists;
 
     mutex _lock;
 };

--- a/drivers/nvme.hh
+++ b/drivers/nvme.hh
@@ -29,7 +29,14 @@
 #define NVME_ADMIN_QUEUE_SIZE 8
 
 //Will be lower if the device doesnt support the specified queue size
-#define NVME_IO_QUEUE_SIZE 64
+// A deeper IO queue lets many I/Os stay in flight concurrently instead of
+// blocking submitters on a full submission queue.  Under a concurrent database
+// workload on real (native NVMe) hardware the old depth of 64 filled quickly,
+// serializing threads on the sq-full wait; 256 keeps more requests in flight
+// without materially more memory.  The device's advertised max (cap.mqes) still
+// clamps this in create_io_queues(), so it is safe on controllers with a
+// smaller queue-entry limit.
+#define NVME_IO_QUEUE_SIZE 256
 
 namespace nvme {
 


### PR DESCRIPTION
## Problem

The NVMe driver created IO submission queues 64 entries deep and pre-allocated
only 16 PRP-list pages per queue. Under a concurrent workload that keeps many
I/Os in flight, a 64-deep queue fills quickly and submitting threads then block
on the sq-full wait, limiting how much I/O can be outstanding at once.

## Fix

Deepen the IO queue to 256 entries. This stays clamped to the device's
advertised maximum (`cap.mqes`) in `create_io_queues()`, so it is safe on
controllers with a smaller queue-entry limit and simply uses more of the depth
the device already offers. Grow the per-queue PRP-list cache from 16 to 128 to
match, so a deep busy queue rarely misses into `alloc_page()` on the submit
path; a miss still falls back to allocation and a full pool frees on return, so
this is a churn optimization rather than a correctness change.

## Testing

Built and booted; NVMe I/O continues to work with the deeper queue. The change
is conservative (bounded by the device's own `cap.mqes`) and touches only queue
sizing.
