### PR TITLE
drivers/ahci: fix boot hang when an AHCI port presents an ATAPI device (breaks all q35 boots)

### DIFF
--- a/drivers/ahci.cc
+++ b/drivers/ahci.cc
@@ -66,6 +66,24 @@ port::port(u32 pnr, hba *hba)
         return;
     }
 
+    // This driver supports plain ATA disks only. A port may also present an
+    // ATAPI device (typically an optical drive), a port multiplier or an
+    // enclosure management bridge, none of which accept the ATA IDENTIFY
+    // DEVICE command that disk_identify() issues. Reading the signature and
+    // skipping such a port avoids sending a command that is guaranteed to be
+    // aborted, and avoids the task file error handling that follows it.
+    //
+    // This is the common configuration rather than an exotic one. Machine
+    // types with a built-in AHCI controller, such as QEMU's q35 with its ICH9,
+    // attach an empty optical drive by default, so an ATAPI device is present
+    // on a port of the very controller this driver probes.
+    auto sig = port_readl(PORT_SIG);
+    if (sig != PORT_SIG_ATA) {
+        debugf("AHCI: port %d ignored, signature 0x%08x is not an ATA disk\n",
+               _pnr, sig);
+        return;
+    }
+
     if (!disk_identify()) {
         debugf("AHCI: port %d ignored, IDENTIFY DEVICE failed\n", _pnr);
         return;

--- a/drivers/ahci.cc
+++ b/drivers/ahci.cc
@@ -65,8 +65,14 @@ port::port(u32 pnr, hba *hba)
     if (!linkup()) {
         return;
     }
-    disk_identify();
+
+    if (!disk_identify()) {
+        debugf("AHCI: port %d ignored, IDENTIFY DEVICE failed\n", _pnr);
+        return;
+    }
+
     enable_irq();
+    _usable = true;
 }
 
 void port::reset()
@@ -207,33 +213,65 @@ int port::send_cmd(u8 slot, int iswrite, void *buffer, u32 bsize)
     return 0;
 }
 
-void port::wait_cmd_poll(u8 slot)
+bool port::wait_cmd_poll(u8 slot)
 {
     auto host_is = _hba->hba_readl(HOST_IS);
+    bool ok = false;
+
     for (;;) {
         auto is = port_readl(PORT_IS);
-        if (is) {
+        if (!is) {
+            continue;
+        }
+
+        // A task file error means the device rejected or failed the command.
+        // The error state has to be sampled before PxIS is acked, because
+        // writing PxIS clears the record of what went wrong. The HBA has also
+        // already cleared PxCMD.ST and will not retire the command slot, so
+        // neither PxTFD nor PxCI will ever settle for this command and waiting
+        // on them would never return (AHCI 1.3.1, section 6.2.2). Report the
+        // failure to the caller instead.
+        if (is & PORT_IS_TFES) {
+            auto tfd = port_readl(PORT_TFD);
             port_writel(PORT_IS, is);
+            debugf("AHCI: port %d command in slot %d failed, "
+                   "PxIS=0x%08x PxTFD=0x%08x\n", _pnr, slot, is, tfd);
+            break;
+        }
 
-            wait_device_ready();
-            wait_ci_ready(slot);
+        port_writel(PORT_IS, is);
 
-           if (is & 0x02) {
-               auto error  = _recv_fis->psfis[3];
-               assert(!error);
-               break;
-           }
+        wait_device_ready();
+        wait_ci_ready(slot);
 
-           if (is & 0x01) {
-               auto error  = recv_fis_error();
-               assert(!error);
-               break;
+        if (is & PORT_IS_PSS) {
+            auto error = _recv_fis->psfis[3];
+            if (error) {
+                debugf("AHCI: port %d slot %d PIO setup FIS error 0x%02x\n",
+                       _pnr, slot, error);
+                break;
             }
+            ok = true;
+            break;
+        }
+
+        if (is & PORT_IS_DHRS) {
+            auto error = recv_fis_error();
+            if (error) {
+                debugf("AHCI: port %d slot %d device to host FIS error "
+                       "0x%02x\n", _pnr, slot, error);
+                break;
+            }
+            ok = true;
+            break;
         }
     }
+
     _hba->hba_writel(HOST_IS, host_is);
 
     _cmd_active &= ~(1U << slot);
+
+    return ok;
 }
 
 u32 port::done_mask()
@@ -309,8 +347,8 @@ int port::make_request(struct bio* bio)
 void port::poll_mode_done(struct bio *bio, u8 slot)
 {
     if (_hba->poll_mode()) {
-        wait_cmd_poll(slot);
-        biodone(bio, true);
+        bool ok = wait_cmd_poll(slot);
+        biodone(bio, ok);
     }
 }
 
@@ -365,7 +403,7 @@ void port::disk_flush(struct bio *bio)
     poll_mode_done(bio, slot);
 }
 
-void port::disk_identify()
+bool port::disk_identify()
 {
     u8 slot = 0;
     struct cmd_table &cmd = _cmd_table[slot];
@@ -378,7 +416,10 @@ void port::disk_identify()
     cmd.fis.command = ATA_CMD_IDENTIFY_DEVICE;
 
     send_cmd(slot, 0, buffer, 512);
-    wait_cmd_poll(slot);
+    if (!wait_cmd_poll(slot)) {
+        delete [] buffer;
+        return false;
+    }
 
     // Word 75 queue depth
     _queue_depth = buffer[75] & 0x1F;
@@ -395,6 +436,7 @@ void port::disk_identify()
     _devsize = sectors * 512;
 
     delete [] buffer;
+    return true;
 }
 
 bool port::used_slot()
@@ -518,7 +560,7 @@ void hba::scan()
             continue;
 
         auto p = new port(pnr, this);
-        if (!p->linkup()) {
+        if (!p->usable()) {
             delete p;
             continue;
         }

--- a/drivers/ahci.cc
+++ b/drivers/ahci.cc
@@ -78,7 +78,7 @@ port::port(u32 pnr, hba *hba)
 void port::reset()
 {
     // Disable FIS and Command
-    for (;;) {
+    for (int i = 0; i < PORT_POLL_LIMIT; i++) {
         auto cmd = port_readl(PORT_CMD);
         if (!(cmd & (PORT_CMD_FRE | PORT_CMD_FR | PORT_CMD_ST | PORT_CMD_CR)))
             break;
@@ -129,7 +129,10 @@ void port::setup()
     port_writel(PORT_SERR, err);
 
     // Wait for Device Becoming Ready
-    wait_device_ready();
+    if (!wait_device_ready()) {
+        _linkup = false;
+        return;
+    }
 
     // Start Device
     cmd |= PORT_CMD_ST;
@@ -151,24 +154,36 @@ void port::enable_irq()
     port_writel(PORT_IE, val);
 }
 
-void port::wait_device_ready()
+bool port::wait_device_ready()
 {
     // Wait for Device Becoming Ready
-    for (;;) {
+    for (int i = 0; i < PORT_POLL_LIMIT; i++) {
         auto tfd = port_readl(PORT_TFD);
         if (!(tfd & (PORT_TFD_BSY | PORT_TFD_DRQ)))
-            break;
+            return true;
+        if (tfd & PORT_TFD_ERR) {
+            debugf("AHCI: port %d device reported an error while becoming "
+                   "ready, PxTFD=0x%08x\n", _pnr, tfd);
+            return false;
+        }
     }
+    debugf("AHCI: port %d timed out waiting for the device to become ready, "
+           "PxTFD=0x%08x\n", _pnr, port_readl(PORT_TFD));
+    return false;
 }
 
-void port::wait_ci_ready(u8 slot)
+bool port::wait_ci_ready(u8 slot)
 {
     // Wait for Command Issue Becoming Ready
-    for (;;) {
+    for (int i = 0; i < PORT_POLL_LIMIT; i++) {
         auto ci = port_readl(PORT_CI);
         if (!(ci & (1U << slot)))
-            break;
+            return true;
     }
+    debugf("AHCI: port %d timed out waiting for slot %d to retire, "
+           "PxCI=0x%08x PxTFD=0x%08x\n", _pnr, slot,
+           port_readl(PORT_CI), port_readl(PORT_TFD));
+    return false;
 }
 
 int port::send_cmd(u8 slot, int iswrite, void *buffer, u32 bsize)
@@ -218,7 +233,7 @@ bool port::wait_cmd_poll(u8 slot)
     auto host_is = _hba->hba_readl(HOST_IS);
     bool ok = false;
 
-    for (;;) {
+    for (int i = 0; i < PORT_POLL_LIMIT; i++) {
         auto is = port_readl(PORT_IS);
         if (!is) {
             continue;
@@ -241,8 +256,9 @@ bool port::wait_cmd_poll(u8 slot)
 
         port_writel(PORT_IS, is);
 
-        wait_device_ready();
-        wait_ci_ready(slot);
+        if (!wait_device_ready() || !wait_ci_ready(slot)) {
+            break;
+        }
 
         if (is & PORT_IS_PSS) {
             auto error = _recv_fis->psfis[3];
@@ -501,7 +517,9 @@ hba::hba(pci::device& pci_dev)
     _driver_name = "ahci";
     parse_pci_config();
 
-    reset();
+    if (!reset()) {
+        return;
+    }
     setup();
     enable_irq();
     scan();
@@ -515,7 +533,7 @@ hba::~hba()
     }
 }
 
-void hba::reset()
+bool hba::reset()
 {
     auto val = hba_readl(HOST_GHC);
 
@@ -530,12 +548,17 @@ void hba::reset()
     val |= HOST_GHC_HR;
     hba_writel(HOST_GHC, val);
 
-    // Wait reset of HBA to finish
-    for (;;) {
+    // Wait reset of HBA to finish. HR is self-clearing and the reset has to
+    // complete within one second (AHCI 1.3.1, section 10.4.3), so a controller
+    // that never clears it is broken and must not hold up the boot.
+    for (int i = 0; i < PORT_POLL_LIMIT; i++) {
         val = hba_readl(HOST_GHC);
         if ((val & HOST_GHC_HR) == 0x00)
-            break;
+            return true;
     }
+    debugf("AHCI: HBA reset did not complete, HOST_GHC=0x%08x\n",
+           hba_readl(HOST_GHC));
+    return false;
 }
 
 void hba::setup()

--- a/drivers/ahci.hh
+++ b/drivers/ahci.hh
@@ -114,6 +114,13 @@ enum port_reg_ssts_bits {
     PORT_SSTS_RETRY     = 0x0F,
 };
 
+// Upper bound on the number of MMIO polls spent waiting for a register bit to
+// settle. AHCI defines no completion deadline for an individual command, so
+// any such wait has to be bounded by the driver: a device that never sets the
+// awaited bit must fail one command rather than wedge the kernel. Sized
+// generously so that a healthy but slow device is never given up on.
+enum { PORT_POLL_LIMIT = 20000000 };
+
 // CIFS: Command FIS
 struct cfis {
     // DWORD 0
@@ -204,7 +211,7 @@ public:
     void dump_config();
     bool ack_irq();
     void enable_irq();
-    void reset();
+    bool reset();
     void setup();
     void scan();
     void add_port(u32 pnr, port * port);
@@ -242,8 +249,8 @@ public:
     void disk_rw(struct bio *bio, bool iswrite);
     int make_request(struct bio *bio);
     void enable_irq();
-    void wait_device_ready();
-    void wait_ci_ready(u8 slot);
+    bool wait_device_ready();
+    bool wait_ci_ready(u8 slot);
     void wakeup() { _irq_thread->wake_with_irq_disabled(); }
     bool linkup() { return _linkup; }
 

--- a/drivers/ahci.hh
+++ b/drivers/ahci.hh
@@ -114,6 +114,17 @@ enum port_reg_ssts_bits {
     PORT_SSTS_RETRY     = 0x0F,
 };
 
+// PORT_SIG values. The signature register reports the type of device attached
+// to the port, latched by the HBA from the first Register Device to Host FIS
+// the device sends (AHCI 1.3.1, section 3.3.4).
+enum port_reg_sig_values {
+    PORT_SIG_ATA        = 0x00000101,
+    PORT_SIG_ATAPI      = 0xEB140101,
+    PORT_SIG_SEMB       = 0xC33C0101,
+    PORT_SIG_PM         = 0x96690101,
+    PORT_SIG_NONE       = 0xFFFFFFFF,
+};
+
 // Upper bound on the number of MMIO polls spent waiting for a register bit to
 // settle. AHCI defines no completion deadline for an individual command, so
 // any such wait has to be bounded by the driver: a device that never sets the

--- a/drivers/ahci.hh
+++ b/drivers/ahci.hh
@@ -102,7 +102,9 @@ enum port_reg_ie_bits {
 // PORT_IS bits
 enum port_reg_is_bits {
     PORT_IS_DHRS    = 1U << 0,
+    PORT_IS_PSS     = 1U << 1,
     PORT_IS_SDBS    = 1U << 3,
+    PORT_IS_TFES    = 1U << 30,
 };
 
 // PORT_SSTS bits
@@ -233,9 +235,9 @@ public:
     void reset();
     void setup();
     int send_cmd(u8 slot, int iswrite, void *buffer, u32 bsize);
-    void wait_cmd_poll(u8 slot);
+    bool wait_cmd_poll(u8 slot);
     void wait_cmd_irq(u8 slot);
-    void disk_identify();
+    bool disk_identify();
     void disk_flush(struct bio *bio);
     void disk_rw(struct bio *bio, bool iswrite);
     int make_request(struct bio *bio);
@@ -244,6 +246,12 @@ public:
     void wait_ci_ready(u8 slot);
     void wakeup() { _irq_thread->wake_with_irq_disabled(); }
     bool linkup() { return _linkup; }
+
+    // A port is usable only once it has been identified as a working ATA disk.
+    // linkup() alone is not sufficient: a port can be linked up and still fail
+    // or reject IDENTIFY DEVICE, in which case it has no valid size and must
+    // not be published as a block device.
+    bool usable() { return _usable; }
 
     u32 port2hba(u32 port_reg)
     {
@@ -284,6 +292,7 @@ public:
 private:
     sched::thread_handle _cmd_send_waiter;
     bool _linkup = false;
+    bool _usable = false;
     u8 _queue_depth;
     size_t _devsize;
     mutex _lock;


### PR DESCRIPTION
## Summary

OSv's AHCI probe hangs forever, during boot, if any AHCI port presents an ATAPI
device. The kernel never reaches the application.

This is usually reported as "OSv does not boot under QEMU `-M q35`", which is how
I started looking at it, but that framing is wrong and the differential below
shows why: `-M pc` hangs identically once an AHCI controller with an optical
drive is attached to it. The machine type is not the variable. q35 only makes the
bug unavoidable, because q35 implies a built-in ICH9 AHCI controller and QEMU
attaches an empty `ide-cd` to it unless `-nodefaults` is given.

That matters right now because distros are dropping i440fx. Amazon Linux 2023's
QEMU 11 ships q35 only, where `-M pc` fails outright with `unsupported machine
type: "pc"`. On such a host every affected image is simply unbootable, with no
`-M pc` fallback available.

## Reproduction and differential diagnosis

Same kernel, same image, same QEMU 8.1.3 binary, TCG throughout, so neither the
accelerator nor the QEMU version is a factor. Before the fix:

```
q35 default                                    -> HANGS
q35 -nodefaults                                -> BOOTS
q35 -nodefaults + ich9-ahci, no CD             -> BOOTS
q35 -nodefaults + ich9-ahci + ide-cd           -> HANGS
pc  default                                    -> BOOTS
pc  default      + ich9-ahci + ide-cd          -> HANGS   <-- i440fx hangs too
```

The last two rows are the diagnosis. Removing the CD from q35 fixes it; adding a
CD to i440fx breaks it. The trigger is an ATAPI device on an AHCI port, and it is
reproducible under TCG on any host, no KVM or particular hardware needed.

## Where it hangs

The last console line is `virtio-blk: Add blk device instances 0 as vblk0`, which
made this look like a virtio-blk problem. It is not: virtio-blk completes
normally, including real block I/O in `read_partition_table()`, and the hang is
in the next driver to probe. Attaching gdb to the stuck guest shows the main init
thread spinning in the AHCI driver:

```
Thread 2 (Thread 1.2 (CPU#1 [running])):
#0  mmio_getl (addr=0x4000febd6238) at core/mmio.cc:47
#1  pci::bar::readl (...) at drivers/pci-function.cc:69
#2  ahci::hba::hba_readl (...) at ./drivers/ahci.hh:213
#3  ahci::port::port_readl (this=0x600000cd0800, reg=56) at ./drivers/ahci.hh:259
#4  ahci::port::wait_ci_ready (...) at drivers/ahci.cc:162
#5  ahci::port::wait_cmd_poll (this=0x600000cd0800, slot=0) at drivers/ahci.cc:219
#6  ahci::port::disk_identify (this=0x600000cd0800) at drivers/ahci.cc:381
#7  ahci::port::port (...) at drivers/ahci.cc:68
#8  ahci::hba::scan (this=0x600000fef400) at drivers/ahci.cc:520
#9  ahci::hba::hba (...) at drivers/ahci.cc:465
#10 ahci::hba::probe (...) at drivers/ahci.cc:608
...
#18 hw::driver_manager::load_all (...) at drivers/driver.cc:38
#19 arch_init_drivers () at arch/x64/arch-setup.cc:402
#20 do_main_thread (...) at loader.cc:547
```

Thread 1 is the idle thread, halted. Nothing else is runnable, so this is a hard
hang rather than a slow path: the wait is on the main init path, with no watchdog
or timeout above it.

Register state at the hang, read from the AHCI ABAR (`reg 56` = 0x38 = PxCI, and
the faulting address decodes to port 2, `0x238 - 0x100 = 0x138`, `0x138 / 0x80 = 2`):

```
HOST_CAP  = 0xc0141f05     HOST_GHC = 0x80000002    HOST_PI = 0x0000003f

port 0 (empty):   PxSIG = 0xffff0101   PxTFD = 0x00000050   PxCI = 0x00000000
port 2 (stuck):   PxSIG = 0xeb140101   <- ATAPI signature, not 0x00000101 ATA
                  PxTFD = 0x00000441   <- ERR code 0x04 = ABRT, status 0x41 = DRDY|ERR
                  PxCI  = 0x00000001   <- slot 0 never retires
                  PxIS  = 0x00000000   <- TFES already acked away by the driver
                  PxCMD = 0x0000c017
```

## Root cause

`hba::scan()` probes every implemented port that reports link up and issues ATA
IDENTIFY DEVICE to it, without checking what kind of device is attached. An ATAPI
device aborts that command, which is exactly what `PxTFD` shows above: ABRT, with
ERR set.

On a task file error the HBA sets `PxIS.TFES`, clears `PxCMD.ST`, and does not
retire the command slot (AHCI 1.3.1, section 6.2.2). A port with ST clear issues
nothing further, so the `PxCI` bit for that command stays set for as long as the
port remains stopped. The specification guarantees it will never clear by itself.

`wait_cmd_poll()` then does three independently wrong things, in this order:

```c
port_writel(PORT_IS, is);        // 1. acks PxIS first, destroying the TFES record
wait_device_ready();
wait_ci_ready(slot);             // 2. waits on PxCI, which per 6.2.2 never clears
if (is & 0x02) { ... }           // 3. only ever tests DHRS/PSS, never TFES
if (is & 0x01) { ... }
```

`PORT_IS_TFES` is already defined in `drivers/ahci.hh` and is never referenced in
`drivers/ahci.cc`. The error bit is defined and ignored, the error record is
destroyed before anything can read it, and the wait is unbounded on a bit that
cannot change. Note also that both existing error paths use `assert(!error)`, so
even a detected error would abort the kernel rather than fail the command; the
patch makes those paths return a failure instead, but does not otherwise expand
scope.

## The fix

Three commits, deliberately separable, each of which stands on its own so a
reviewer can take a subset. Commits 1 and 2 are the general robustness fix and
commit 3 is the specific cause.

1. **`fail a command on a task file error instead of waiting forever`** - check
   `PxIS.TFES`, sample `PxTFD` before acking `PxIS`, and return a `bool` so a
   failed command is reported. `disk_identify()` propagates the failure, `scan()`
   gates on a new `usable()` rather than `linkup()` so a port that failed
   IDENTIFY is not published as a block device with no valid size, and
   `poll_mode_done()` passes the result to `biodone()` instead of
   unconditionally reporting success on a failed read.

2. **`bound every register poll so a stuck device cannot hang the boot`** - five
   loops had no exit other than the bit they awaited. Each gets a poll bound and
   a way to report failure, and `wait_device_ready()` also returns early on
   `PxTFD.ERR`. This is the part that converts any future device error from an
   unbootable kernel into one failed command plus a diagnostic. It does not
   depend on knowing which condition leaves a bit stuck.

3. **`skip ports that are not ATA disks`** - read `PxSIG` and probe only ports
   reporting the ATA signature (`0x00000101`), skipping ATAPI (`0xEB140101`),
   port multipliers and enclosure bridges. The signature is latched from the
   device's first D2H Register FIS (AHCI 1.3.1, section 3.3.4), so it costs no
   I/O. A narrow skip is preferred over implementing ATAPI: OSv has no use for
   an optical drive, and declining the device class is both the whole
   requirement and far less code than a new command path.

## Verification

Full matrix re-run with the exact patch in this PR applied, rebuilt from clean:

```
### q35-default                  BOOTS (rc=0)
      virtio-blk: Add blk device instances 0 as vblk0, devsize=536870912
      AHCI: port 2 ignored, signature 0xeb140101 is not an ATA disk
      Booted up in 0.00 ms
      Failed to load object: /tools/umount.so. Powering off.

### q35-nodefaults               BOOTS (rc=0)
### q35-ahci-no-cd               BOOTS (rc=0)

### q35-ahci-with-cd             BOOTS (rc=0)
      virtio-blk: Add blk device instances 0 as vblk0, devsize=536870912
      AHCI: port 2 ignored, signature 0xeb140101 is not an ATA disk
      Booted up in 0.00 ms
      Failed to load object: /tools/umount.so. Powering off.

### pc-default                   BOOTS (rc=0)
      virtio-blk: Add blk device instances 0 as vblk0, devsize=536870912
      Booted up in 0.00 ms
      Failed to load object: /tools/umount.so. Powering off.

### pc-PLUS-ahci-cd              BOOTS (rc=0)
      virtio-blk: Add blk device instances 0 as vblk0, devsize=536870912
      AHCI: port 2 ignored, signature 0xeb140101 is not an ATA disk
      Booted up in 0.00 ms
      Failed to load object: /tools/umount.so. Powering off.
```

All six cells boot, including `pc + ich9-ahci + ide-cd`, which confirms the bug
was fixed rather than the machine type avoided, and `pc default`, which confirms
no regression on the previously working configuration.

Full boot to ZFS root and clean poweroff on q35, the configuration that used to
hang:

```
OSv v0.57.0-398-g0e34e4dc
2 CPUs detected
NUMA: no SRAT, assuming a single flat node
bsd: initializing - done
VFS: mounting ramfs at /
VFS: mounting devfs at /dev
net: initializing - done
vga: Add VGA device instance
devfs: created device vblk0.1 for a partition at offset:6291456 with size:530579456
virtio-blk: Add blk device instances 0 as vblk0, devsize=536870912
AHCI: port 2 ignored, signature 0xeb140101 is not an ATA disk
random: <Software, Yarrow> initialized
VFS: unmounting /dev
zfs: driver has been initialized!
VFS: mounting zfs at /zfs
zfs: mounting osv from device /dev/vblk0.1
random: device unblocked.
BSD shrinker: unlocked, running
Booted up in 0.00 ms
Cmdline: /hello
Powering off.
```

AHCI is still exercised as a real boot disk, so the skip does not disable working
functionality. With the image on `ide-hd` (the `scripts/run.py --sata` path):

```
### sata-boot-q35                BOOTS (rc=0)
      AHCI: Add sata device port 0 as vblk0, devsize=536870912
### sata-boot-pc                 BOOTS (rc=0)

##### AHCI disk AND an ATAPI CD on the same controller (q35) #####
### sata-disk-plus-cd            BOOTS (rc=0)
      AHCI: Add sata device port 0 as vblk0, devsize=536870912
      AHCI: port 2 ignored, signature 0xeb140101 is not an ATA disk
```

The last case is the one that matters for the skip: a real SATA disk on port 0 is
still found and used while the ATAPI device on port 2 is declined.

Each of the three commits was also built standalone on top of `master`, all with
zero compiler warnings, to confirm they are individually applyable.

## Blast radius

Correction worth stating precisely, because the obvious reading of the config is
misleading. `conf/profiles/x64/base.mk` has `conf_drivers_ahci?=0`, which suggests
AHCI is off by default, but the default drivers profile is `all`, and
`conf/profiles/x64/all.mk` includes `vbox.mk`, which sets `conf_drivers_ahci?=1`
before base.mk's `?=0` is evaluated. A default `scripts/build` kernel therefore
has the AHCI driver linked in and probing, which I confirmed on the built kernel:

```
$ nm -C build/last/loader.elf | grep -c ahci
73
```

So the affected set is any default-profile x86_64 kernel booted on a host that
presents an ATAPI device on an AHCI port, which on q35 is the out-of-the-box
configuration.

## Notes

Tested on QEMU 8.1.3 under TCG, which still provides both `pc` and `q35` and so
permits the A/B; the q35 half also reproduces and is fixed under KVM. QEMU is
behaving per the AHCI specification throughout, so this is entirely an OSv bug.
