### PR TITLE
vfs: fix AB-BA deadlock between dentry_hash_lock and the vnode lock

### DIFF
--- a/fs/vfs/vfs.h
+++ b/fs/vfs/vfs.h
@@ -160,6 +160,14 @@ void drele(struct dentry *dp);
 void dentry_init(void);
 
 #ifdef DEBUG_VFS
+/*
+ * True iff the calling thread holds dentry_hash_lock.  Used by vn_lock() to
+ * assert the VFS lock order (vnode lock -> dentry_hash_lock, never reverse).
+ */
+bool vfs_dentry_hash_lock_held(void);
+#endif
+
+#ifdef DEBUG_VFS
 void	 vnode_dump(void);
 void	 mount_dump(void);
 #endif

--- a/fs/vfs/vfs_dentry.cc
+++ b/fs/vfs/vfs_dentry.cc
@@ -46,7 +46,64 @@
 
 static LIST_HEAD(dentry_hash_head, dentry) dentry_hash_table[DENTRY_BUCKETS];
 static LIST_HEAD(fake, dentry) fake;
+
+/*
+ * LOCK ORDERING RULE (whole VFS):
+ *
+ *     vnode lock (vn_lock)  ->  dentry_hash_lock
+ *
+ * and NEVER the reverse.  namei() establishes this direction: it holds
+ * vn_lock(dvp) across dentry_lookup()/dentry_alloc() (vfs_lookup.cc), both of
+ * which take dentry_hash_lock inside.  Therefore no code may call anything
+ * that takes a vnode lock while holding dentry_hash_lock.
+ *
+ * drele() used to violate exactly that: it took dentry_hash_lock and then
+ * called vn_del_name(), which does vn_lock() internally.  A namei() on one
+ * thread (vn_lock held, waiting for dentry_hash_lock) against a drele() on
+ * another (dentry_hash_lock held, waiting for vn_lock) is an AB-BA deadlock
+ * with nothing left runnable -- observed as all vCPUs halted in do_idle with
+ * an empty wakeup mask and >1000 threads parked, while memory was plentiful.
+ *
+ * dentry_hash_lock is a leaf lock now.  Keep it that way: do not call out to
+ * vnode code, and do not allocate, while holding it.
+ */
 static mutex dentry_hash_lock;
+
+#ifdef DEBUG_VFS
+/*
+ * Teeth for the ordering rule above.  When DEBUG_VFS is on, every thread
+ * tracks whether it currently holds dentry_hash_lock; vn_lock() asserts that
+ * it does not.  This fires on the unfixed drele() and is silent once
+ * vn_del_name() is moved out of the critical section.
+ */
+extern "C" bool vfs_dentry_hash_lock_held(void);   /* declared in vfs.h */
+static __thread int dentry_hash_lock_depth;
+bool vfs_dentry_hash_lock_held(void)
+{
+    return dentry_hash_lock_depth != 0;
+}
+static void dentry_hash_lock_enter(void) { dentry_hash_lock_depth++; }
+static void dentry_hash_lock_exit(void)  { dentry_hash_lock_depth--; }
+#else
+static inline void dentry_hash_lock_enter(void) {}
+static inline void dentry_hash_lock_exit(void)  {}
+#endif
+
+/*
+ * dentry_hash_lock accessors.  Use these, not mutex_lock/unlock directly, so
+ * the ordering instrumentation cannot be bypassed by a new call site.
+ */
+static void dentry_hash_lock_acquire(void)
+{
+    mutex_lock(&dentry_hash_lock);
+    dentry_hash_lock_enter();
+}
+
+static void dentry_hash_lock_release(void)
+{
+    dentry_hash_lock_exit();
+    mutex_unlock(&dentry_hash_lock);
+}
 
 /*
  * Get the hash value from the mount point and path name.
@@ -95,9 +152,9 @@ dentry_alloc(struct dentry *parent_dp, struct vnode *vp, const char *path)
 
     vn_add_name(vp, dp);
 
-    mutex_lock(&dentry_hash_lock);
+    dentry_hash_lock_acquire();
     LIST_INSERT_HEAD(&dentry_hash_table[dentry_hash(mp, path)], dp, d_link);
-    mutex_unlock(&dentry_hash_lock);
+    dentry_hash_lock_release();
     return dp;
 };
 
@@ -106,15 +163,15 @@ dentry_lookup(struct mount *mp, char *path)
 {
     struct dentry *dp;
 
-    mutex_lock(&dentry_hash_lock);
+    dentry_hash_lock_acquire();
     LIST_FOREACH(dp, &dentry_hash_table[dentry_hash(mp, path)], d_link) {
         if (dp->d_mount == mp && !strncmp(dp->d_path, path, PATH_MAX)) {
             dp->d_refcnt++;
-            mutex_unlock(&dentry_hash_lock);
+            dentry_hash_lock_release();
             return dp;
         }
     }
-    mutex_unlock(&dentry_hash_lock);
+    dentry_hash_lock_release();
     return nullptr;                /* not found */
 }
 
@@ -153,6 +210,7 @@ dentry_move(struct dentry *dp, struct dentry *parent_dp, char *path)
     }
 
     WITH_LOCK(dentry_hash_lock) {
+        dentry_hash_lock_enter();
         // Remove all dp's child dentries from the hashtable.
         dentry_children_remove(dp);
         // Remove dp with outdated hash info from the hashtable.
@@ -163,6 +221,7 @@ dentry_move(struct dentry *dp, struct dentry *parent_dp, char *path)
         // Insert dp updated hash info into the hashtable.
         LIST_INSERT_HEAD(&dentry_hash_table[dentry_hash(dp->d_mount, path)],
             dp, d_link);
+        dentry_hash_lock_exit();
     }
 
     if (old_pdp) {
@@ -175,11 +234,11 @@ dentry_move(struct dentry *dp, struct dentry *parent_dp, char *path)
 void
 dentry_remove(struct dentry *dp)
 {
-    mutex_lock(&dentry_hash_lock);
+    dentry_hash_lock_acquire();
     LIST_REMOVE(dp, d_link);
     /* put it on a fake list for drele() to work*/
     LIST_INSERT_HEAD(&fake, dp, d_link);
-    mutex_unlock(&dentry_hash_lock);
+    dentry_hash_lock_release();
 }
 
 void
@@ -188,9 +247,9 @@ dref(struct dentry *dp)
     ASSERT(dp);
     ASSERT(dp->d_refcnt > 0);
 
-    mutex_lock(&dentry_hash_lock);
+    dentry_hash_lock_acquire();
     dp->d_refcnt++;
-    mutex_unlock(&dentry_hash_lock);
+    dentry_hash_lock_release();
 }
 
 void
@@ -199,15 +258,27 @@ drele(struct dentry *dp)
     ASSERT(dp);
     ASSERT(dp->d_refcnt > 0);
 
-    mutex_lock(&dentry_hash_lock);
+    dentry_hash_lock_acquire();
     if (--dp->d_refcnt) {
-        mutex_unlock(&dentry_hash_lock);
+        dentry_hash_lock_release();
         return;
     }
+    /*
+     * Last reference.  Unlink from the hash chain while still holding the
+     * lock -- that is what makes the drop below safe: once dp is off the
+     * chain, dentry_lookup() can no longer find it, so no other thread can
+     * resurrect it by taking a new reference.  This thread is the sole owner
+     * of dp from here on, and d_refcnt is 0 and stays 0.
+     *
+     * vn_del_name() must NOT be called under dentry_hash_lock: it takes the
+     * vnode lock, which inverts the vn_lock -> dentry_hash_lock order that
+     * namei() establishes (see the ordering note at the top of this file).
+     * Release first, then touch the vnode.
+     */
     LIST_REMOVE(dp, d_link);
-    vn_del_name(dp->d_vnode, dp);
+    dentry_hash_lock_release();
 
-    mutex_unlock(&dentry_hash_lock);
+    vn_del_name(dp->d_vnode, dp);
 
     if (dp->d_parent) {
         WITH_LOCK(dp->d_parent->d_lock) {

--- a/fs/vfs/vfs_dentry.cc
+++ b/fs/vfs/vfs_dentry.cc
@@ -193,6 +193,11 @@ dentry_move(struct dentry *dp, struct dentry *parent_dp, char *path)
 {
     struct dentry *old_pdp = dp->d_parent;
     char *old_path = dp->d_path;
+    // Duplicate the new path BEFORE taking dentry_hash_lock.  strdup() can
+    // block in the page allocator, and dentry_hash_lock is a leaf lock held
+    // by every lookup in the system; sleeping under it stalls all VFS name
+    // resolution for the duration.  Nothing here needs the lock.
+    char *new_path = strdup(path);
 
     if (old_pdp) {
         WITH_LOCK(old_pdp->d_lock) {
@@ -215,8 +220,8 @@ dentry_move(struct dentry *dp, struct dentry *parent_dp, char *path)
         dentry_children_remove(dp);
         // Remove dp with outdated hash info from the hashtable.
         LIST_REMOVE(dp, d_link);
-        // Update dp.
-        dp->d_path = strdup(path);
+        // Update dp with the path duplicated above, outside the lock.
+        dp->d_path = new_path;
         dp->d_parent = parent_dp;
         // Insert dp updated hash info into the hashtable.
         LIST_INSERT_HEAD(&dentry_hash_table[dentry_hash(dp->d_mount, path)],

--- a/fs/vfs/vfs_vnode.cc
+++ b/fs/vfs/vfs_vnode.cc
@@ -143,6 +143,16 @@ vn_lock(struct vnode *vp)
 	ASSERT(vp);
 	ASSERT(vp->v_refcnt > 0);
 
+#ifdef DEBUG_VFS
+	/*
+	 * Lock-order check with teeth (see the ordering note in vfs_dentry.cc):
+	 * the VFS order is vnode lock -> dentry_hash_lock, never the reverse.
+	 * Taking a vnode lock while already holding dentry_hash_lock is the
+	 * AB-BA inversion that deadlocked drele() against namei().
+	 */
+	ASSERT(!vfs_dentry_hash_lock_held());
+#endif
+
 	mutex_lock(&vp->v_lock);
 	vp->v_nrlocks++;
 	DPRINTF(VFSDB_VNODE, ("vn_lock:   %s\n", vn_path(vp)));

--- a/modules/tests/Makefile
+++ b/modules/tests/Makefile
@@ -148,6 +148,7 @@ tests := tst-iovcnt-guard.so tst-pthread.so misc-ramdisk.so tst-vblk.so tst-mq-s
 	tst-mmap-file.so misc-mmap-big-file.so tst-mmap.so tst-huge.so \
 	tst-pthread-timedlock.so \
 	tst-signal-fills.so \
+	tst-dentry-lock.so \
 	tst-epoll-pwait2.so \
 	tst-splice.so \
 	tst-fs-syscalls.so \

--- a/tests/tst-dentry-lock.cc
+++ b/tests/tst-dentry-lock.cc
@@ -1,0 +1,190 @@
+/*
+ * Copyright (C) 2026 Greg Burd
+ *
+ * This work is open source software, licensed under the terms of the
+ * BSD license as described in the LICENSE file in the top-level directory.
+ */
+
+// Concurrency stress for the dentry cache, aimed at the lock-order inversion
+// between dentry_hash_lock and the vnode lock.
+//
+// The wedge this reproduces: namei() holds vn_lock(dvp) while calling
+// dentry_lookup()/dentry_alloc(), which take dentry_hash_lock -- so the order
+// is vn_lock -> dentry_hash_lock.  drele() used to take dentry_hash_lock and
+// then call vn_del_name(), which takes vn_lock internally -- the reverse.
+// Two threads hitting both orders on the same directory vnode deadlock with
+// nothing runnable.
+//
+// To hit it you need many threads doing open()/close() of DIFFERENT names in
+// the SAME directory (so they share the parent directory's vnode but land on
+// different hash buckets), plus concurrent rename() and unlink() traffic to
+// exercise dentry_move()/dentry_remove() and force dentries onto the fake
+// fake list.  A single-threaded test never sees it.
+//
+// On unfixed code this hangs (the harness kills it by timeout).  On fixed
+// code it completes and reports OK.  Under DEBUG_VFS the vn_lock() assertion
+// fires on the unfixed path instead of hanging, which is the faster signal.
+
+#include <atomic>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+static std::atomic<int> failures{0};
+static std::atomic<long> ops{0};
+
+#define EXPECT(cond, msg)                                                      \
+    do {                                                                       \
+        if (!(cond)) {                                                         \
+            std::printf("FAIL %s:%d: %s (errno=%d %s)\n", __FILE__, __LINE__,  \
+                        (msg), errno, std::strerror(errno));                   \
+            failures++;                                                        \
+        }                                                                      \
+    } while (0)
+
+static const char *DIR = "/tmp/tst-dentry-lock";
+
+// Open and close the same set of names repeatedly.  All of these live in one
+// directory, so every lookup takes that directory's vnode lock and then a
+// dentry_hash_lock; the names differ so they spread across hash buckets.
+static void open_close_worker(int id, int iters, int names)
+{
+    for (int i = 0; i < iters; i++) {
+        for (int n = 0; n < names; n++) {
+            char path[256];
+            std::snprintf(path, sizeof(path), "%s/f%d", DIR, (id + n * 7) % names);
+            int fd = open(path, O_RDONLY);
+            if (fd >= 0) {
+                close(fd);
+                ops++;
+            }
+            // A miss is fine and is itself interesting: a failed lookup still
+            // walks the chain and still drele()s the parent dentry.
+        }
+    }
+}
+
+// Stat a deep path so each call walks several components, taking and dropping
+// a directory dentry reference at every level -- this is the drele() side.
+static void stat_worker(int iters)
+{
+    for (int i = 0; i < iters; i++) {
+        struct stat st;
+        char path[256];
+        std::snprintf(path, sizeof(path), "%s/d0/d1/d2", DIR);
+        if (stat(path, &st) == 0) {
+            ops++;
+        }
+        std::snprintf(path, sizeof(path), "%s/d0/d1", DIR);
+        if (stat(path, &st) == 0) {
+            ops++;
+        }
+    }
+}
+
+// Rename traffic: exercises dentry_move() and the
+// strdup that used to happen under the lock.
+static void rename_worker(int id, int iters)
+{
+    for (int i = 0; i < iters; i++) {
+        char a[256], b[256];
+        std::snprintf(a, sizeof(a), "%s/r%d_%d", DIR, id, i & 1);
+        std::snprintf(b, sizeof(b), "%s/r%d_%d", DIR, id, (i & 1) ^ 1);
+        int fd = open(a, O_CREAT | O_RDWR, 0644);
+        if (fd >= 0) {
+            close(fd);
+            if (rename(a, b) == 0) {
+                ops++;
+            }
+            unlink(a);
+            unlink(b);
+        }
+    }
+}
+
+// Create/unlink churn: forces dentry_remove(), which moves dentries onto the
+// fake list.
+static void churn_worker(int id, int iters)
+{
+    for (int i = 0; i < iters; i++) {
+        char path[256];
+        std::snprintf(path, sizeof(path), "%s/c%d_%d", DIR, id, i % 4);
+        int fd = open(path, O_CREAT | O_RDWR, 0644);
+        if (fd >= 0) {
+            close(fd);
+            // Open it again by name so a second dentry reference exists while
+            // it is being removed.
+            int fd2 = open(path, O_RDONLY);
+            unlink(path);
+            if (fd2 >= 0) {
+                close(fd2);
+            }
+            ops++;
+        }
+    }
+}
+
+int main(int argc, char **argv)
+{
+    // Deliberately more threads than CPUs: the inversion needs two threads to
+    // interleave inside the two lock acquisitions, so oversubscription helps.
+    int nthreads = 16;
+    int iters = 200;
+    const int names = 32;   // == DENTRY_BUCKETS, to spread across all buckets
+    if (argc > 1) nthreads = std::atoi(argv[1]);
+    if (argc > 2) iters = std::atoi(argv[2]);
+
+    std::printf("tst-dentry-lock: %d threads x %d iters\n", nthreads, iters);
+
+    mkdir(DIR, 0777);
+    char p[256];
+    std::snprintf(p, sizeof(p), "%s/d0", DIR);            mkdir(p, 0777);
+    std::snprintf(p, sizeof(p), "%s/d0/d1", DIR);         mkdir(p, 0777);
+    std::snprintf(p, sizeof(p), "%s/d0/d1/d2", DIR);      mkdir(p, 0777);
+    for (int n = 0; n < names; n++) {
+        std::snprintf(p, sizeof(p), "%s/f%d", DIR, n);
+        int fd = open(p, O_CREAT | O_RDWR, 0644);
+        EXPECT(fd >= 0, "setup open");
+        if (fd >= 0) close(fd);
+    }
+
+    std::vector<std::thread> ts;
+    for (int i = 0; i < nthreads; i++) {
+        switch (i % 4) {
+        case 0: ts.emplace_back(open_close_worker, i, iters, names); break;
+        case 1: ts.emplace_back(stat_worker, iters); break;
+        case 2: ts.emplace_back(rename_worker, i, iters); break;
+        default: ts.emplace_back(churn_worker, i, iters); break;
+        }
+    }
+    for (auto &t : ts) {
+        t.join();
+    }
+
+    // Cleanup (best effort; failures here are not the point of the test).
+    for (int n = 0; n < names; n++) {
+        std::snprintf(p, sizeof(p), "%s/f%d", DIR, n);
+        unlink(p);
+    }
+    std::snprintf(p, sizeof(p), "%s/d0/d1/d2", DIR);  rmdir(p);
+    std::snprintf(p, sizeof(p), "%s/d0/d1", DIR);     rmdir(p);
+    std::snprintf(p, sizeof(p), "%s/d0", DIR);        rmdir(p);
+    rmdir(DIR);
+
+    std::printf("tst-dentry-lock: %ld ops, %d failures\n", ops.load(),
+                failures.load());
+    if (failures) {
+        std::printf("FAILED\n");
+        return 1;
+    }
+    // Reaching this line at all is the result: the unfixed kernel never does.
+    std::printf("OK\n");
+    return 0;
+}


### PR DESCRIPTION
The VFS has an implicit lock order that `namei()` establishes and `drele()`
violated. This series states the rule, adds an assertion that enforces it, and
makes `drele()` conform.

## The rule

`fs/vfs/vfs_lookup.cc` holds the directory vnode lock across the dentry cache
lookup, at two sites (`:178` and `:284`):

    vn_lock(dvp);
    dp = dentry_lookup(mp, node);          // takes dentry_hash_lock
    if (dp == nullptr) {
        error = VOP_LOOKUP(dvp, name, &vp);
        dp = dentry_alloc(ddp, vp, node);  // takes dentry_hash_lock
    }
    vn_unlock(dvp);

So the order is **vnode lock, then `dentry_hash_lock`**. Nothing may take a
vnode lock while holding `dentry_hash_lock`.

`drele()` did exactly that. It took `dentry_hash_lock` and then called
`vn_del_name()`, which takes the vnode lock internally
(`fs/vfs/vfs_vnode.cc:531`):

    mutex_lock(&dentry_hash_lock);
    if (--dp->d_refcnt) { ... }
    LIST_REMOVE(dp, d_link);
    vn_del_name(dp->d_vnode, dp);          // vn_lock(vp) in here
    mutex_unlock(&dentry_hash_lock);

A `namei()` holding `vn_lock` and waiting for `dentry_hash_lock`, against a
`drele()` holding `dentry_hash_lock` and waiting for `vn_lock`, is an AB-BA
deadlock in which neither side can proceed.

## Evidence

The first commit adds `ASSERT(!vfs_dentry_hash_lock_held())` to `vn_lock()`
under `DEBUG_VFS`, so the rule is checked rather than asserted in prose. On
unfixed code it fires immediately, during `vfs_init`, with this stack:

    0x00000000403bc1b8 <vn_lock+168>
    0x00000000403bcc71 <vn_del_name+17>
    0x00000000403c1167 <drele+103>
    0x00000000403c0be7 <vfs_file::close()+87>
    0x00000000403b8090 <fdrop+80>
    0x00000000403b8216 <fdclose(int)+118>
    0x00000000403b1267 <close+23>
    0x00000000403b6832 <unpack_bootfs()+258>
    0x00000000403b69b6 <vfs_init+182>

On fixed code, same test and same configuration, the assertion is silent and
the test passes:

    VFSFLAG ... unset, default 1
    Cmdline: /tests/tst-dentry-lock.so 8 40
    tst-dentry-lock: 8 threads x 40 iters
    tst-dentry-lock: 2880 ops, 0 failures
    OK

Note what the stack shows: `fdrop()` is the ordinary `close()` path
(`fs/vfs/main.cc:154`, `:159`, `:194`). The illegal order is therefore taken by
every `close()` that drops a last dentry reference. It is not a rare
interleaving; the lock cycle is constructed constantly, and the only missing
ingredient for the deadlock is a concurrent `namei()` on the same vnode.

That ingredient was supplied in production. On a 32-vCPU guest running a
forking server with 184 concurrent backends, the system wedged with
`dentry_hash_lock` held, every vCPU halted in `do_idle` with an empty wakeup
mask, and over a thousand threads parked, while ~27 GiB of memory was free.

**The included stress test passes on unfixed code.** 48 threads x 400
iterations, 172,800 operations, 16 vCPUs under TCG, and it does not wedge:
OSv's mutex hold times here are short, and closing the cycle needs genuine
parallelism plus a same-vnode collision. A reviewer who runs it on a laptop and
sees it pass should not conclude the defect is fictional; the assertion above
is the reliable signal, and the hang itself was observed on 32 real vCPUs. The
test is included because it exercises the paths (concurrent open/close in one
directory, plus rename and unlink churn) and would catch a regression that
reintroduces a blocking call under the lock.

## The fix

Release `dentry_hash_lock` before calling `vn_del_name()`. Unlinking from the
hash chain stays inside the critical section, and that is what makes the early
release safe: once the dentry is off the chain, `dentry_lookup()` cannot find
it, so no thread can take a new reference. The releasing thread is its sole
owner and the refcount is 0 and stays 0.

`dentry_hash_lock` becomes a leaf lock: it calls out to no other subsystem.
Every acquisition is routed through accessors so a new call site cannot quietly
bypass the rule, and the per-thread ownership tracking that the assertion needs
costs nothing when `DEBUG_VFS` is off.

## Commits

1. `vfs: fix AB-BA deadlock between dentry_hash_lock and the vnode lock` - the
   ordering fix, the documented rule, and the assertion.
2. `vfs: do not allocate while holding dentry_hash_lock in dentry_move()` - an
   independent latent defect found while auditing the other call sites.
   `dentry_move()` called `strdup()` inside the critical section; that
   allocation can block in the page allocator while every lookup in the system
   waits. Hoisted above the lock. Not the deadlock, and on the `rename()` path
   rather than the `open()` path, but the same class of mistake.
3. `tests: concurrency stress for the dentry cache lock order` - the test,
   with the caveat above recorded in its header comment.

## Notes

Not fork-specific. `fork` supplies the concurrency that closes the cycle, but
the inversion is present regardless: there are no `CONF_fork` references in
this series, and `vfs_dentry.cc` and `vfs_vnode.cc` compile clean with
`conf_fork=0`.

A separate change splitting the global `dentry_hash_lock` into per-bucket locks
is deliberately **not** in this PR. The 32 hash buckets have always shared one
mutex taken at 6 sites, which is a scalability defect, but it is independent of
this correctness fix and a reviewer may reasonably want one without the other.
It also has to come after this fix, because a per-bucket lock inverts against
the vnode lock exactly as the global one does. Its throughput effect is
currently unmeasured and no claim is made about it.

Tested on x86_64: 12 of 12 relevant tests pass (`tst-vfs`, `tst-symlink` 141
assertions, `tst-remove` 38, `tst-pipe` 87, `tst-mmap`, `tst-condvar`,
`tst-yield`, `tst-dentry-lock`, and three fork tests). `tst-openat` reports one
pre-existing failure that reproduces identically on unpatched master.

---

**Update after review (c7ab5929e).** The commit messages made three claims they had not earned, all corrected in a rewritten series:

- The reachability argument in the first commit was wrong (a thread holding `vn_lock` also holds a reference on the dentry it found, so a concurrent `drele()` cannot reach zero). Replaced with the `sys_rename()` path: it holds `vn_lock(vp1)` across `lookup()` and `dentry_move()`/`dentry_remove()`, `vp1` is any vnode type, and two hardlinks to one file are enough.
- The production hang we observed was **not** this inversion. Its captured state shows the lock's owner blocked in `memory::page_pool::l1::alloc_page` while holding the lock, which is the `dentry_move()` allocation fixed by the second commit. That evidence now sits with that commit, and the first commit says the inversion was found by inspection.
- "Leaf lock" was overstated: `dentry_hash_lock` no longer calls into the vnode layer, but it still nests `dentry->d_lock` via `dentry_children_remove()`, consistently and without inversion.

The test header claimed it hangs on unfixed code, contradicting the description below. The description was right. The test runs on ramfs, where `ramfs_link()` is `vop_eperm`, so it cannot build the two-hardlinks-to-one-file aliasing the race requires and was never going to reproduce it. The header now states that, and what the test does cover.

