### PR TITLE
zfs(openzfs): cap the default ARC at half of RAM for app coexistence

### DIFF
--- a/modules/open_zfs/osv/module/os/osv/zfs/arc_os.c
+++ b/modules/open_zfs/osv/module/os/osv/zfs/arc_os.c
@@ -106,6 +106,18 @@ arc_default_max(uint64_t min, uint64_t allmem)
 	else
 		size = allmem / 8;
 
+	/*
+	 * OSv: the ARC and the application share one physical address space.
+	 * Cap the default at half of RAM for guests > 2 GiB so a large app
+	 * (e.g. PostgreSQL with multi-GiB shared_buffers plus many backends)
+	 * always keeps at least half the guest's memory and a checkpoint burst
+	 * cannot drive the guest OOM.  ZFS_MODULE_PARAM is a no-op on OSv, so
+	 * zfs_arc_max cannot yet override this at boot; a future cmdline wiring
+	 * could.
+	 */
+	if (allmem > (2ULL << 30))
+		size = MIN(size, allmem / 2);
+
 	return (MAX(size, min));
 }
 

--- a/modules/open_zfs/osv/module/os/osv/zfs/zfs_initialize_osv.c
+++ b/modules/open_zfs/osv/module/os/osv/zfs/zfs_initialize_osv.c
@@ -48,6 +48,7 @@ __thread void *zfs_fsyncer_key;
  * pipeline during TXG sync.
  */
 extern uint64_t arc_reduce_target_size_noshrink(uint64_t to_free);
+extern uint64_t arc_reduce_target_size_shrink_sync(uint64_t to_free);
 /*
  * Use arc_all_memory() (a function call via PLT within libsolaris.so) rather
  * than referencing arc_c directly.  arc_c is compiled with -fvisibility=hidden
@@ -59,14 +60,23 @@ extern uint64_t arc_reduce_target_size_noshrink(uint64_t to_free);
  */
 extern uint64_t arc_all_memory(void);
 
-/* Called by the shrinker in "hard" mode (evict aggressively). */
+/*
+ * Called by the shrinker in "hard" mode (the reclaimer has OOM-blocked
+ * waiters).  Use the synchronous variant so we do not return until real memory
+ * has actually been evicted: OSv's reclaimer OOMs if a shrinker pass frees
+ * nothing, and the plain noshrink variant only lowers the target and wakes the
+ * async evict thread, returning before any page is freed.  Under a burst (a
+ * large PostgreSQL checkpoint plus many backend/autovacuum-worker forks) the
+ * async eviction lags demand and the reclaimer aborts even though eviction is
+ * in flight.  The synchronous variant waits for the eviction to complete.
+ */
 static size_t
 osv_arc_lowmem(void *arg, int howto)
 {
 	uint64_t to_free = arc_all_memory() / 4;
 	if (to_free < (16UL << 20))
 		to_free = 16UL << 20;
-	return ((size_t)arc_reduce_target_size_noshrink(to_free));
+	return ((size_t)arc_reduce_target_size_shrink_sync(to_free));
 }
 
 /* Called by the shrinker in "soft" mode (reclaim a specific amount). */

--- a/modules/open_zfs/patches/0001-osv-openzfs-upstream-file-edits.patch
+++ b/modules/open_zfs/patches/0001-osv-openzfs-upstream-file-edits.patch
@@ -231,7 +231,7 @@ index 22f9be7..29044e1 100644
  	if (zfs_arc_evict_threads == 0) {
  		/*
  		 * Compute number of threads we want to use for eviction.
-@@ -4757,6 +4775,49 @@ arc_reduce_target_size(uint64_t to_free)
+@@ -4757,5 +4775,73 @@ arc_reduce_target_size(uint64_t to_free)
  	return (to_free);
  }
  
@@ -278,9 +278,33 @@ index 22f9be7..29044e1 100644
 +	return (to_free);
 +}
 +
++/*
++ * OSv: synchronous hard-mode shrink.  Lower the target and kick eviction the
++ * same way arc_reduce_target_size_noshrink() does, then block until the
++ * requested amount has actually been evicted.  Called only from the hard-mode
++ * ARC shrinker (OSv reclaimer about to OOM), which needs real freed memory
++ * before it returns, not just a lowered target.  lax=B_TRUE returns early once
++ * the ARC stops overflowing; use_reserve=B_FALSE.  The eviction waiter is
++ * fork-COW-coherent (identity heap) and the OSv reclaimer thread may block.
++ */
++uint64_t
++arc_reduce_target_size_shrink_sync(uint64_t to_free)
++{
++	uint64_t asize_before = aggsum_value(&arc_sums.arcstat_size);
++	uint64_t requested = arc_reduce_target_size_noshrink(to_free);
++
++	if (requested == 0)
++		return (0);
++
++	arc_wait_for_eviction(requested, B_TRUE, B_FALSE);
++
++	uint64_t asize_after = aggsum_value(&arc_sums.arcstat_size);
++	return (asize_before > asize_after ?
++	    (asize_before - asize_after) : 0);
++}
++
  /*
   * Determine if the system is under memory pressure and is asking
-  * to reclaim memory. A return value of B_TRUE indicates that the system
 @@ -7982,6 +8043,18 @@ arc_set_limits(uint64_t allmem)
  	/* Set min cache to 1/32 of all memory, or 32MB, whichever is more. */
  	arc_c_min = MAX(allmem / 32, 2ULL << SPA_MAXBLOCKSHIFT);


### PR DESCRIPTION
**Draft / follow-on to #1423 and #1478.**

On OSv the ARC and the application share one physical address space. `arc_default_max()` for a guest with >= 1 GiB of RAM returns `MAX(allmem*5/8, allmem-1GiB)`, which on a large guest is nearly all of RAM (about 31 GiB of a 32 GiB guest). A memory-hungry application such as PostgreSQL (multi-GiB shared_buffers plus many concurrent backends) then has almost no headroom, and a checkpoint burst stacking dirty ARC buffers on top of the backends' working set drives the guest OOM and aborts it. This showed up as an OOM at high concurrency on a 32 GiB guest.

Since `ZFS_MODULE_PARAM` is a no-op on OSv (`zfs_arc_max` cannot be set at boot), this caps the computed default at half of RAM for guests with more than 2 GiB, so the application always keeps at least half the guest's memory. Small guests are unchanged.

Draft because the proper long-term fix is to wire `zfs_arc_max` to the boot cmdline so this becomes an overridable default rather than a hard cap; kept as a draft PR so the tuning is not lost while the maintainer reviews the ZFS follow-on stack. Edits the tracked `modules/open_zfs/osv/module/os/osv/zfs/arc_os.c` directly (the OSv platform layer is now source files on master, not a numbered patch).