### PR TITLE
lwext4: pin the checkout to an exact commit

### DIFF
--- a/modules/lwext4/Makefile
+++ b/modules/lwext4/Makefile
@@ -23,9 +23,18 @@ lwext4: upstream/lwext4/build_lib_only/src/liblwext4.so
 
 .PHONY: lwext4
 
+# Pin the lwext4 checkout to an exact commit.  A bare `clone --depth 1` takes
+# whatever the remote HEAD happens to be at build time, so two builds of the
+# same OSv tree could link different lwext4 revisions and neither would record
+# which one.  That makes any ext4 measurement or bug report unreproducible after
+# the fork moves.  Override with `make lwext4_commit=<sha>` to test another
+# revision.
+lwext4_commit?=6f6d8f7c509da696e71e80cc5a59abfc48e4971b
+
 upstream/lwext4/.git:
 	mkdir -p $(module-dir)/upstream && cd $(module-dir)/upstream && \
-	git clone --depth 1 https://github.com/osvunikernel/lwext4.git
+	git clone https://github.com/osvunikernel/lwext4.git && \
+	cd lwext4 && git checkout --detach $(lwext4_commit)
 
 upstream/lwext4/build_lib_only/src/liblwext4.so: upstream/lwext4/.git
 	cd $(module-dir)/upstream/lwext4 && \


### PR DESCRIPTION
`modules/lwext4/Makefile` cloned the upstream fork with a bare `git clone --depth 1`, which takes whatever the remote `HEAD` happens to be at the moment the build runs:

```make
upstream/lwext4/.git:
	mkdir -p $(module-dir)/upstream && cd $(module-dir)/upstream && \
	git clone --depth 1 https://github.com/osvunikernel/lwext4.git
```

Two builds of the same OSv tree can therefore link different lwext4 revisions, and neither build records which revision it used. That makes an ext4 performance measurement or a libext bug report unreproducible once the fork moves, and it makes bisecting a regression across the OSv/lwext4 boundary impossible.

This pins the checkout to an explicit commit, currently the fork's present `HEAD`:

```
6f6d8f7c509da696e71e80cc5a59abfc48e4971b  2025-07-04
Disable journaling and link with -nodefaultlibs
```

so the default build behaviour is unchanged today while becoming reproducible tomorrow. The commit stays overridable for testing another revision:

```
make lwext4_commit=<sha>
```

`--depth 1` is dropped because a shallow clone cannot check out an arbitrary commit. That costs a slightly larger clone; the repository is small.

Verified by running the clone and checkout rather than assuming the SHA resolves:

```
git clone https://github.com/osvunikernel/lwext4.git
git checkout --detach 6f6d8f7c509da696e71e80cc5a59abfc48e4971b
-> 6f6d8f7 2025-07-04 Disable journaling and link with -nodefaultlibs
```