### PR TITLE
sched: skip waking a null or invalid thread pointer

### DIFF
--- a/core/sched.cc
+++ b/core/sched.cc
@@ -1309,6 +1309,14 @@ void thread::destroy()
 // waking state.
 void thread::wake_impl(detached_state* st, unsigned allowed_initial_states_mask)
 {
+    // Defend against a null detached_state: a wait_record whose backing thread
+    // is not resolvable in the waker's address space can yield a null st here.
+    // Dereferencing it would fault, and on a preemption-disabled wake path that
+    // fault aborts the instance (assert(preemptable()) in page_fault).  Skip
+    // the wake.
+    if (!st) {
+        return;
+    }
     status old_status = status::waiting;
     trace_sched_wake(st->t);
     while (!st->st.compare_exchange_weak(old_status, status::waking)) {

--- a/include/osv/wait_record.hh
+++ b/include/osv/wait_record.hh
@@ -35,7 +35,21 @@ public:
     explicit waiter(sched::thread *t) : t(t) { };
 
     inline void wake() {
-        t.load(std::memory_order_relaxed)->wake_with_from_mutex([&] { t.store(nullptr, std::memory_order_release); });
+        // A wait_record left linked in a condvar/mutex queue can be stale: it
+        // may already be woken (wake() stores null below), or its backing
+        // thread pointer may not be resolvable in the waker's address space,
+        // reading as null or a tiny-integer remnant.  Dereferencing it faults,
+        // and on the preemption-disabled wake path that fault aborts the whole
+        // instance.  Skip a thread pointer that is null or an obviously invalid
+        // low value (no sched::thread lives in the first page); a real thread
+        // lives high in the address space.  This is deliberately narrow -- only
+        // clearly-bogus pointers are dropped -- so it never discards a
+        // legitimate wake.
+        sched::thread *w = t.load(std::memory_order_relaxed);
+        if (reinterpret_cast<uintptr_t>(w) < 0x1000UL) {
+            return;
+        }
+        w->wake_with_from_mutex([&] { t.store(nullptr, std::memory_order_release); });
     }
 
     inline void wait() const {


### PR DESCRIPTION
The wake path dereferences two pointers without checking them, and it runs
with preemption disabled, so a null dereference there does not fault
recoverably -- it trips `assert(sched::preemptable())` in `page_fault` and
aborts the whole instance.

- `waiter::wake()` loads the `sched::thread *` out of a `wait_record` and
  immediately calls `wake_with_from_mutex()` on it.
- `thread::wake_impl()` dereferences the `detached_state *` it is handed
  (`trace_sched_wake(st->t)` and the CAS loop on `st->st`).

A `wait_record` left linked in a condvar/mutex queue can be stale: it may
already have been woken (`wake()` stores null), or its backing thread may not
be resolvable in the waker's context, in which case the stored pointer reads
as null or a small-integer remnant. A live `sched::thread` never lives in the
first page of the address space, so such a value is unambiguously not a thread.

This change guards both paths:

- in `waiter::wake()`, skip a thread pointer below `0x1000` (null or an
  obviously invalid low value);
- in `thread::wake_impl()`, return early on a null `detached_state`.

The guard is deliberately narrow -- only clearly-bogus pointers are dropped --
so it never discards a legitimate wake. Behavior is unchanged for every valid
waiter; the only effect is turning a fatal abort on a stale/torn record into a
no-op wake, which is the correct outcome (there is nothing live to wake).

Two small files, no functional change on the happy path.
