### PR TITLE
build: make bootfs depend on the ZFS library for any ZFS build, not only fs=zfs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2233,6 +2233,18 @@ bootfs_dep += $(out)/modules/libext/libext.so
 else
 ifeq ($(fs),zfs)
 bootfs_dep += $(tools:%=$(out)/%) $(out)/libsolaris.so
+else
+# bootfs.manifest.skel names /usr/lib/fs/libsolaris.so unconditionally, so the
+# ZFS library is part of bootfs for every root filesystem, not only fs=zfs.  Any
+# ZFS-enabled build therefore has to list it (and the tools that go with it) as a
+# prerequisite here, or mkbootfs runs before it exists: serially that is a hard
+# failure on the missing file, and under -j it is a race that shows up as an
+# intermittent build break.  Key on the ZFS build itself rather than on the root
+# filesystem choice.  A conf_zfs=openzfs image with, say, fs=ramfs and a runtime
+# data pool is a normal configuration and hits exactly this.
+ifdef conf_zfs_openzfs
+bootfs_dep += $(tools:%=$(out)/%) $(out)/libsolaris.so
+endif
 endif
 endif
 $(out)/bootfs.bin: $(bootfs_dep)


### PR DESCRIPTION
## Summary

A ZFS-enabled build whose root filesystem is not `zfs` has no rule ordering the ZFS
library and tools before MKBOOTFS runs, so the bootfs manifest can reference files
that have not been built yet. `bootfs_dep` listed them only under `fs=zfs`:

```make
ifeq ($(fs),ext)
bootfs_dep += $(out)/modules/libext/libext.so
else
ifeq ($(fs),zfs)
bootfs_dep += $(tools:%=$(out)/%) $(out)/libsolaris.so
endif
endif
```

The case that matters in practice is `conf_zfs=openzfs fs=ramfs` with a ZFS pool
created at runtime, which is a normal configuration. For `fs=ramfs`,
`scripts/build` (line 224) sets `manifest=$OUT/usr.manifest`, i.e. the bootfs
manifest IS `usr.manifest` and `bootfs.manifest.skel` is not used at all. The ZFS
module contributes `/usr/lib/fs/libsolaris.so` to that manifest, so bootfs needs
`libsolaris.so` and the userspace ZFS tools built first, yet nothing said so.

Serially that fails outright on the missing file; under `-j` it is a race that
surfaces as an intermittent MKBOOTFS break on `libsolaris.so` or one of the
userspace ZFS libraries. It is why building such an image has required building the
ZFS shared objects by hand first.

## The change

Key the dependency on the ZFS build itself (`conf_zfs_openzfs`) rather than on the
root filesystem choice.

## Verified behaviour

Evaluating the conditional for each configuration, before and after:

| configuration | before | after |
|---|---|---|
| `conf_zfs=openzfs fs=ramfs` | libsolaris.so and tools **absent** | present |
| `conf_zfs=openzfs fs=zfs` | present | present, unchanged |
| `conf_zfs=openzfs fs=ext` | libext.so | libext.so, unchanged |
| no ZFS, `fs=ramfs` | nothing added | nothing added, unchanged |

Only the broken configuration changes; `fs=zfs`, `fs=ext` and non-ZFS builds keep
their existing dependencies.

One file.

## Note on a separate, independent bug

While validating this we found a second and distinct defect at the same site, which
this PR does **not** address: passing `open_zfs` explicitly in the image list
shadows the `zfs` placeholder module. `resolve.require()` registers `open_zfs`'s
`provides=['zfs']` under the name `zfs`, so `modules/zfs/module.py` is never
imported and the `/usr/lib/fs/libsolaris.so` manifest line it owns never reaches
`usr.manifest` at all. Measured:

| image list | modules loaded | libsolaris.so in usr.manifest |
|---|---|---|
| `zfs,zfs-tools` | open_zfs, zfs, zfs-tools | present |
| `open_zfs,zfs-tools` | open_zfs, zfs-tools | absent |
| `open_zfs,zfs,zfs-tools` | open_zfs, zfs-tools | absent |

On `fs=ramfs` that is fatal rather than a race: the guest dies at "Failed to
preload ZFS library. Powering off." The same shadowing applies to `bsd_zfs`. That
deserves its own fix in the module-resolution layer and is not in scope here.
