### PR TITLE
drivers/nvme: make interrupt coalescing opt-in, default off for low latency

### DIFF
--- a/drivers/nvme.cc
+++ b/drivers/nvme.cc
@@ -13,6 +13,8 @@
 #include <osv/interrupt.hh>
 
 #include <cassert>
+#include <cstdlib>
+#include <cstdio>
 #include <string>
 #include <string.h>
 #include <map>
@@ -149,8 +151,28 @@ driver::driver(pci::device &pci_dev)
     //Create IO queues
     create_io_queues();
 
+    // NVMe interrupt coalescing trades completion latency for fewer interrupts:
+    // the controller delays a completion IRQ up to (time * 100us) or until
+    // 'threshold' completions accumulate.  That is a throughput win for deep,
+    // streaming IO but a large latency penalty for low-queue-depth synchronous
+    // IO -- e.g. a database fsync / ZFS ZIL commit that issues one FLUSH and
+    // waits for it: it pays the full aggregation-timer delay on every commit.
+    // Default to NO coalescing (lowest latency); allow opt-in via
+    // OSV_NVME_INT_COALESCING="threshold,time100us" for throughput-bound loads.
+    // QEMU's emulated controller ignores the feature, so only touch real ones.
     if (_identify_controller->vid != QEMU_VID) {
-        set_interrupt_coalescing(20, 2);
+        u8 coalesce_threshold = 0, coalesce_time = 0;
+        const char *ic = getenv("OSV_NVME_INT_COALESCING");
+        if (ic) {
+            int t = 0, tm = 0;
+            if (sscanf(ic, "%d,%d", &t, &tm) == 2) {
+                coalesce_threshold = (u8)t;
+                coalesce_time = (u8)tm;
+            }
+        }
+        if (coalesce_threshold || coalesce_time) {
+            set_interrupt_coalescing(coalesce_threshold, coalesce_time);
+        }
     }
 
     std::string dev_name("vblk");


### PR DESCRIPTION
## Summary

The NVMe driver unconditionally programmed interrupt coalescing (`threshold=20`, `time=2`, a 200us completion-aggregation window) on every non-QEMU controller. Coalescing reduces interrupt load for deep, streaming I/O, but it adds latency to low-queue-depth synchronous I/O: a request that issues a single command and waits for its completion pays the full aggregation-timer delay on every such operation.

This hurts barrier-style operations that dominate database and journaling workloads (an fsync, a filesystem journal commit, a ZFS ZIL commit), where each commit issues one FLUSH and waits for it. With the 200us window, every commit is delayed up to 200us before its completion interrupt fires, capping synchronous write throughput.

## Change

- Default to no interrupt coalescing (lowest completion latency).
- Opt back in via `OSV_NVME_INT_COALESCING="threshold,time100us"` for workloads that prefer fewer interrupts (threshold in completions, time in 100us units, matching the NVMe Set Features encoding).
- The real-controller guard is preserved, since QEMU's emulated controller ignores the feature.

## Measured effect

On real NVMe, disabling coalescing measurably improves synchronous-commit write throughput at low-to-moderate concurrency. There is a genuine tradeoff: streaming read throughput benefits from coalescing, so the env knob lets those workloads restore it. Defaulting off favors latency-sensitive workloads, which is the more common surprise when moving from an emulated controller (no coalescing) to real hardware.
