### PR TITLE
random: satisfy early /dev/random reads from RDRAND instead of blocking

### DIFF
--- a/drivers/random.cc
+++ b/drivers/random.cc
@@ -56,6 +56,10 @@ static random_device_priv *to_priv(device *dev)
     return reinterpret_cast<random_device_priv*>(dev->private_data);
 }
 
+#ifdef __x86_64__
+static int drng_read(void *, int);   // hardware RDRAND read, defined below
+#endif
+
 static int
 random_read(struct device *dev, struct uio *uio, int ioflags)
 {
@@ -64,6 +68,32 @@ random_read(struct device *dev, struct uio *uio, int ioflags)
 
     // Blocking logic
     if (!random_adaptor->seeded) {
+#ifdef __x86_64__
+        // The software CSPRNG has not accumulated enough harvested entropy to
+        // seed yet.  If the CPU has RDRAND (a hardware CSPRNG that needs no
+        // accumulation window), satisfy the read directly from it instead of
+        // blocking: RDRAND output is cryptographically secure, so /dev/{u,}random
+        // is usable from the very first read.  Otherwise an early reader --
+        // e.g. a PostgreSQL backend generating its cancel key via
+        // pg_strong_random() -> read(/dev/urandom) -- blocks in
+        // randomdev_block() -> msleep(PCATCH); with signals unblocked that
+        // becomes an EINTR retry loop, and until the adaptor crosses its reseed
+        // threshold the read never completes -- observed (racily) as "could not
+        // generate random cancel key" failing backends at startup.  Pre-existing
+        // OSv startup race; independent of fork.
+        if (processor::features().rdrand) {
+            while (uio->uio_resid > 0 && !error) {
+                c = std::min(uio->uio_resid, static_cast<long int>(PAGE_SIZE));
+                // drng_read wants a multiple-of-8 length; round up in the page
+                // buffer and copy out only what the caller asked for.
+                int c8 = (c + 7) & ~7;
+                int got = drng_read(static_cast<void *>(random_buf), c8);
+                if (got <= 0) { error = EIO; break; }
+                error = uiomove(random_buf, std::min(c, got), uio);
+            }
+            return error;
+        }
+#endif
         error = (*random_adaptor->block)(ioflags);
     }
 


### PR DESCRIPTION
## Summary

A process that reads `/dev/random` or `/dev/urandom` before the software CSPRNG
has accumulated enough harvested entropy to seed blocks in `randomdev_block()`
-> `msleep(PCATCH)`. On a freshly booted, otherwise idle guest there is very
little entropy to harvest, so the reader can wait indefinitely; with signals
unblocked it becomes an EINTR retry loop that does not complete until the
adaptor finally crosses its reseed threshold.

This is easy to hit in practice. PostgreSQL calls `pg_strong_random()`, which
reads `/dev/urandom`, while generating a backend cancel key at startup, and
fails with `could not generate random cancel key`.

## The change

When the CPU has RDRAND there is no reason to block. RDRAND is a hardware CSPRNG
that needs no accumulation window and its output is cryptographically secure, so
serve the read from it directly while the software adaptor is still unseeded.
`/dev/{u,}random` then works from the very first read. CPUs without RDRAND keep
the previous blocking behaviour, so this is additive.

The hardware read is length-rounded up to the multiple of 8 that `drng_read()`
requires, and only the number of bytes the caller asked for is copied out.

Note the driver already registers RDRAND as a live entropy source when present;
this uses the same source to answer the read itself rather than only to feed the
accumulator.

One file, self-contained.
