### PR TITLE
libext: bound ext_readlink and ext_readdir against a crafted ext4 image (rebase of #1449)

### DIFF
--- a/modules/libext/ext_vnops.cc
+++ b/modules/libext/ext_vnops.cc
@@ -677,6 +677,15 @@ ext_readdir(struct vnode *dvp, struct file *fp, struct dirent *dir)
         if (ext4_dir_en_get_inode(it.curr) != 0) {
             memset(dir->d_name, 0, sizeof(dir->d_name));
             uint16_t name_length = ext4_dir_en_get_name_len(&fs->sb, it.curr);
+            // On an old-rev (rev0, minor<5) image ext4_dir_en_get_name_len()
+            // folds in name_length_high, so it can return up to entry_len-8
+            // (~block_size, ~4 KiB) while d_name is only 256 bytes.  lwext4's
+            // ext4_dir_iterator_set() only bounds the name against the entry
+            // length, not against d_name, so a crafted rev0 directory entry
+            // memcpy'd here would overflow the fixed-size d_name.  Clamp it.
+            if (name_length >= sizeof(dir->d_name)) {
+                name_length = sizeof(dir->d_name) - 1;
+            }
             memcpy(dir->d_name, it.curr->name, name_length);
             ext_debug("readdir directory with i-node=%ld at offset:%ld => entry name:%s\n", dvp->v_ino, file_offset(fp), dir->d_name);
 
@@ -1386,7 +1395,32 @@ ext_readlink(vnode_t *vp, uio_t *uio)
         return uiomove(content, fsize, uio);
     } else {
         uint32_t block_size = ext4_sb_get_block_size(&fs->sb);
+        // A slow symlink's target lives in exactly one block: ext_fsymlink_set()
+        // rejects size > block_size when creating one, and a path is bounded by
+        // PATH_MAX anyway.  But @fsize here is ext4_inode_get_size(), read raw
+        // off disk and fully attacker-controlled on a crafted image, and it is
+        // passed as the read *size* into a block_size heap buffer.  Unclamped,
+        // ext_internal_read() writes up to @fsize bytes (2^64-1) into a
+        // block_size allocation: kernel heap overflow.  Reject the malformed
+        // inode instead (EIO, matching how rofs_readlink() reports corrupt
+        // on-disk symlink metadata).
+        if (fsize > block_size) {
+            return EIO;
+        }
+        // ext_internal_read() clamps its size to (fsize - offset) in unsigned
+        // arithmetic, so an offset at or past EOF underflows that subtraction
+        // and the clamp silently keeps the full @fsize while the block index is
+        // computed from the out-of-range offset -- a read of blocks the symlink
+        // does not own.  With the guard above that is no longer an overflow,
+        // only bogus content, so reject it explicitly.  Both in-tree callers
+        // (sys_readlink, read_link) pass offset 0, so this is defence in depth.
+        if ((uint64_t)uio->uio_offset >= fsize) {
+            return 0;
+        }
         void *buf = malloc(block_size);
+        if (!buf) {
+            return ENOMEM;
+        }
         size_t read_count = 0;
         int ret = ext_internal_read(fs, &inode_ref._ref, uio->uio_offset, buf, fsize, &read_count);
         if (ret) {

--- a/modules/tests/Makefile
+++ b/modules/tests/Makefile
@@ -137,6 +137,7 @@ endif
 
 ext-only-tests := tst-readdir.so tst-concurrent-read.so tst-fs-link.so
 ext-only-tests += tst-ext4-rw.so
+ext-only-tests += tst-ext-readlink.so
 
 specific-fs-tests := $($(fs_type)-only-tests)
 

--- a/tests/tst-ext-readlink.cc
+++ b/tests/tst-ext-readlink.cc
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2026 Greg Burd
+ *
+ * This work is open source software, licensed under the terms of the
+ * BSD license as described in the LICENSE file in the top-level directory.
+ */
+
+// Regression test for the ext_readlink()/ext_readdir() bounds hardening.
+//
+// ext-specific: it creates its own symlinks on a writable ext root, so build
+// and run it with ext as the root filesystem:
+//
+//   scripts/build image=tests fs=ext
+//   scripts/test.py
+//
+// The interesting case is the *slow* symlink: a target shorter than
+// sizeof(inode->blocks) (60 bytes) is stored inline in the inode and served by
+// ext_readlink()'s fast path, which the hardening does not touch.  A target of
+// 60 bytes or more is stored in a data block and goes through the guarded
+// malloc(block_size) + ext_internal_read() path, so the test uses both lengths
+// and checks that neither is truncated or corrupted.
+//
+// Crafting an inode with i_size > block_size (the actual overflow) needs a
+// debugfs-built image and cannot be done from inside the guest, so that case is
+// covered by the reasoning in the commit message, not here.  What this test
+// pins down is that the guards do not break any legitimate symlink, including
+// the longest one ext can store.
+
+#include <unistd.h>
+#include <string.h>
+#include <stdio.h>
+#include <errno.h>
+#include <dirent.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <sys/stat.h>
+
+#include <cassert>
+#include <string>
+
+// Create a symlink at @path pointing at @target, then read it back and require
+// an exact round-trip.
+static void check_symlink(const std::string& path, const std::string& target)
+{
+    unlink(path.c_str());
+    if (symlink(target.c_str(), path.c_str()) != 0) {
+        fprintf(stderr, "symlink(%s -> %zu bytes) FAILED: %s\n",
+                path.c_str(), target.size(), strerror(errno));
+        assert(false);
+    }
+
+    char buf[PATH_MAX];
+    memset(buf, 0, sizeof(buf));
+    ssize_t n = readlink(path.c_str(), buf, sizeof(buf) - 1);
+    if (n < 0) {
+        fprintf(stderr, "readlink(%s) FAILED: %s\n",
+                path.c_str(), strerror(errno));
+        assert(false);
+    }
+    buf[n] = 0;
+    fprintf(stderr, "readlink(%s) = %zd bytes (expected %zu)\n",
+            path.c_str(), n, target.size());
+    assert(n == (ssize_t)target.size());
+    assert(target == buf);
+
+    unlink(path.c_str());
+}
+
+int main(int argc, char **argv)
+{
+    fprintf(stderr, "Running ext-readlink tests\n");
+
+    // Default to the (writable) ext root; an optional argument lets the same
+    // binary be pointed at another directory, e.g. a mounted ext image at
+    // /data, or a host filesystem when sanity-checking the test itself.
+    const std::string base = (argc > 1) ? argv[1] : "";
+
+    // Fast path: target < sizeof(inode->blocks) (60), stored inline.
+    check_symlink(base + "/tst-ext-link-fast", "/realfile");
+
+    // Slow path: >= 60 bytes, so the target is stored in a data block and read
+    // back through the guarded malloc(block_size) + ext_internal_read() branch
+    // that this change hardens.  64 bytes, just over the inline limit.
+    check_symlink(base + "/tst-ext-link-slow", std::string(64, 'a'));
+
+    // Still the slow path, at the longest target a single block can hold on the
+    // smallest supported block size (1 KiB), to confirm the fsize <= block_size
+    // guard does not reject a legitimate long symlink.
+    check_symlink(base + "/tst-ext-link-long", "/" + std::string(1022, 'b'));
+
+    // ext_readdir() name clamp: a legitimate 255-byte name (EXT4's maximum)
+    // must still be returned intact, i.e. the clamp to sizeof(d_name)-1 = 255
+    // does not truncate any name a well-formed image can contain.
+    {
+        const std::string longest(255, 'c');
+        const std::string dir = base + "/tst-ext-rd";
+        const std::string path = dir + "/" + longest;
+        rmdir(dir.c_str());
+        assert(mkdir(dir.c_str(), 0755) == 0);
+        int fd = creat(path.c_str(), 0644);
+        assert(fd >= 0);
+        close(fd);
+
+        DIR *d = opendir(dir.c_str());
+        assert(d != nullptr);
+        bool found = false;
+        struct dirent *de;
+        while ((de = readdir(d)) != nullptr) {
+            if (longest == de->d_name) {
+                found = true;
+            }
+            // Whatever the entry, the clamp must leave d_name NUL-terminated
+            // within its 256 bytes.
+            assert(strlen(de->d_name) < sizeof(de->d_name));
+        }
+        closedir(d);
+        fprintf(stderr, "readdir 255-byte name found: %d\n", (int)found);
+        assert(found);
+
+        unlink(path.c_str());
+        assert(rmdir(dir.c_str()) == 0);
+    }
+
+    fprintf(stderr, "ext-readlink tests PASSED\n");
+    return 0;
+}


### PR DESCRIPTION
Rebase of #1449 onto current master. #1449 cannot be updated in place: three commits landed on `modules/libext/ext_vnops.cc` after it was branched (bf16817c9 inode deletion time, af27ba4b7 real fsync + page-cache bridge, c08544641 inode refcounting), and force-push to that head branch is not available to me, so this is a fresh branch. **#1449 can be closed in favour of this one.** Same two bugs, re-verified against the current code, with two corrections to the original patch described at the bottom.

Both overflows are still present verbatim in `master` as of 0e34e4dc2. The upstream refactor moved the functions but did not touch either unbounded length.

## 1. `ext_readlink()` heap overflow (critical)

For a slow symlink (target not inline in the inode):

```c
uint32_t block_size = ext4_sb_get_block_size(&fs->sb);
void *buf = malloc(block_size);                        // e.g. 4096
ext_internal_read(fs, ..., uio->uio_offset, buf, fsize, &read_count);
//                                                ^^^^^ up to 2^64-1
```

`fsize` is `ext4_inode_get_size()`, the raw 64-bit `i_size` off disk, and it is passed as the read *size* into a `block_size` allocation. `ext_internal_read()`'s only clamp is

```c
size = ((uint64_t)size > (fsize - offset)) ? ((size_t)(fsize - offset)) : size;
```

which with `size == fsize` and `offset == 0` is a no-op. So it writes ~`fsize` bytes into a `block_size` heap buffer.

A symlink inode with `i_size = 0x100000` and `i_blocks != 0` (so the slow branch is taken) turns any `readlink()`, or any path traversal through that link, into a ~1 MiB write into a 4 KiB allocation. In a unikernel that is kernel heap corruption, i.e. RCE-class. Reaching it needs only that a crafted ext4 image be mounted: an attached volume, or a multi-tenant host.

Working the arithmetic through for the guarded and unguarded cases:

| `i_size` on disk | buffer | bytes written, unpatched | patched |
|---|---|---|---|
| 64 (normal slow symlink) | 4096 | 64, in bounds | 64, in bounds |
| 1 MiB (the PoC) | 4096 | 1048576 | rejected `EIO` |
| 2^32 | 4096 | 4294967296 | rejected `EIO` |
| 2^64-1 | 4096 | 2^64-1 (~16 EiB) | rejected `EIO` |
| 1023 on a 1 KiB-block fs | 1024 | 1023, in bounds | 1023, in bounds |

**Fix:** reject `fsize > block_size`. That is not a heuristic bound: `ext_fsymlink_set()`, the only creator, already refuses `size > block_size`, and a path is bounded by `PATH_MAX` regardless, so a slow symlink's target always occupies exactly one block. Anything larger is a malformed inode. Also reject an offset at or past EOF, where the `(fsize - offset)` clamp underflows; after the first guard that is no longer an overflow, but it still reads blocks the symlink does not own. Both in-tree callers (`sys_readlink`, `read_link`) pass offset 0, so that guard is defence in depth. And check `malloc`.

## 2. `ext_readdir()` `d_name` overflow (high, old-rev image)

```c
uint16_t name_length = ext4_dir_en_get_name_len(&fs->sb, it.curr);
memcpy(dir->d_name, it.curr->name, name_length);   // d_name is 256 bytes
```

On a rev-0 (`rev_level == 0 && minor_rev_level < 5`) image, `ext4_dir_en_get_name_len()` folds in `name_length_high` and can return up to `entry_len - 8`, roughly a full block. lwext4's `ext4_dir_iterator_set()` validates the name against the *entry* length only, never against the caller's buffer, so a crafted rev-0 entry overflows the fixed 256-byte `d_name` by ~4 KiB. **Fix:** clamp to `sizeof(d_name) - 1`.

## Two corrections versus #1449

Reviewing the fix against the new code turned up two things worth changing, so this is not a plain re-apply:

1. **`EIO` instead of `EINVAL`** for the malformed-inode rejection, to match how `rofs_readlink()` reports corrupt on-disk symlink metadata (07f61154a). `EINVAL` on a path OSv reaches through lookup reads as "bad argument" when the argument is fine and the disk is not.
2. **The regression test in #1449 did not reach the patched code.** It asserted `readlink() == "realfile"`, 9 bytes, which is under `sizeof(inode->blocks)` (60) and therefore served by the *fast* inline path; the guarded `else` branch never executed. It was also added to the generic `tests +=` list, so it entered `usr.manifest` for every `fs_type` and `scripts/test.py` would have run it on zfs/rofs images, where `/data/mylink` does not exist, failing the run.

   The test here covers the legitimate side of both guards, which is what a guest can actually construct: an inline symlink, a slow symlink just over the 60-byte inline limit, a slow symlink at the largest target a 1 KiB block can hold (the boundary the `fsize <= block_size` guard turns on), and a 255-byte directory entry round-tripped through `readdir()`. That pins down that the bounds reject only malformed images and truncate nothing a well-formed one can contain. It creates its own fixtures on a writable ext root and is registered in `ext-only-tests` next to `tst-ext4-rw`, so it is built and run only for `fs_type=ext`.

   Crafting `i_size > block_size` needs debugfs to build the image and cannot be done from inside the guest, so the overflow case itself is argued from the arithmetic above rather than asserted in the test.

## Verification

- `modules/libext/ext_vnops.cc` compiles clean under the module's own flags (`-std=gnu++11 -Wall -fno-exceptions -fno-rtti -O2`) against current OSv and lwext4 headers; no new warnings, including under `-Wextra -Wsign-compare` for the two patched functions (the `uint16_t` vs `sizeof` comparison in the clamp is warning-free).
- `tst-ext-readlink` compiles `-Wall -Wextra` clean and all four cases pass when run against a real ext4 filesystem, including the 1023-byte slow symlink and the 255-byte directory entry.
- The length arithmetic in the table above was reproduced from `ext_internal_read()`'s clamp rather than estimated.

Both bugs are in shipped `master`, not in new code.
