### PR TITLE
pagecache: skip the whole-file writeback scan on fsync when nothing is dirty

### DIFF
--- a/core/pagecache.cc
+++ b/core/pagecache.cc
@@ -1075,6 +1075,25 @@ int writeback_inode(dev_t dev, ino_t ino, off_t start, off_t end)
 
     SCOPE_LOCK(write_lock);
 
+    /*
+     * The write cache only ever holds pages faulted in through a writable
+     * MAP_SHARED mapping (see the single insert() call site, reached solely
+     * from the mmap write-fault path).  A file written with write()/pwrite()
+     * has no pages here, so its dirty set is empty.  Without this guard the
+     * loops below still walk every page in [start,end) doing a hash lookup
+     * that always misses -- an O(file-size) scan on every fsync() that flushes
+     * nothing.  Skip it when the cache holds no write pages at all: an empty
+     * cache cannot contain a dirty page for this inode, so there is nothing to
+     * promote, collect, or write back.
+     */
+    if (write_cache.empty())
+        return 0;
+    /* ponytail: whole-cache empty guard removes the O(file-size) scan for the
+     * write()/pwrite() case (no writable mmap pages anywhere).  A large file
+     * with a few dirty mmap pages elsewhere in the guest still scans its whole
+     * range; add a per-inode dirty-offset index if a mixed mmap+write workload
+     * ever needs that. */
+
     /* Phase 1: promote PTE-dirty pages to software-dirty.  clear_dirty()
      * writes the PTE only when the dirty bit was set (mapping preserved),
      * so an empty to_flush means no PTE changed and the flush below can be


### PR DESCRIPTION
`sys_fsync()` calls `pagecache::writeback_inode(dev, ino, 0, st_size)` before the filesystem's own fsync handler, to push dirty pages from writable `MAP_SHARED` mappings out ahead of the journal. `writeback_inode()` walks the whole range one page at a time, twice (promote-dirty, then collect), doing a `find_in_cache()` hash lookup per page under the global `write_lock`.

The write cache only ever holds pages faulted in through a writable `MAP_SHARED` mapping: its single `insert()` call site is reached only from the mmap write-fault path. A file written with `write()`/`pwrite()` has no pages there at all. So for a `write()`-based writer the two loops walk every page in the file and every lookup misses: an O(file-size) scan on every `fsync()` that promotes, collects, and writes back nothing.

The fix returns early when the write cache is empty: an empty cache cannot hold a dirty page for any inode, so there is nothing to flush. Whenever there genuinely are cached write pages, the scan runs exactly as before.

## Measurements

All on ZFS-on-NVMe (m5d.metal, instance-store NVMe, ashift=12, recsize=8k), same NVMe and geometry across arms.

**Microbenchmark -- single thread, 8k `pwrite` + `fdatasync`, per-op p50 (medians of 3):**

| file size | before (p50) | after (p50) |
|----------:|-------------:|------------:|
|   8 MiB   |  11 us       |  99 us*     |
|  64 MiB   |  74 us       | 106 us*     |
| 256 MiB   | 283 us       | 112 us      |
| 512 MiB   | 490 us       | 105 us      |

The before column is the scan cost in isolation (measured with `sync=disabled`, so the ZIL commit and device flush are bypassed and only the scan remains); it is dead linear in file size at ~1.1 us/MiB. At 256 MiB an instrumented build counted **3.08 billion page-scans and zero page-flushes** on a `pwrite` workload. After the fix, per-fdatasync p50 is flat (~100-112 us) across a 64x file-size range and no longer grows. The `*` rows: the small-file after-numbers include the real ZIL log-write + device flush of the full sync (~65 us) that the before column excluded, which is why 8/64 MiB do not look faster in isolation; the point is the slope, which is now zero.

**Correctness:** an mmap-write durability test (mmap a file writable, dirty a page, `msync`+`fsync`, reopen fresh, read-verify) passes with the fix. Instrumentation confirms the scan still runs in that case (`write_cache` non-empty), so the guard only short-circuits when there is genuinely nothing to flush.

**End-to-end (HammerDB TPROC-C, 200 warehouses, same-binary A/B toggling the guard):**

- **Checkpoint duration:** with the old scan, the post-run checkpoint grows with the database: 168 -> 249 -> 438 s run-over-run at 8 VU, 616 s at 32 VU. With the fix it stays flat at ~50-86 s. A 3-7x reduction, and it no longer grows with size.
- **Tail latency (32 VU):** NEWORD p99 58.6 ms with the fix vs 70.5 ms without, -16.9%.
- **Wait profile (8 VU, arm medians):** the old scan leaves backends spending more time serialized on the WAL-fsync path (`LWLock:WALWrite` 40.1% vs 24.2%); the fix eases that, in the expected direction.

**What this does NOT change:** peak TPROC-C NOPM is within run-to-run noise between the two arms (47.2k vs 48.7k at 8 VU; 33.4k vs 32.2k at 32 VU). Peak throughput on this workload is gated by a separate, arm-independent scheduling stall, not by this scan, so I am **not** claiming a throughput win. The scan is a real, size-growing per-fsync cost that shows up in checkpoint duration and tail latency; that is what this fixes.

Applies cleanly to master (`git merge-tree` reports no conflicts). Single file, 19 lines.
