### PR TITLE
drivers: allocate block device names from one shared namespace

### DIFF
--- a/drivers/ahci.cc
+++ b/drivers/ahci.cc
@@ -16,8 +16,6 @@
 
 namespace ahci {
 
-int hba::_disk_idx = 0;
-
 struct hba_priv {
     devop_strategy_t strategy;
     class hba *hba;
@@ -523,8 +521,7 @@ void hba::scan()
             continue;
         }
 
-        std::string dev_name("vblk");
-        dev_name += std::to_string(_disk_idx++);
+        std::string dev_name = blk_next_device_name();
         auto dev = device_create(&hba_driver, dev_name.c_str(), D_BLK);
         auto prv = static_cast<struct hba_priv*>(dev->private_data);
         prv->hba = this;

--- a/drivers/ahci.hh
+++ b/drivers/ahci.hh
@@ -222,7 +222,6 @@ private:
     bool _poll_mode = false;
     pci::device& _pci_dev;
     interrupt_manager _msi;
-    static int _disk_idx;
     pci::bar *_bar6;
 };
 

--- a/drivers/blk-common.cc
+++ b/drivers/blk-common.cc
@@ -11,12 +11,20 @@
 #include <osv/bio.h>
 #include <osv/ioctl.h>
 
+#include <atomic>
+
 #include <osv/trace.hh>
 #include "drivers/blk-common.hh"
 
 #include <sys/mount.h>
 
 TRACEPOINT(trace_blk_ioctl, "dev=%s type=%#x nr=%d size=%d, dir=%d", char*, int, int, int, int);
+
+std::string blk_next_device_name()
+{
+    static std::atomic<int> disk_idx(0);
+    return "vblk" + std::to_string(disk_idx++);
+}
 
 int
 blk_ioctl(struct device* dev, u_long io_cmd, void* buf)

--- a/drivers/blk-common.hh
+++ b/drivers/blk-common.hh
@@ -11,6 +11,18 @@
 
 #include <osv/device.h>
 
+#include <string>
+
 int blk_ioctl(struct device* dev, u_long io_cmd, void* buf);
+
+// Allocate the next free name in the shared "vblk<N>" block device namespace.
+//
+// Every block driver registers its disks in the same flat devfs namespace, and
+// device_register() treats a name collision as fatal (sys_panic("duplicate
+// device")).  A per-driver counter is therefore not sufficient: two different
+// drivers each starting at 0 both produce "vblk0", and the second one to probe
+// panics the kernel.  Drawing every name from this single allocator keeps them
+// unique no matter which drivers are compiled in or what order they probe in.
+std::string blk_next_device_name();
 
 #endif

--- a/drivers/ide.cc
+++ b/drivers/ide.cc
@@ -86,7 +86,7 @@ ide_drive::ide_drive(pci::device& pci_dev)
 
     struct ide_priv* prv;
     struct device *dev;
-    std::string dev_name("vblk0");
+    std::string dev_name = blk_next_device_name();
 
     dev = device_create(&ide_driver, dev_name.c_str(), D_BLK);
     prv = reinterpret_cast<struct ide_priv*>(dev->private_data);

--- a/drivers/nvme.cc
+++ b/drivers/nvme.cc
@@ -9,6 +9,7 @@
 #include <sys/cdefs.h>
 
 #include "drivers/nvme.hh"
+#include "drivers/blk-common.hh"
 #include "drivers/pci-device.hh"
 #include <osv/interrupt.hh>
 
@@ -42,7 +43,6 @@ TRACEPOINT(trace_nvme_strategy, "bio=%p, bcount=%lu", struct bio*, size_t);
 
 namespace nvme {
 
-int driver::_disk_idx = 0;
 int driver::_instance = 0;
 
 struct nvme_priv {
@@ -153,8 +153,7 @@ driver::driver(pci::device &pci_dev)
         set_interrupt_coalescing(20, 2);
     }
 
-    std::string dev_name("vblk");
-    dev_name += std::to_string(_disk_idx++);
+    std::string dev_name = blk_next_device_name();
 
     struct device* dev = device_create(&_driver, dev_name.c_str(), D_BLK);
     struct nvme_priv* prv = reinterpret_cast<struct nvme_priv*>(dev->private_data);

--- a/drivers/nvme.hh
+++ b/drivers/nvme.hh
@@ -94,9 +94,6 @@ private:
     static int _instance;
     int _id;
 
-    //Disk index number
-    static int _disk_idx;
-
     std::vector<std::unique_ptr<msix_vector>> _msix_vectors;
 
     std::unique_ptr<admin_queue_pair, aligned_new_deleter<admin_queue_pair>> _admin_queue;

--- a/drivers/virtio-blk.cc
+++ b/drivers/virtio-blk.cc
@@ -218,8 +218,7 @@ blk::blk(virtio_device& virtio_dev)
 
     struct blk_priv* prv;
     struct device *dev;
-    std::string dev_name("vblk");
-    dev_name += std::to_string(_disk_idx++);
+    std::string dev_name = blk_next_device_name();
 
     dev = device_create(&blk_driver, dev_name.c_str(), D_BLK);
     prv = reinterpret_cast<struct blk_priv*>(dev->private_data);

--- a/drivers/virtio-scsi.cc
+++ b/drivers/virtio-scsi.cc
@@ -112,8 +112,7 @@ void scsi::add_lun(u16 target, u16 lun)
 
     exec_read_capacity(target, lun, devsize);
 
-    std::string dev_name("vblk");
-    dev_name += std::to_string(_disk_idx++);
+    std::string dev_name = blk_next_device_name();
     dev = device_create(&scsi_driver, dev_name.c_str(), D_BLK);
     prv = static_cast<struct scsi_priv*>(dev->private_data);
     prv->strategy = scsi_strategy;

--- a/drivers/virtio.cc
+++ b/drivers/virtio.cc
@@ -17,8 +17,6 @@ TRACEPOINT(trace_virtio_wait_for_queue, "queue(%p) have_elements=%d", void*, int
 
 namespace virtio {
 
-int virtio_driver::_disk_idx = 0;
-
 virtio_driver::virtio_driver(virtio_device& dev)
     : hw_driver()
     , _dev(dev)

--- a/drivers/virtio.hh
+++ b/drivers/virtio.hh
@@ -114,7 +114,6 @@ protected:
     u32 _num_queues;
     bool _cap_indirect_buf;
     bool _cap_event_idx = false;
-    static int _disk_idx;
     u64 _enabled_features;
 };
 

--- a/drivers/vmw-pvscsi.cc
+++ b/drivers/vmw-pvscsi.cc
@@ -28,7 +28,6 @@ using namespace memory;
 
 namespace vmw {
 int pvscsi::_instance = 0;
-int pvscsi::_disk_idx = 0;
 
 struct pvscsi_priv {
     devop_strategy_t strategy;
@@ -312,8 +311,7 @@ void pvscsi::add_lun(u16 target, u16 lun)
 
     exec_read_capacity(target, lun, devsize);
 
-    std::string dev_name("vblk");
-    dev_name += std::to_string(_disk_idx++);
+    std::string dev_name = blk_next_device_name();
     dev = device_create(&pvscsi_driver, dev_name.c_str(), D_BLK);
     prv = static_cast<struct pvscsi_priv*>(dev->private_data);
     prv->strategy = pvscsi_strategy;

--- a/drivers/vmw-pvscsi.hh
+++ b/drivers/vmw-pvscsi.hh
@@ -172,9 +172,6 @@ private:
     static int _instance;
     int _id;
 
-    // Disk index number
-    static int _disk_idx;
-
     // This mutex protects parallel make_request invocations
     mutex _lock;
 


### PR DESCRIPTION
Two block drivers in the same guest panic the kernel at boot with `panic: duplicate device`, because each driver mints device names from its own counter starting at 0 and they collide on `vblk0`.

This is independent of #1498 (the AHCI/ATAPI probe hang) and does not depend on it. Details on how they interact are at the end.

## Reproduction

Stock x86_64 kernel built from master (`0e34e4dc`), qemu 8.1.3, no local configuration changes. Give the guest one virtio-blk disk and one NVMe disk:

```
qemu-system-x86_64 -M pc -m 1G -smp 1 -kernel loader.elf \
  -append "--verbose /hello" -nographic -display none \
  -device virtio-blk-pci,drive=hd0 -drive file=vblk.qcow2,if=none,id=hd0 \
  -device nvme,drive=nv0,serial=beef01 -drive file=nvme.qcow2,if=none,id=nv0
```

Before this change:

```
virtio-blk: Add blk device instances 0 as vblk0, devsize=104857600
panic: duplicate device
[backtrace]
0x00000000403b1e02 <sys_panic+18>
0x00000000403bdce6 <device_register+150>
0x00000000403bde17 <device_create+87>
0x00000000402f2b7c <nvme::driver::driver(pci::device&)+812>
0x00000000402f2e2a <nvme::driver::probe(hw::hw_device*)+122>
0x00000000402d312b <hw::device_manager::for_each_device(std::function<void (hw::hw_device*)>)+59>
0x00000000402d73b6 <hw::driver_manager::load_all()+70>
0x000000004030657b <arch_init_drivers()+907>
0x0000000040235807 <do_main_thread(void*)+119>
```

The panic happens on both machine types, so it is not machine specific:

| configuration | machine | before | after |
| --- | --- | --- | --- |
| virtio-blk + NVMe | `-M pc` | panic: duplicate device | boots |
| virtio-blk + NVMe | `-M q35` | panic: duplicate device | naming fixed, see note |
| virtio-blk alone | `-M pc` | boots | boots |
| NVMe alone | `-M pc` | boots | boots |
| virtio-blk + 2 NVMe | `-M pc` | panic: duplicate device | boots |

The single-driver rows are the control that identifies this as a naming collision rather than a fault in any one driver: **either driver on its own boots fine and takes `vblk0`**. It is only the combination that fails, and it fails in whichever driver happens to probe second.

## Cause

Block drivers register disks as `vblk<N>` in the flat devfs namespace, and `fs/devfs/device.cc:168-170` makes a collision fatal:

```c
/* Check if specified name is already used. */
if (device_lookup(name) != NULL)
        sys_panic("duplicate device");
```

But the `<N>` came from four independent counters, each initialised to 0, feeding six naming sites:

| counter | drivers |
| --- | --- |
| `virtio_driver::_disk_idx` | virtio-blk, virtio-scsi (already shared) |
| `nvme::driver::_disk_idx` | nvme |
| `ahci::hba::_disk_idx` | ahci |
| `vmw::pvscsi::_disk_idx` | vmw-pvscsi |

So virtio-blk names its first disk `vblk0` and NVMe independently names its first disk `vblk0` too. Whichever probes second panics.

`drivers/ide.cc:89` was worse: it did not count at all, it hardcoded the literal `"vblk0"`, so an IDE disk collided with the first disk of any other block driver unconditionally.

## Fix

One `blk_next_device_name()` in `blk-common`, handing out names from a single atomic index, used by all six sites. `blk-common.hh` was already included by five of the six drivers, so this adds one include (nvme) and no new file.

```c
std::string blk_next_device_name()
{
    static std::atomic<int> disk_idx(0);
    return "vblk" + std::to_string(disk_idx++);
}
```

The four now-unused counters are removed. They were used for nothing but building these names.

Names keep the same `vblk<N>` form deliberately, so boot arguments, manifests and anything referring to `/dev/vblk0` keep working. Giving each driver its own prefix (`nvme0`, `sata0`) would also fix the collision but would be a user visible naming change, turning a bug fix into a compatibility break, so I did not do that.

The one behaviour change worth calling out: the number a given disk receives now depends on probe order across all block drivers rather than per driver. That is already how virtio-blk and virtio-scsi behaved with respect to each other, since they shared a counter.

## Verification

Same command line as the reproduction, after the change, showing distinct names:

```
virtio-blk: Add blk device instances 0 as vblk0, devsize=104857600
nvme: Add device instances 0 as vblk1, devsize=67108864, serial number:beef01
Failed to load object: /hello. Powering off.
```

Three disks across two drivers:

```
virtio-blk: Add blk device instances 0 as vblk0, devsize=104857600
nvme: Add device instances 0 as vblk1, devsize=67108864, serial number:beef01
nvme: Add device instances 1 as vblk2, devsize=67108864, serial number:beef02
Failed to load object: /hello. Powering off.
```

Single driver, confirming no regression in the common case:

```
virtio-blk: Add blk device instances 0 as vblk0, devsize=104857600
Failed to load object: /hello. Powering off.
```

All of the above are from a kernel built with exactly this one commit applied to `0e34e4dc`, with the default driver profile, so ahci, ide, nvme, pvscsi, virtio-blk and virtio-scsi are all compiled in.

## Relationship to #1498

Independent bugs, no dependency in either direction, and they do not touch the same lines. #1498 changes the AHCI probe and command polling; this changes only the naming call in `hba::scan()`. I verified the two apply together cleanly and built a tree with both.

Worth noting for sequencing, since it shows the two are genuinely separate: with only this patch, the `-M q35` row above gets its names right and then hangs in the #1498 ATAPI bug, since q35 always presents an empty ATAPI CD-ROM on its built in AHCI. With both patches, q35 boots and you can see each fix doing its own job:

```
virtio-blk: Add blk device instances 0 as vblk0, devsize=104857600
nvme: Add device instances 0 as vblk1, devsize=67108864, serial number:beef01
AHCI: port 2 ignored, signature 0xeb140101 is not an ATA disk
Failed to load object: /hello. Powering off.
```

Either can be merged first.
