### PR TITLE
x64: cover the psABI stack and pointer guards in the thread control block

### DIFF
--- a/arch/x64/arch-setup.cc
+++ b/arch/x64/arch-setup.cc
@@ -226,6 +226,12 @@ void arch_setup_tls(void *tls, const elf::tls_data& info)
     memset(tls + info.filesize, 0, info.size - info.filesize);
     tcb = (struct thread_control_block *)(tls + info.size);
     tcb->self = tcb;
+    // tcb0 lives in .bss (see tcb0 in arch/x64/loader.ld) so it is already zero,
+    // but set the psABI guards explicitly: this is the TCB every stack-protected
+    // function runs under until the first sched::thread installs its own, and a
+    // zero canary here would disagree with the ones setup_tcb() installs later.
+    tcb->stack_guard = tcb_guard_value();
+    tcb->pointer_guard = tcb_guard_value();
     processor::wrmsr(msr::IA32_FS_BASE, reinterpret_cast<uint64_t>(tcb));
 }
 

--- a/arch/x64/arch-switch.hh
+++ b/arch/x64/arch-switch.hh
@@ -285,6 +285,16 @@ void thread::setup_tcb()
     _tcb->tls_base = p + user_tls_size;
 
     _tcb->app_tcb = 0;
+    _tcb->reserved0 = 0;
+    _tcb->reserved1 = 0;
+    // Install the psABI guards.  Applications compiled with -fstack-protector
+    // read the canary straight from %fs:0x28, so an uninitialised slot here is
+    // read as a canary by the very first stack-protected function the app calls.
+    // The value is process-wide on purpose: fork() children resume mid-frame on
+    // the parent's stack and must see the value the parent spilled (see
+    // arch-tls.hh and arch/x64/fork.cc).
+    _tcb->stack_guard = tcb_guard_value();
+    _tcb->pointer_guard = tcb_guard_value();
 }
 
 void thread::setup_large_syscall_stack()

--- a/arch/x64/arch-tls.hh
+++ b/arch/x64/arch-tls.hh
@@ -8,12 +8,74 @@
 #ifndef ARCH_TLS_HH
 #define ARCH_TLS_HH
 
+#include <stdint.h>
+#include <osv/export.h>
+
 // Don't change the declaration sequence of all existing members'.
 // Please add new members from the last.
+//
+// The x86-64 psABI fixes the -fstack-protector canary at %fs:0x28 and the
+// pointer guard at %fs:0x30; glibc's tcbhead_t and musl's struct pthread agree
+// on both.  GCC and Clang hardcode those offsets into every stack-protected
+// function's prologue and epilogue, so a stack-protected application (the
+// distro default) reads %fs:0x28 directly, with no way to ask libc where the
+// canary lives.
+//
+// This block must therefore be at least 0x38 bytes AND have the canary at
+// exactly 0x28.  Before that was true the struct was 3 words (0x18) and was
+// placed at the very END of the TLS allocation (see thread::setup_tcb() in
+// arch-switch.hh), so every application canary read was an out-of-bounds read
+// 16 bytes past the end of that buffer, returning whatever the allocator
+// happened to have there.  reserved0/reserved1 only pad the ABI-mandated gap
+// (glibc keeps multiple_threads/gscope_flag/sysinfo there); nothing on OSv
+// reads them, and they exist solely to place stack_guard at 0x28.
 struct thread_control_block {
-    thread_control_block* self;
-    void* tls_base;
-    unsigned long app_tcb;
+    thread_control_block* self;   // 0x00
+    void* tls_base;               // 0x08
+    unsigned long app_tcb;        // 0x10
+    unsigned long reserved0;      // 0x18 -- ABI padding, unused by OSv
+    unsigned long reserved1;      // 0x20 -- ABI padding, unused by OSv
+    uintptr_t stack_guard;        // 0x28 -- -fstack-protector canary (psABI)
+    uintptr_t pointer_guard;      // 0x30 -- pointer-mangling guard (psABI)
 };
+
+static_assert(__builtin_offsetof(thread_control_block, stack_guard) == 0x28,
+              "x86-64 psABI requires the stack-protector canary at %fs:0x28");
+static_assert(__builtin_offsetof(thread_control_block, pointer_guard) == 0x30,
+              "x86-64 psABI requires the pointer guard at %fs:0x30");
+
+// The single process-wide guard value installed in every TCB.
+//
+// It MUST be process-wide, not per-thread.  A fork() child resumes mid-frame on
+// the parent's stack (arch/x64/fork.cc), so every frame that was live across
+// fork() carries the canary the PARENT spilled, while the child's epilogue
+// re-reads the canary through its OWN fresh TCB.  Per-thread canaries would make
+// those epilogues mismatch on every single fork -- turning today's intermittent
+// abort into a deterministic one.  The same argument applies to pointer_guard: a
+// pointer mangled before fork() is demangled after it.
+//
+// This is a CORRECTNESS fix, not a hardening feature: a fixed compile-time
+// constant is trivially guessable and provides no real stack-protector security.
+// It only guarantees that a canary check compares equal values.  We reuse the
+// existing exported __stack_chk_guard (core/runtime.cc) so the kernel symbol and
+// the TCB slot can never disagree.  Note the zero top byte, which is deliberate
+// and matches glibc/musl: on little-endian it terminates the canary for str*
+// overflows.
+//
+// ponytail: fixed constant, no entropy.  Upgrade path is to seed
+// __stack_chk_guard once from the random device after it is up (setup_tcb() runs
+// for the first kernel threads long before that), keeping it process-wide.
+//
+// Declared with C++ linkage to match its definition in core/runtime.cc, which
+// includes this header via osv/sched.hh; a global-scope variable is unmangled
+// either way, so this is the same symbol applications resolve.  OSV_LIBC_API
+// keeps the declaration's visibility identical to the definition's under
+// -fvisibility=hidden.
+extern OSV_LIBC_API void* __stack_chk_guard;
+
+inline uintptr_t tcb_guard_value()
+{
+    return reinterpret_cast<uintptr_t>(__stack_chk_guard);
+}
 
 #endif /* ARCH_TLS_HH */


### PR DESCRIPTION
`thread_control_block` on x86-64 is three words:

```c
struct thread_control_block {
    thread_control_block* self;
    void* tls_base;
    unsigned long app_tcb;
};
```

The x86-64 psABI, however, places the `-fstack-protector` canary at `%fs:0x28` and the pointer-mangling guard at `%fs:0x30`. Both offsets fall past the end of that structure, and past the end of its allocation: `setup_tcb()` sizes the block as `total_tls_size + sizeof(*_tcb)` and places the TCB at the very end. So every canary check made by an application built with the stack protector is an out-of-bounds read of whatever the allocator happened to place next.

The values that come back are not random-looking, which is what makes the diagnosis clear. Reading `%fs:0x28` in a freshly created thread returns things like

```
0x802000006812d065
0x802000007592d065
0x802000007c32d065
```

that is, page-table entries: NX set, present, user, accessed, dirty. The read is landing in neighbouring allocator memory.

This has not been noticed because the kernel is built with `-fno-stack-protector`, so nothing in OSv itself consults those slots. It affects only applications, and only those compiled with the protector enabled, where the effect is a silently wrong read rather than a visible failure. `__stack_chk_guard` is defined in `runtime.cc`, but GCC does not read the global on this architecture, it reads `%fs:0x28`.

It turns into a hard failure as soon as one execution context resumes on a stack frame into which another spilled its canary, because the two then disagree and the epilogue check fails:

```
__stack_chk_fail(): Stack overflow detected. Aborting.
```

The message is misleading in that situation: there is no stack overflow, only two disagreeing canary values, one of them read out of bounds.

This change extends the block to cover `0x28` and `0x30` with named fields, adds `static_assert`s on both offsets and on the minimum size so the layout cannot drift out of agreement with the ABI, and initialises both guards in `setup_tcb()` as well as for the pre-scheduler TCB, so every stack-protected function runs under an initialised value rather than whatever memory follows.

Notes for review:

* The guard value is deliberately uniform rather than per-thread. A per-thread random canary is stronger in principle, but it is only sound if no execution context ever resumes on a frame another created; a uniform value is the conservative choice and is what makes the check consistent. This is a correctness fix, not a hardening claim.
* `aarch64` should be checked separately. Its TCB layout and the offset its toolchain uses for the canary are different, and I have not verified whether the same shortfall exists there.
* The compile-time asserts are the part worth keeping regardless of the rest: they turn any future divergence between this structure and the psABI into a build failure instead of an out-of-bounds read.