### PR TITLE
aarch64: do not cap GICv3 SGI targets at 16 CPUs

### DIFF
--- a/arch/aarch64/gic-v3.hh
+++ b/arch/aarch64/gic-v3.hh
@@ -49,6 +49,7 @@
 
 #include "gic-common.hh"
 #include <osv/spinlock.h>
+#include <osv/sched.hh>
 
 #define GICD_CTLR_WRITE_COMPLETE   (1UL << 31)
 #define GICD_CTLR_ARE_NS           (1U << 4)
@@ -279,7 +280,12 @@ private:
     u64 _typer;
 };
 
-constexpr int max_sgi_cpus = 16;
+// The SGI target is encoded as an affinity path (AFF3.AFF2.AFF1) plus a
+// 16-CPU target list within that affinity-1 cluster (the RS field selects
+// which group of 16), so GICv3 itself is not limited to 16 CPUs.  This array
+// only needs to hold one MPIDR per OSv logical CPU.  It used to be a flat 16,
+// which made send_sgi() assert as soon as a guest had more than 16 vCPUs.
+constexpr int max_sgi_cpus = sched::max_cpus;
 
 class gic_v3_driver : public gic_driver {
 public:


### PR DESCRIPTION
## Summary

On aarch64 with GICv3, a guest configured with more than 16 vCPUs aborts as soon
as the scheduler sends its first inter-processor interrupt:

```
Assertion failed: smp_idx < max_sgi_cpus (arch/aarch64/gic-v3.cc: send_sgi: 671)
  <gic::gic_v3_driver::send_sgi(...)+268>
  <lockfree::mutex::unlock()+304>
  <sched::cpu::notifier::fire()+84>
  <sched::cpu::load_balance()+40>
```

Reproduced immediately at `-smp 32`.

## The bug

`arch/aarch64/gic-v3.hh` declared

```c
constexpr int max_sgi_cpus = 16;
```

which sizes `gic_v3_driver::_mpids_by_smpid`, the array holding one MPIDR per
logical CPU. `send_sgi()` asserts `smp_idx < max_sgi_cpus`. OSv supports
`sched::max_cpus` (64) CPUs, so any guest above 16 vCPUs trips the assert.

The 16 is not a GICv3 limitation. `ICC_SGI1R_EL1` encodes an affinity path
(AFF3.AFF2.AFF1) plus a 16-bit target list *within* the affinity-1 cluster, with
the RS field selecting which group of 16. `send_sgi()` already builds exactly
that from the recorded MPIDR:

```c
((aff0 >> 4) << ICC_SGIxR_EL1_RS_SHIFT) | (1 << (aff0 & 0xf))
```

So the interrupt encoding already scales beyond 16 CPUs; only the lookup array
was bounded at a flat 16.

## The fix

Size the array by `sched::max_cpus`, one entry per OSv logical CPU, and record
why 16 was never the right bound. One line plus a comment.

`gic-v3.hh` now includes `osv/sched.hh`; there is no include cycle
(`sched.hh` does not reference the GIC) and all three existing consumers of
`gic-v3.hh` already include `sched.hh` themselves.

## Validation

With this change an aarch64 guest boots and reaches the scheduler at 32 vCPUs;
before it aborted in `send_sgi` on the first IPI from `load_balance()`.
Also still boots at small vCPU counts, so the previous behaviour is unaffected.

One file, 7 insertions, 1 deletion. Independent of any other pending change.
