### PR TITLE
zfs: allow an explicit ARC ceiling via OSV_ZFS_ARC_MAX

### DIFF
--- a/modules/open_zfs/osv/module/os/osv/zfs/arc_os.c
+++ b/modules/open_zfs/osv/module/os/osv/zfs/arc_os.c
@@ -22,7 +22,8 @@
 #include <sys/kstat.h>
 #include <sys/zthr.h>
 #include <sys/aggsum.h>
-
+/* getenv()/strtoull(): zfs_context.h only pulls stdlib.h in for userspace. */
+#include <stdlib.h>
 extern unsigned long physmem;
 extern unsigned long freemem;
 
@@ -92,10 +93,53 @@ arc_available_memory(void)
  *      its eviction thread catches up.  Leaving 7/8 (≥ 112 MiB) free for
  *      everything else prevents the peak-usage spike from exceeding physmem.
  */
+/*
+ * Honour an explicit ARC ceiling from the environment.
+ *
+ * Other platforms expose zfs_arc_max as a module parameter or sysctl, both of
+ * which OSv lacks, so a unikernel image had no way to bound the ARC short of
+ * rebuilding.  That matters for any configuration that has to reason about
+ * cache size: sizing a guest against a known cache budget, comparing against
+ * another system with a fixed cache, or simply leaving room for an application
+ * that manages its own buffers.  Read the value here, before arc_init() applies
+ * its own validation, and let arc.c decide whether to accept it.
+ *
+ * Accepts a plain byte count with an optional K/M/G suffix.  A value arc.c
+ * rejects as out of range (below 64 MiB, or at or above physical memory) simply
+ * leaves the tiered default in place.
+ */
+static void
+arc_apply_env_max(void)
+{
+	const char *e = getenv("OSV_ZFS_ARC_MAX");
+	char *end = NULL;
+	unsigned long long v;
+
+	if (e == NULL || *e == '\0')
+		return;
+
+	v = strtoull(e, &end, 0);
+	if (end == e)
+		return;
+
+	switch (*end) {
+	case 'g': case 'G': v <<= 30; end++; break;
+	case 'm': case 'M': v <<= 20; end++; break;
+	case 'k': case 'K': v <<= 10; end++; break;
+	default: break;
+	}
+	if (*end != '\0')
+		return;
+
+	zfs_arc_max = (uint64_t)v;
+}
+
 uint64_t
 arc_default_max(uint64_t min, uint64_t allmem)
 {
 	uint64_t size;
+
+	arc_apply_env_max();
 
 	if (allmem >= (1ULL << 30))
 		size = MAX(allmem * 5 / 8, allmem - (1ULL << 30));


### PR DESCRIPTION
Other platforms expose `zfs_arc_max` as a module parameter or a sysctl. OSv has neither, so the only way to bound the ARC in an image was to rebuild it, and `arc_default_max()`'s tiered fraction was effectively the only policy available.

That fraction is a sensible default, but it is not always the right one:

- a guest sized against a known cache budget,
- a comparison against another system whose cache is fixed,
- an application that manages its own buffers and wants the rest of RAM left alone.

This reads an optional `OSV_ZFS_ARC_MAX` in `arc_default_max()`, which runs from `arc_set_limits()` before `arc_init()` consults `zfs_arc_max`, so the value is in place by the time arc.c validates it. **Validation is deliberately left to arc.c**, which already ignores anything below `MIN_ARC_MAX` (64 MiB) or at or above physical memory; in those cases the tiered default simply stands.

A plain byte count is accepted with an optional `K`/`M`/`G` suffix. Anything unparseable is ignored rather than clamped, so a typo cannot silently shrink the cache to something tiny. Parsing verified standalone:

```
16G          -> 17179869184  = 16.00 GiB
16g          -> 17179869184  = 16.00 GiB
17179869184  -> 17179869184  = 16.00 GiB
0x400000000  -> 17179869184  = 16.00 GiB
64M          ->    67108864
12K          ->       12288
16GB         -> 0  (default kept, trailing junk rejected)
bogus        -> 0  (default kept)
(empty)      -> 0  (default kept)
unset        -> 0  (default kept)
```

`stdlib.h` is included explicitly because `zfs_context.h` only pulls it in for userspace builds, not under `_KERNEL`.

For context on why I wanted this: on a 64 GiB guest the tiered default gives `max(5/8 * 64, 64 - 1)` = **63 GiB** of ARC. Comparing that against another system deliberately capped at 16 GiB is not a like-for-like comparison, and I had no way to match them without a custom build. It is generally useful beyond that, which is why it is an environment variable rather than anything benchmark-specific.

Applies cleanly to master (`git merge-tree` reports no conflicts).
