### PR TITLE
zfs: honour sub-tick timeouts in the SPL cv_timedwait_hires

### DIFF
--- a/bsd/porting/netport1.cc
+++ b/bsd/porting/netport1.cc
@@ -90,3 +90,19 @@ int openzfs_cv_timedwait(kcondvar_t *cv, mutex_t *mutex, clock_t abstime)
     auto ret = cv->wait(mutex, std::chrono::nanoseconds(ticks2ns(delta)));
     return ret == ETIMEDOUT ? -1 : 0;
 }
+
+// Nanosecond-granular timed wait, for OpenZFS callers whose delays are shorter
+// than a tick.  cv_timedwait_hires() in the OSv SPL header resolves its
+// absolute/relative deadline against gethrtime() and passes the remaining delay
+// here, so no clock conversion happens on this side.  Rounding these delays to
+// hz-granular ticks would truncate every sub-millisecond wait to zero, which
+// defeats ZIL commit-batch coalescing (see the comment at the call site).
+OSV_LIBSOLARIS_API
+int osv_cv_timedwait_ns(kcondvar_t *cv, mutex_t *mutex, long long delta_ns)
+{
+    if (delta_ns <= 0) {
+        return -1;
+    }
+    auto ret = cv->wait(mutex, std::chrono::nanoseconds(delta_ns));
+    return ret == ETIMEDOUT ? -1 : 0;
+}

--- a/bsd/sys/cddl/compat/opensolaris/sys/kcondvar.h
+++ b/bsd/sys/cddl/compat/opensolaris/sys/kcondvar.h
@@ -50,6 +50,9 @@ typedef enum {
 int cv_timedwait(kcondvar_t *cv, mutex_t *mutex, clock_t tmo);
 // OpenZFS variant: absolute deadline (see bsd/porting/netport1.cc).
 int openzfs_cv_timedwait(kcondvar_t *cv, mutex_t *mutex, clock_t abstime);
+// Nanosecond-granular relative wait, for delays shorter than a tick
+// (see cv_timedwait_hires() in the OSv SPL condvar header).
+int osv_cv_timedwait_ns(kcondvar_t *cv, mutex_t *mutex, long long delta_ns);
 
 #ifdef __cplusplus
 }

--- a/exported_symbols/osv_libsolaris.so.symbols
+++ b/exported_symbols/osv_libsolaris.so.symbols
@@ -9,6 +9,7 @@ copyinstr
 copyout
 cv_timedwait
 openzfs_cv_timedwait
+osv_cv_timedwait_ns
 debug
 destroy_bio
 device_close

--- a/modules/open_zfs/osv/include/os/osv/spl/sys/condvar.h
+++ b/modules/open_zfs/osv/include/os/osv/spl/sys/condvar.h
@@ -50,16 +50,30 @@ static inline int
 cv_timedwait_hires(kcondvar_t *cvp, mutex_t *mp, long long tim,
     long long res __attribute__((unused)), int flag)
 {
-	clock_t ticks;
+	long long delta_ns = tim;
 
-	if (flag == 0) {
-		/* Relative time: add current hrtime */
-		tim += gethrtime();
+	/*
+	 * With CALLOUT_FLAG_ABSOLUTE, `tim` is an absolute deadline on the
+	 * same clock the caller read via gethrtime(), so derive the remaining
+	 * delay from gethrtime() as well rather than from any other clock.
+	 */
+	if (flag != 0) {
+		delta_ns = tim - (long long)gethrtime();
+	}
+	if (delta_ns <= 0) {
+		return (-1);
 	}
 
-	/* Convert absolute hrtime (nanoseconds) to tick deadline */
-	ticks = (clock_t)(tim / (1000000000LL / hz));
-	return (cv_timedwait(cvp, mp, ticks));
+	/*
+	 * Wait the true nanosecond delay.  Converting to hz-granular ticks
+	 * would round every sub-millisecond delay down to zero: the ZIL sizes
+	 * its commit-batch window at ~10% of the last log-write latency
+	 * (zfs_commit_timeout_pct), i.e. tens to hundreds of microseconds, so
+	 * on a 1000 Hz tick grid the waiter would never wait, never accumulate
+	 * a second itx, and every commit would pay its own log write and
+	 * device cache flush instead of coalescing with its peers.
+	 */
+	return (osv_cv_timedwait_ns(cvp, mp, delta_ns));
 }
 
 #define	cv_timedwait_sig_hires		cv_timedwait_hires


### PR DESCRIPTION
The OSv SPL's `cv_timedwait_hires()` converts its nanosecond deadline into `hz`-granular ticks and forwards it to `cv_timedwait()`. That is wrong in two independent ways, and the second one silently disables ZIL commit batching.

**The unit.** With `CALLOUT_FLAG_ABSOLUTE` the caller passes an absolute deadline, so the code correctly skips adding `gethrtime()`, then divides the absolute nanosecond timestamp by `1e6` and hands the quotient to `cv_timedwait()`, which treats its argument as a *relative* tick count. A deadline a quarter of a millisecond away becomes a relative wait of over twenty thousand days:

```
OLD, ABSOLUTE 250us window -> cv_timedwait(ticks=1789146780736)
     = 1789146780.7 seconds = 20707.7 DAYS
```

So the timeout never fires. `zil_commit_waiter()` depends on it firing to discharge what upstream's comment calls responsibility (2), issuing an lwb whose batch window has expired; instead that work waits for whichever other thread happens along.

**The resolution.** Even on the relative path, `hz` is 1000, so a tick is a millisecond and integer division truncates anything shorter to zero:

```
asks   10 us -> 0 ticks    asks  100 us -> 0 ticks
asks   25 us -> 0 ticks    asks  250 us -> 0 ticks
asks   50 us -> 0 ticks    asks  999 us -> 0 ticks
```

The ZIL sizes its commit-batch window at `zfs_commit_timeout_pct`, 10% of the last log-write latency (`zil.c`), which is tens to hundreds of microseconds. Every such window collapses to no wait at all, so a commit waiter never accumulates a second itx and **each commit pays its own log write and device cache flush instead of coalescing with its peers.**

The patch resolves the deadline against `gethrtime()` and waits the remaining nanoseconds via a new `osv_cv_timedwait_ns()`. Verified with the fixed body compiled standalone:

```
ABSOLUTE, 250us window -> requested 250000 ns
RELATIVE, 250us window -> requested 250000 ns
past deadline           -> rc -1
```

One subtlety worth flagging for review, because it is easy to get wrong: `now` must come from `gethrtime()`, the same clock the caller used to build the deadline. `gethrtime()` here resolves to `CLOCK_REALTIME` (`compat/opensolaris/sys/time.h` defines `CLOCK_UPTIME` to `CLOCK_REALTIME`), so subtracting a monotonic reading instead would reintroduce an error the size of the gap between the two clocks. An earlier version of this fix that I did not submit used a monotonic clock and was broken in the same direction as the bug it was meant to repair.

**On the performance side I want to be careful about what is and is not measured here.** Earlier measurement on this port showed `synchronous_commit=on` at 878 tps / 18.0 ms versus `off` at 5528 tps / 2.9 ms for the same workload, i.e. the per-commit synchronous flush accounted for essentially the whole gap to Linux on sync writes, and sync throughput barely scaled with concurrency (c1 364, c8 656, c32 845 tps) which is the signature of no batching. That is consistent with this defect and is what sent me looking here. **I have not yet re-run that benchmark with this patch applied**, so I am claiming the defect and the mechanism, not a specific speedup. Happy to post numbers once I have them on a matched base.

Applies cleanly to master (`git merge-tree` reports no conflicts).
