### PR TITLE
open_zfs: bump vendored OpenZFS to 2.4.4 and adapt the OSv platform layer

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -24,5 +24,5 @@
 [submodule "open_zfs"]
 	path = modules/open_zfs/openzfs
 	url = https://github.com/openzfs/zfs.git
-	branch = zfs-2.4.3
+	branch = zfs-2.4.4
 	ignore = dirty

--- a/modules/open_zfs/osv/include/os/osv/zfs/sys/zfs_context_os.h
+++ b/modules/open_zfs/osv/include/os/osv/zfs/sys/zfs_context_os.h
@@ -249,6 +249,14 @@ zfs_uio_init(zfs_uio_t *uio, struct uio *uio_s)
 #include <sys/rwlock.h>
 
 /*
+ * Include cred types (cred_t) - OpenZFS 2.4.4 references cred_t in
+ * sys/zfs_file.h (zfs_file_open gained a cred_t *arg) but zfs_context.h
+ * does not include sys/cred.h on the _KERNEL path; provide it from the
+ * SPL layer, mirroring the FreeBSD/Linux zfs_context_os.h.
+ */
+#include <sys/cred.h>
+
+/*
  * RW_NONE - some code uses this as a "no lock" sentinel.
  */
 #ifndef RW_NONE

--- a/modules/open_zfs/osv/include/os/osv/zfs/sys/zfs_vfsops_os.h
+++ b/modules/open_zfs/osv/include/os/osv/zfs/sys/zfs_vfsops_os.h
@@ -57,6 +57,7 @@ struct zfsvfs {
 	int		z_norm;		/* normalization flags */
 	boolean_t	z_atime;	/* enable atimes mount option */
 	boolean_t	z_unmounted;	/* unmounted */
+	boolean_t	z_use_hold;	/* held via dmu_objset_hold */
 	zfs_teardown_lock_t z_teardown_lock;
 	zfs_teardown_inactive_lock_t z_teardown_inactive_lock;
 	list_t		z_all_znodes;	/* all vnodes in the fs */
@@ -174,7 +175,7 @@ extern int zfs_suspend_fs(zfsvfs_t *zfsvfs);
 extern int zfs_resume_fs(zfsvfs_t *zfsvfs, struct dsl_dataset *ds);
 extern int zfs_end_fs(zfsvfs_t *zfsvfs, struct dsl_dataset *ds);
 extern int zfs_set_version(zfsvfs_t *zfsvfs, uint64_t newvers);
-extern int zfsvfs_create(const char *name, boolean_t readonly, zfsvfs_t **zfvp);
+extern int zfsvfs_create_hold(const char *name, zfsvfs_t **zfvp);
 extern int zfsvfs_create_impl(zfsvfs_t **zfvp, zfsvfs_t *zfsvfs, objset_t *os);
 extern void zfsvfs_free(zfsvfs_t *zfsvfs);
 extern int zfs_check_global_label(const char *dsname, const char *hexsl);

--- a/modules/open_zfs/osv/lib/libspl/include/os/osv/sys/zfs_context_os.h
+++ b/modules/open_zfs/osv/lib/libspl/include/os/osv/sys/zfs_context_os.h
@@ -3,7 +3,7 @@
  * OSv userspace zfs_context_os.h
  *
  * Minimal definitions for building libzfs/libzutil/zpool/zfs userspace
- * tools against OpenZFS 2.4.1 on OSv.  This is NOT the kernel version
+ * tools against OpenZFS 2.4.4 on OSv.  This is NOT the kernel version
  * (include/os/osv/zfs/sys/zfs_context_os.h); it is the userspace SPL
  * context header placed so that the libspl include path finds it at
  * sys/zfs_context_os.h.

--- a/modules/open_zfs/osv/module/os/osv/zfs/vdev_disk.c
+++ b/modules/open_zfs/osv/module/os/osv/zfs/vdev_disk.c
@@ -41,8 +41,9 @@ vdev_disk_rele(vdev_t *vd)
 
 static int
 vdev_disk_open(vdev_t *vd, uint64_t *psize, uint64_t *max_psize,
-    uint64_t *logical_ashift, uint64_t *physical_ashift)
+    uint64_t *logical_ashift, uint64_t *physical_ashift, cred_t *cr)
 {
+	(void) cr;
 	struct vdev_disk *dvd;
 	int error;
 	char *device_name;

--- a/modules/open_zfs/osv/module/os/osv/zfs/zfs_file_os.c
+++ b/modules/open_zfs/osv/module/os/osv/zfs/zfs_file_os.c
@@ -20,9 +20,10 @@
  */
 
 int
-zfs_file_open(const char *path, int flags, int mode, zfs_file_t **fpp)
+zfs_file_open(const char *path, int flags, int mode, cred_t *cr,
+    zfs_file_t **fpp)
 {
-	(void) path; (void) flags; (void) mode; (void) fpp;
+	(void) path; (void) flags; (void) mode; (void) cr; (void) fpp;
 	/* OSv does not support zpool.cache file access yet */
 	return (SET_ERROR(ENOTSUP));
 }

--- a/modules/open_zfs/osv/module/os/osv/zfs/zfs_vfsops.c
+++ b/modules/open_zfs/osv/module/os/osv/zfs/zfs_vfsops.c
@@ -104,6 +104,48 @@ zfsvfs_create(const char *osname, boolean_t readonly, zfsvfs_t **zfvp)
 	return (error);
 }
 
+
+/*
+ * Create a zfsvfs structure for an unmounted dataset using a shared
+ * dmu_objset_hold() rather than an exclusive dmu_objset_own().  A shared
+ * hold does not conflict with the exclusive own taken by zfs_domount(),
+ * which avoids the EBUSY race between quota queries and mount (OpenZFS
+ * 2.4.4, upstream commit b021ebcdc).  Mirrors the FreeBSD/Linux
+ * zfsvfs_create_hold(); the shared zfs_ioctl.c zfsvfs_hold()/zfsvfs_rele()
+ * branch on z_use_hold to rele (not disown) and to juggle the pool config
+ * lock.  On zfsvfs_create_impl() error we release here (OSv keeps the
+ * disown/free in the caller, unlike upstream which frees inside _impl).
+ */
+int
+zfsvfs_create_hold(const char *osname, zfsvfs_t **zfvp)
+{
+	objset_t *os;
+	zfsvfs_t *zfsvfs;
+	int error;
+
+	zfsvfs = kmem_zalloc(sizeof (zfsvfs_t), KM_SLEEP);
+
+	error = dmu_objset_hold(osname, zfsvfs, &os);
+	if (error != 0) {
+		kmem_free(zfsvfs, sizeof (zfsvfs_t));
+		return (error);
+	}
+
+	if (dmu_objset_type(os) != DMU_OST_ZFS) {
+		dmu_objset_rele(os, zfsvfs);
+		kmem_free(zfsvfs, sizeof (zfsvfs_t));
+		return (SET_ERROR(EINVAL));
+	}
+
+	zfsvfs->z_use_hold = B_TRUE;
+	error = zfsvfs_create_impl(zfvp, zfsvfs, os);
+	if (error != 0) {
+		dmu_objset_rele(os, zfsvfs);
+		zfsvfs_free(zfsvfs);
+	}
+	return (error);
+}
+
 /*
  * zfsvfs_init -- read on-disk ZPL properties into a zfsvfs_t.
  *

--- a/modules/open_zfs/osv/module/zfs/zfs_gitrev.h
+++ b/modules/open_zfs/osv/module/zfs/zfs_gitrev.h
@@ -2,6 +2,6 @@
 #ifndef _ZFS_GITREV_H
 #define _ZFS_GITREV_H
 
-#define ZFS_META_GITREV "OpenZFS 2.4.1 (OSv port)"
+#define ZFS_META_GITREV "OpenZFS 2.4.4 (OSv port)"
 
 #endif /* _ZFS_GITREV_H */


### PR DESCRIPTION
## What

Bump the vendored OpenZFS integration from 2.4.3 to 2.4.4 and adapt the in-tree OSv platform layer to the 2.4.4 API changes.

- **Submodule**: `modules/open_zfs/openzfs` moves from the `zfs-2.4.3` tag (commit `83020cf8`) to the `zfs-2.4.4` tag (commit `71a9f9578`); `.gitmodules` branch pin updated `zfs-2.4.3` -> `zfs-2.4.4`.
- **Patch**: the single `0001-osv-openzfs-upstream-file-edits.patch` still applies cleanly on 2.4.4 (verified with `git apply --check` on a fresh 2.4.4 checkout), so no rebase was needed.
- **Platform layer** (`modules/open_zfs/osv`) adapted to the 2.4.4 signature changes that reach our code:
  - `vdev_open_func_t` gained a trailing `cred_t *cr` (upstream `907dd00bf`): update the OSv `.vdev_op_open` callback `vdev_disk_open()` to match (arg ignored, as FreeBSD/Linux do).
  - `zfs_file_open()` gained a `cred_t *cr` before the `zfs_file_t **fp` out-param (upstream `07f76455b`): update the OSv stub (still `ENOTSUP`).
  - 2.4.4 references `cred_t` in `sys/zfs_file.h` on the kernel path, but the OSv kernel `zfs_context_os.h` never included `sys/cred.h`: include the SPL `sys/cred.h` there, mirroring FreeBSD/Linux, so every OpenZFS TU sees `cred_t`.
  - `zfsvfs_hold()` in the shared `module/zfs/zfs_ioctl.c` now calls the new `zfsvfs_create_hold()` and branches on `zfsvfs_t.z_use_hold` (upstream `b021ebcdc`, EBUSY race fix): add the `z_use_hold` field and an OSv `zfsvfs_create_hold()` that opens via a shared `dmu_objset_hold()`, matching FreeBSD/Linux while keeping OSv's caller-owned release convention.
  - Refresh the hardcoded `ZFS_META_GITREV` string (and a userspace context-header comment) from 2.4.1 to 2.4.4.

## Why

Stay current with upstream OpenZFS and pick up the 2.4.4 bug fixes.

## Validation

Built and booted on bare-metal x86-64 under qemu-kvm.

- Clean from-scratch build `scripts/build conf_fork=1 conf_zfs=openzfs`: **exit 0** (the OpenZFS kernel, the OSv platform layer, the userspace zpool/zfs/libzfs tools, and a populated ZFS image all build).
- Boot test: the `zfs_builder` boots, creates a pool on a virtio-blk data disk, writes and reads back a file on a dataset, scrubs, and reports `zpool status` ONLINE. Serial-log excerpt:

```
ZFS: OpenZFS 5000 initialized
zpool create -f -o ashift=12 -R /mnt -m / testp /dev/vblk0  (ret=0)
  pool: testp
 state: ONLINE
  NAME        STATE     READ WRITE CKSUM
  testp       ONLINE       0     0     0
    vblk0     ONLINE       0     0     0
errors: No known data errors
zfs create -o mountpoint=/data testp/data  (ret=0)
READBACK OK: openzfs-2.4.4-on-osv-readback-ok
zpool scrub testp  (ret=0)
  scan: scrub repaired 0B in 00:00:00 with 0 errors
  testp       ONLINE       0     0     0
    vblk0     ONLINE       0     0     0
errors: No known data errors
```

- Crash-marker grep (`Aborted|page_fault|Assertion|panic`) over the serial log: clean.
