### PR TITLE
build: order the mount tools before bootfs for fs=ramfs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2233,6 +2233,15 @@ bootfs_dep += $(out)/modules/libext/libext.so
 else
 ifeq ($(fs),zfs)
 bootfs_dep += $(tools:%=$(out)/%) $(out)/libsolaris.so
+else
+ifeq ($(fs),ramfs)
+# For fs=ramfs, scripts/build passes $(out)/usr.manifest as the bootfs manifest,
+# and that manifest is generated from usr_ramfs.manifest.skel, which lists
+# tools/mount/mount-fs.so and tools/mount/umount.so.  Without these the very
+# first build of a fresh tree races: mkbootfs.py stats a tool nothing ordered
+# and dies with FileNotFoundError.
+bootfs_dep += $(out)/tools/mount/mount-fs.so $(out)/tools/mount/umount.so
+endif
 endif
 endif
 $(out)/bootfs.bin: $(bootfs_dep)


### PR DESCRIPTION
Building a fresh tree with `fs=ramfs` fails during `MKBOOTFS`:

```
strip: 'tools/mount/mount-fs.so': No such file
FileNotFoundError: [Errno 2] No such file or directory: 'tools/mount/mount-fs.so'
make: *** [Makefile:2238: build/release.x64/bootfs.bin] Error 1
```

### Cause

For `fs=ramfs`, `scripts/build` uses the generated `$(out)/usr.manifest` as the bootfs manifest, and that manifest is generated from `usr_ramfs.manifest.skel`, which names two tools:

```
/tools/mount-fs.so: tools/mount/mount-fs.so
/tools/umount.so: tools/mount/umount.so
```

`bootfs_dep`, however, only gains the tools for `fs=ext` and `fs=zfs`:

```make
bootfs_dep := scripts/mkbootfs.py $(bootfs_manifest) $(bootfs_manifest_dep) $(out)/libenviron.so
ifeq ($(fs),ext)
bootfs_dep += $(out)/modules/libext/libext.so
else
ifeq ($(fs),zfs)
bootfs_dep += $(tools:%=$(out)/%) $(out)/libsolaris.so
endif
endif
```

So for `fs=ramfs` nothing orders those two objects before `bootfs.bin`, and `mkbootfs.py` stats a file make was never told to build first.

It is timing dependent, which is why it is not always visible: in a tree that already built something else the tools may happen to be present. In a clean clone it fails every time, because `bootfs.bin` is reached before anything else has a reason to build the mount tools.

### Fix

Add just those two objects to `bootfs_dep` for `fs=ramfs`. Only the files the ramfs manifest actually names are added, rather than all of `$(tools)`, so a ramfs build does not start pulling in `mkfs`/`cpiod`/`uush`, which it never references.

### Verification

I checked this against a clean clone of this repository's master rather than only against my own tree, since that is where it reproduces most clearly:

| build | result |
|---|---|
| clean clone, `fs=ramfs`, without this change | fails at `MKBOOTFS` (`FileNotFoundError`) |
| clean clone, `fs=ramfs`, with this change | completes, image produced |

I also re-ran the default (`zfs`) and `fs=rofs` builds with the change applied and both still complete, so the added dependency does not disturb the other filesystem paths.

Note this is a distinct problem from the `bootfs` ZFS-library dependency in #1494: that one is about `libsolaris.so` and the ZFS tools for a ZFS-enabled build, while this is the ramfs manifest's own two mount tools going unordered.
