### PR TITLE
fs: raise default max file descriptors from 16384 to 65536

### DIFF
--- a/conf/kconfig/fs
+++ b/conf/kconfig/fs
@@ -11,7 +11,7 @@ config fs_sysfs
 config fs_max_file_descriptors
   prompt "Maximum file descriptors"
   hex
-  default 0x4000
+  default 0x10000
 
 config fs_buffer_cache_size
   prompt "Buffer cache size"


### PR DESCRIPTION
The default `fs_max_file_descriptors` is 0x4000 (16384), which sizes the global file-descriptor table in `fs/vfs/kern_descrip.cc`. Server workloads that keep many files and sockets open concurrently can exhaust this table and hit `EMFILE`, at which point the affected component typically aborts rather than degrades.

This was observed with a database under high connection count: each backend accumulates open relation files, WAL segments, and client sockets, and a busy sweep drives the live fd count past 16384, producing `EMFILE` in the WAL writer and an abort.

Raise the compile-time default to 0x10000 (65536). It remains a configurable Kconfig value, so images that want the smaller table can set it back. The table is an array of pointers, so the extra headroom costs a few hundred KB of kernel memory at most.

Standalone change, no dependencies.