### PR TITLE
aarch64: satisfy early /dev/random reads from RNDR (FEAT_RNG)

### DIFF
--- a/arch/aarch64/cpuid.cc
+++ b/arch/aarch64/cpuid.cc
@@ -33,6 +33,8 @@ static const char *hwcap_str[HWCAP_BIT_N] = {
 #define IS_SHA2_SET(ISAR)  (((ISAR >> 12) & 0x0f) == 1)
 #define IS_CRC32_SET(ISAR) (((ISAR >> 16) & 0x0f) == 1)
 #define IS_ATOMIC_SET(ISAR) (((ISAR >> 20) & 0x0f) == 2)
+/* FEAT_RNG: ID_AA64ISAR0_EL1.RNDR (bits 63:60) == 1 means RNDR/RNDRRS exist */
+#define IS_RNDR_SET(ISAR)  (((ISAR >> 60) & 0x0f) == 1)
 
 const std::string& features_str()
 {
@@ -134,6 +136,10 @@ const unsigned long hwcap32()
 
 void process_cpuid(features_type& features)
 {
+    u64 isar; /* Instruction Set Attribute Register 0 */
+    asm volatile ("mrs %0, ID_AA64ISAR0_EL1" : "=r"(isar));
+    features.rndr = IS_RNDR_SET(isar);
+
 #if CONF_drivers_xen
     xen::get_features(features);
 #endif

--- a/arch/aarch64/cpuid.hh
+++ b/arch/aarch64/cpuid.hh
@@ -35,6 +35,7 @@ struct features_type {
     bool xen_clocksource;
     bool xen_vector_callback;
     bool xen_pci;
+    bool rndr; /* FEAT_RNG: the RNDR/RNDRRS hardware CSPRNG registers */
 };
 
 extern const features_type& features();

--- a/drivers/random.cc
+++ b/drivers/random.cc
@@ -56,6 +56,10 @@ static random_device_priv *to_priv(device *dev)
     return reinterpret_cast<random_device_priv*>(dev->private_data);
 }
 
+#ifdef __x86_64__
+static int drng_read(void *, int);   // hardware RDRAND read, defined below
+#endif
+
 static int
 random_read(struct device *dev, struct uio *uio, int ioflags)
 {
@@ -64,6 +68,32 @@ random_read(struct device *dev, struct uio *uio, int ioflags)
 
     // Blocking logic
     if (!random_adaptor->seeded) {
+#ifdef __x86_64__
+        // The software CSPRNG has not accumulated enough harvested entropy to
+        // seed yet.  If the CPU has RDRAND (a hardware CSPRNG that needs no
+        // accumulation window), satisfy the read directly from it instead of
+        // blocking: RDRAND output is cryptographically secure, so /dev/{u,}random
+        // is usable from the very first read.  Otherwise an early reader --
+        // e.g. a PostgreSQL backend generating its cancel key via
+        // pg_strong_random() -> read(/dev/urandom) -- blocks in
+        // randomdev_block() -> msleep(PCATCH); with signals unblocked that
+        // becomes an EINTR retry loop, and until the adaptor crosses its reseed
+        // threshold the read never completes -- observed (racily) as "could not
+        // generate random cancel key" failing backends at startup.  Pre-existing
+        // OSv startup race; independent of fork.
+        if (processor::features().rdrand) {
+            while (uio->uio_resid > 0 && !error) {
+                c = std::min(uio->uio_resid, static_cast<long int>(PAGE_SIZE));
+                // drng_read wants a multiple-of-8 length; round up in the page
+                // buffer and copy out only what the caller asked for.
+                int c8 = (c + 7) & ~7;
+                int got = drng_read(static_cast<void *>(random_buf), c8);
+                if (got <= 0) { error = EIO; break; }
+                error = uiomove(random_buf, std::min(c, got), uio);
+            }
+            return error;
+        }
+#endif
         error = (*random_adaptor->block)(ioflags);
     }
 

--- a/drivers/random.cc
+++ b/drivers/random.cc
@@ -44,6 +44,9 @@
 #include <dev/random/randomdev_soft.h>
 #include <dev/random/random_adaptors.h>
 #include <dev/random/live_entropy_sources.h>
+#ifdef __aarch64__
+#include "cpuid.hh"
+#endif
 
 namespace randomdev {
 
@@ -60,6 +63,10 @@ static random_device_priv *to_priv(device *dev)
 static int drng_read(void *, int);   // hardware RDRAND read, defined below
 #endif
 
+#ifdef __aarch64__
+static int rndr_read(void *, int);   // hardware RNDR read, defined below
+#endif
+
 static int
 random_read(struct device *dev, struct uio *uio, int ioflags)
 {
@@ -68,26 +75,42 @@ random_read(struct device *dev, struct uio *uio, int ioflags)
 
     // Blocking logic
     if (!random_adaptor->seeded) {
-#ifdef __x86_64__
+#if defined(__x86_64__) || defined(__aarch64__)
         // The software CSPRNG has not accumulated enough harvested entropy to
-        // seed yet.  If the CPU has RDRAND (a hardware CSPRNG that needs no
-        // accumulation window), satisfy the read directly from it instead of
-        // blocking: RDRAND output is cryptographically secure, so /dev/{u,}random
-        // is usable from the very first read.  Otherwise an early reader --
-        // e.g. a PostgreSQL backend generating its cancel key via
-        // pg_strong_random() -> read(/dev/urandom) -- blocks in
-        // randomdev_block() -> msleep(PCATCH); with signals unblocked that
-        // becomes an EINTR retry loop, and until the adaptor crosses its reseed
-        // threshold the read never completes -- observed (racily) as "could not
-        // generate random cancel key" failing backends at startup.  Pre-existing
-        // OSv startup race; independent of fork.
+        // seed yet.  If the CPU has a hardware CSPRNG that needs no
+        // accumulation window (x86 RDRAND, aarch64 RNDR/FEAT_RNG), satisfy the
+        // read directly from it instead of blocking: its output is
+        // cryptographically secure, so /dev/{u,}random is usable from the very
+        // first read.  Otherwise an early reader -- e.g. a PostgreSQL backend
+        // generating its cancel key via pg_strong_random() ->
+        // read(/dev/urandom) -- blocks in randomdev_block() -> msleep(PCATCH);
+        // with signals unblocked that becomes an EINTR retry loop, and until
+        // the adaptor crosses its reseed threshold the read never completes.
+        // On x86 this was observed (racily) as "could not generate random
+        // cancel key" failing backends at startup.  On aarch64, where there was
+        // no hardware path at all before this, the very first postmaster read
+        // of /dev/urandom blocked FOREVER and PostgreSQL never reached "ready
+        // to accept connections" -- the postmaster thread sat in
+        // sys_read -> device_read -> randomdev::random_read ->
+        // randomdev_block -> _msleep -> sched::thread::wait with every CPU
+        // idle.  Pre-existing OSv startup race; independent of fork.
+#ifdef __x86_64__
         if (processor::features().rdrand) {
+#endif
+#ifdef __aarch64__
+        if (processor::features().rndr) {
+#endif
             while (uio->uio_resid > 0 && !error) {
                 c = std::min(uio->uio_resid, static_cast<long int>(PAGE_SIZE));
-                // drng_read wants a multiple-of-8 length; round up in the page
-                // buffer and copy out only what the caller asked for.
+                // the hardware read wants a multiple-of-8 length; round up in
+                // the page buffer and copy out only what the caller asked for.
                 int c8 = (c + 7) & ~7;
+#ifdef __x86_64__
                 int got = drng_read(static_cast<void *>(random_buf), c8);
+#endif
+#ifdef __aarch64__
+                int got = rndr_read(static_cast<void *>(random_buf), c8);
+#endif
                 if (got <= 0) { error = EIO; break; }
                 error = uiomove(random_buf, std::min(c, got), uio);
             }
@@ -192,6 +215,68 @@ drng_read(void *buf, int size)
 }
 #endif
 
+//
+// Arm FEAT_RNG, RNDR: architectural hardware source of entropy.
+// RNDR returns a 64-bit random number from a DRBG seeded by a true entropy
+// source, with NZCV.C=0 on success (C=1 means the RNG could not return a
+// number in reasonable time, and the result must be discarded).
+//
+#ifdef __aarch64__
+static int rndr_read(void *, int);
+
+// Mirrors the x86 RDRAND retry policy: RNDR can transiently fail to deliver
+// while the underlying entropy source catches up, so retry a bounded number of
+// times before giving up.
+static constexpr int rndr_retries_max = 10;
+
+static struct random_hardware_source arm_rndr = {
+    "arm rndr",
+    RANDOM_PURE_RDRAND,
+    &rndr_read,
+};
+
+static inline bool rndr_with_retries(uint64_t *data)
+{
+    for (auto retry = 0; retry <= rndr_retries_max; retry++) {
+        uint64_t val;
+        uint64_t fail;
+        // mrs <x>, RNDR (S3_3_C2_C4_0); PSTATE.C is set if the read failed.
+        asm volatile("mrs %0, s3_3_c2_c4_0\n\t"
+                     "cset %1, cs\n\t"
+                     : "=r"(val), "=r"(fail)
+                     :
+                     : "cc");
+        if (!fail) {
+            *data = val;
+            return true;
+        }
+    }
+    return false;
+}
+
+static int
+rndr_read(void *buf, int size)
+{
+    uint64_t *dest = static_cast<uint64_t *>(buf);
+    uint64_t data;
+    unsigned qwords, qwords_to_read;
+
+    assert((size & (sizeof(uint64_t) - 1)) == 0);
+    qwords_to_read = size / sizeof(uint64_t);
+
+    for (qwords = 0; qwords < qwords_to_read; qwords++) {
+        if (!rndr_with_retries(&data)) {
+            // Handle the unlikely case where RNDR failed after all retries.
+            break;
+        }
+
+        *dest++ = data;
+    }
+
+    return qwords * sizeof(uint64_t);
+}
+#endif
+
 random_device::random_device()
 {
     struct random_device_priv *prv;
@@ -199,6 +284,11 @@ random_device::random_device()
 #ifdef __x86_64__
     if (processor::features().rdrand) {
         live_entropy_source_register(&drng);
+    }
+#endif
+#ifdef __aarch64__
+    if (processor::features().rndr) {
+        live_entropy_source_register(&arm_rndr);
     }
 #endif
     if (live_entropy_sources_empty()) {
@@ -224,6 +314,11 @@ random_device::~random_device()
 #ifdef __x86_64__
     if (processor::features().rdrand) {
         live_entropy_source_deregister(&drng);
+    }
+#endif
+#ifdef __aarch64__
+    if (processor::features().rndr) {
+        live_entropy_source_deregister(&arm_rndr);
     }
 #endif
     (random_adaptor->deinit)();


### PR DESCRIPTION
**Stacked on #1492** (which adds the equivalent RDRAND path for x86_64). Review
that one first; this commit is the aarch64 half.

## Summary

On aarch64 an application that reads `/dev/urandom` at startup can block
forever. PostgreSQL does exactly that (`pg_strong_random()` while setting up a
backend), so on aarch64 the postmaster never logged a single line: it was parked
on its first read.

gdb on a wedged guest: all CPUs idle in `wait_for_interrupt`, 149 threads, and
exactly one `postgres` thread with status `waiting`, unwinding as

```
reschedule_from_interrupt / sched::cpu::schedule() / sched::thread::wait()
synch_port::_msleep(...)
randomdev_block(int)
randomdev::random_read(device*, uio*, int)
device_read / vfs_file::read / sys_read / pread64
... osv::application::run_main()
```

`randomdev_block()` sleeps until `random_context.seeded`, which on an idle
freshly booted guest may never happen.

## Why aarch64 specifically

The driver already avoids this on x86_64 by answering the read from RDRAND when
the software adaptor is unseeded, but that path is gated on `__x86_64__` and
`processor::features().rdrand`. aarch64 had no hardware path at all, so it always
fell into the blocking sleep. That asymmetry is why the same image and the same
application work on x86_64 and hang on aarch64.

## The change

Use Arm's architectural equivalent of RDRAND: FEAT_RNG, advertised by
`ID_AA64ISAR0_EL1.RNDR` (bits 63:60), which provides the `RNDR`/`RNDRRS`
registers.

- detect FEAT_RNG in the aarch64 `features_type`
- when the software adaptor is not yet seeded, serve the read from `RNDR`, with
  the same bounded-retry policy the x86 path uses
- register it as a live entropy source, as x86 does with RDRAND

Cores without FEAT_RNG keep the previous behaviour, so this is additive.

## Validation

On an aarch64 host advertising `rng` in cpuinfo, PostgreSQL 18.6 now starts:

```
LOG:  starting PostgreSQL 18.6 on aarch64-unknown-linux-musl
LOG:  listening on IPv4 address "0.0.0.0", port 5432
LOG:  database system is ready to accept connections
```

Before this change the same image produced no PostgreSQL log output at all.

Three files.
